### PR TITLE
feat(backup): add backup and restore commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ Never write provider-specific logic in core code. Use adapter pattern in `deploy
 | Topic                | Document                                                     |
 | -------------------- | ------------------------------------------------------------ |
 | Architecture         | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)                 |
+| Backup & Restore     | [docs/BACKUP_RESTORE.md](docs/BACKUP_RESTORE.md)             |
 | CLI Reference        | [docs/CLI.md](docs/CLI.md)                                   |
 | Configuration        | [docs/CONFIGURATION.md](docs/CONFIGURATION.md)               |
 | Deployment           | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)                     |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ cd sindri
 - **[FAQ](docs/FAQ.md)** - Searchable answers to common questions
 - **[Architecture Overview](docs/ARCHITECTURE.md)** - System design and concepts
 - **[Configuration Reference](docs/CONFIGURATION.md)** - Complete sindri.yaml guide
+- **[CLI Reference](docs/CLI.md)** - Complete command-line reference
 
 ### Extensions
 
@@ -84,6 +85,7 @@ cd sindri
 ### Development & Operations
 
 - **[Project Management](docs/PROJECT_MANAGEMENT.md)** - Using new-project and clone-project
+- **[Backup & Restore](docs/BACKUP_RESTORE.md)** - Workspace backup, migration, and recovery
 - **[Contributing Guide](docs/CONTRIBUTING.md)** - Development workflow and standards
 - **[Testing Guide](docs/TESTING.md)** - Running tests and CI/CD
 - **[Workflow Architecture](.github/WORKFLOW_ARCHITECTURE.md)** - CI/CD workflow structure and design

--- a/cli/backup-restore
+++ b/cli/backup-restore
@@ -1,0 +1,1101 @@
+#!/bin/bash
+# ==============================================================================
+# Sindri Backup/Restore Manager
+# ==============================================================================
+# Handles backup and restore of Sindri workspace with smart profiles and modes.
+#
+# Backup Profiles:
+#   user-data  - Projects, scripts, Claude data, SSH keys, git config
+#   standard   - user-data + shell configs + app configs (default)
+#   full       - Everything except caches
+#
+# Restore Modes:
+#   safe       - Never overwrite existing files (default)
+#   merge      - Backup existing files, then restore
+#   full       - Overwrite everything (dangerous)
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Detect environment and source common functions
+if [[ -f "/docker/lib/common.sh" ]]; then
+    source /docker/lib/common.sh
+    BASE_DIR="/docker"
+    RUNNING_IN_CONTAINER=true
+else
+    BASE_DIR="$(dirname "$SCRIPT_DIR")"
+    source "$BASE_DIR/docker/lib/common.sh"
+    RUNNING_IN_CONTAINER=false
+fi
+
+# ==============================================================================
+# Constants
+# ==============================================================================
+
+ALT_HOME="${ALT_HOME:-/alt/home/developer}"
+WORKSPACE="${WORKSPACE:-${ALT_HOME}/workspace}"
+BACKUP_DIR="${WORKSPACE}/backups"
+
+# Files/directories that should NEVER be restored (system markers)
+NEVER_RESTORE=(
+    ".initialized"
+    ".welcome_shown"
+    "workspace/.system/bootstrap.yaml"
+    "workspace/.system/installed"
+    "workspace/.system/install-status"
+)
+
+# Files/directories to always exclude from backup (caches, regenerable)
+ALWAYS_EXCLUDE=(
+    ".cache"
+    ".local/share/mise/installs"
+    ".local/state/mise"
+    ".local/state"
+    "workspace/.system/logs"
+)
+
+# Profile definitions
+declare -A PROFILE_INCLUDES
+declare -A PROFILE_EXCLUDES
+
+# user-data profile: essential user files only
+PROFILE_INCLUDES[user-data]="workspace/projects workspace/config workspace/scripts workspace/bin .claude .ssh/host_keys .gitconfig"
+PROFILE_EXCLUDES[user-data]=".bashrc .profile .config .local"
+
+# standard profile: user-data + configs
+PROFILE_INCLUDES[standard]="workspace/projects workspace/config workspace/scripts workspace/bin .claude .ssh/host_keys .gitconfig .bashrc .profile .config .local/bin"
+PROFILE_EXCLUDES[standard]=".config/mise/shims .local/share/mise .local/state"
+
+# full profile: everything except caches
+PROFILE_INCLUDES[full]=""
+PROFILE_EXCLUDES[full]=""
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================
+
+show_backup_help() {
+    cat << 'EOF'
+sindri backup - Create workspace backup
+
+USAGE:
+    sindri backup [options]
+
+OPTIONS:
+    -o, --output <path>     Output location (directory or file path)
+                            Supports: local path, s3://bucket/path
+                            Default: ./sindri-backup-{name}-{timestamp}.tar.gz
+    -p, --profile <name>    Backup profile:
+                            - user-data: Projects, Claude data, git config (smallest)
+                            - standard:  user-data + shell/app configs (default)
+                            - full:      Everything except caches (largest)
+    -c, --config <file>     Sindri config file (default: sindri.yaml)
+    --exclude <pattern>     Additional exclude pattern (can repeat)
+    --dry-run               Show what would be backed up
+    --list                  List backups on instance
+    -v, --verbose           Verbose output
+    -h, --help              Show this help
+
+EXAMPLES:
+    sindri backup                                    # Standard backup
+    sindri backup --profile user-data -o ./backups/ # Small migration backup
+    sindri backup --dry-run                          # Preview backup
+    sindri backup --output s3://bucket/backups/      # Backup to S3
+EOF
+}
+
+show_restore_help() {
+    cat << 'EOF'
+sindri restore - Restore workspace from backup
+
+USAGE:
+    sindri restore <source> [options]
+
+ARGUMENTS:
+    source                  Backup file: local path, s3://bucket/path, https://url
+
+OPTIONS:
+    -m, --mode <name>       Restore mode:
+                            - safe:  Never overwrite existing (default)
+                            - merge: Backup existing, then restore
+                            - full:  Overwrite everything (dangerous)
+    -c, --config <file>     Sindri config file (default: sindri.yaml)
+    --dry-run               Preview restore without making changes
+    --no-interactive        Skip confirmation prompts
+    -v, --verbose           Verbose output
+    -h, --help              Show this help
+
+EXAMPLES:
+    sindri restore ./backup.tar.gz                   # Safe restore
+    sindri restore ./backup.tar.gz --mode merge      # Merge with backups
+    sindri restore ./backup.tar.gz --dry-run         # Preview changes
+    sindri restore s3://bucket/backup.tar.gz         # From S3
+EOF
+}
+
+# Get instance name from config
+get_instance_name() {
+    local config="${1:-sindri.yaml}"
+    if [[ -f "$config" ]]; then
+        yq '.name' "$config" 2>/dev/null || echo "sindri"
+    else
+        echo "sindri"
+    fi
+}
+
+# Get provider from config
+get_provider() {
+    local config="${1:-sindri.yaml}"
+    if [[ -f "$config" ]]; then
+        yq '.deployment.provider' "$config" 2>/dev/null || echo "docker"
+    else
+        echo "docker"
+    fi
+}
+
+# Generate backup filename
+generate_backup_filename() {
+    local name="$1"
+    local timestamp
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    echo "sindri-backup-${name}-${timestamp}.tar.gz"
+}
+
+# Check if path is S3
+is_s3_path() {
+    [[ "$1" =~ ^s3:// ]]
+}
+
+# Check if path is URL
+is_url() {
+    [[ "$1" =~ ^https?:// ]]
+}
+
+# Build tar exclude arguments
+build_exclude_args() {
+    local profile="$1"
+    shift
+    local extra_excludes=("$@")
+    local args=()
+
+    # Always exclude these
+    for pattern in "${ALWAYS_EXCLUDE[@]}"; do
+        args+=("--exclude=$pattern")
+    done
+
+    # Profile-specific excludes
+    local profile_excl="${PROFILE_EXCLUDES[$profile]:-}"
+    for pattern in $profile_excl; do
+        args+=("--exclude=$pattern")
+    done
+
+    # Extra excludes from command line
+    for pattern in "${extra_excludes[@]}"; do
+        [[ -n "$pattern" ]] && args+=("--exclude=$pattern")
+    done
+
+    echo "${args[@]}"
+}
+
+# Build tar include arguments for user-data profile
+build_include_args() {
+    local profile="$1"
+    local includes="${PROFILE_INCLUDES[$profile]:-}"
+
+    if [[ -z "$includes" ]]; then
+        echo "."
+    else
+        echo "$includes"
+    fi
+}
+
+# ==============================================================================
+# Backup Functions
+# ==============================================================================
+
+# Execute backup on instance
+do_backup_local() {
+    local output="$1"
+    local profile="$2"
+    local dry_run="$3"
+    local verbose="$4"
+    shift 4
+    local extra_excludes=("$@")
+
+    local home_dir="${ALT_HOME}"
+
+    if [[ ! -d "$home_dir" ]]; then
+        print_error "Home directory not found: $home_dir"
+        return 1
+    fi
+
+    # Build exclude arguments
+    local exclude_args
+    exclude_args=$(build_exclude_args "$profile" "${extra_excludes[@]}")
+
+    # Build include arguments
+    local include_args
+    include_args=$(build_include_args "$profile")
+
+    if [[ "$dry_run" == "true" ]]; then
+        print_header "Backup Preview (profile: $profile)"
+        echo ""
+        echo "Would backup from: $home_dir"
+        echo "Output: $output"
+        echo ""
+        echo "Files to include:"
+        # shellcheck disable=SC2086
+        cd "$home_dir" && tar $exclude_args -cvf /dev/null $include_args 2>/dev/null | head -50
+        echo "..."
+        echo ""
+        echo "Run without --dry-run to create backup"
+        return 0
+    fi
+
+    # Ensure output directory exists
+    local output_dir
+    output_dir=$(dirname "$output")
+    mkdir -p "$output_dir"
+
+    print_status "Creating backup (profile: $profile)..."
+    [[ "$verbose" == "true" ]] && print_status "Excludes: $exclude_args"
+
+    # Create backup
+    # shellcheck disable=SC2086
+    cd "$home_dir" && tar $exclude_args -czf "$output" $include_args
+
+    local size
+    size=$(du -h "$output" | cut -f1)
+    print_success "Backup created: $output ($size)"
+}
+
+# Execute backup via Docker
+do_backup_docker() {
+    local container="$1"
+    local output="$2"
+    local profile="$3"
+    local dry_run="$4"
+    local verbose="$5"
+    shift 5
+    local extra_excludes=("$@")
+
+    # Build exclude arguments
+    local exclude_args
+    exclude_args=$(build_exclude_args "$profile" "${extra_excludes[@]}")
+
+    # Build include arguments
+    local include_args
+    include_args=$(build_include_args "$profile")
+
+    if [[ "$dry_run" == "true" ]]; then
+        print_header "Backup Preview (profile: $profile)"
+        echo ""
+        echo "Container: $container"
+        echo "Output: $output"
+        echo ""
+        echo "Files to include:"
+        # shellcheck disable=SC2086
+        docker exec "$container" bash -c "cd /alt/home/developer && tar $exclude_args -cvf /dev/null $include_args 2>/dev/null" | head -50
+        echo "..."
+        return 0
+    fi
+
+    print_status "Creating backup from Docker container (profile: $profile)..."
+
+    # Ensure output directory exists
+    local output_dir
+    output_dir=$(dirname "$output")
+    mkdir -p "$output_dir"
+
+    # Stream tar from container to local file
+    # shellcheck disable=SC2086
+    docker exec "$container" bash -c "cd /alt/home/developer && tar $exclude_args -czf - $include_args" > "$output"
+
+    local size
+    size=$(du -h "$output" | cut -f1)
+    print_success "Backup created: $output ($size)"
+}
+
+# Execute backup via Fly.io
+do_backup_fly() {
+    local app="$1"
+    local output="$2"
+    local profile="$3"
+    local dry_run="$4"
+    local verbose="$5"
+    shift 5
+    local extra_excludes=("$@")
+
+    # Build exclude arguments
+    local exclude_args
+    exclude_args=$(build_exclude_args "$profile" "${extra_excludes[@]}")
+
+    # Build include arguments
+    local include_args
+    include_args=$(build_include_args "$profile")
+
+    if [[ "$dry_run" == "true" ]]; then
+        print_header "Backup Preview (profile: $profile)"
+        echo ""
+        echo "Fly.io app: $app"
+        echo "Output: $output"
+        echo ""
+        echo "Files to include:"
+        # shellcheck disable=SC2086
+        flyctl ssh console -a "$app" -C "cd /alt/home/developer && tar $exclude_args -cvf /dev/null $include_args 2>/dev/null" | head -50
+        echo "..."
+        return 0
+    fi
+
+    print_status "Creating backup from Fly.io (profile: $profile)..."
+
+    # Create backup on instance first (more reliable than streaming)
+    local remote_backup="/tmp/sindri-backup-$$.tar.gz"
+
+    # shellcheck disable=SC2086
+    flyctl ssh console -a "$app" -C \
+        "cd /alt/home/developer && tar $exclude_args -czf $remote_backup $include_args"
+
+    # Download via sftp
+    print_status "Downloading backup..."
+    flyctl ssh sftp get -a "$app" "$remote_backup" "$output"
+
+    # Clean up remote
+    flyctl ssh console -a "$app" -C "rm -f $remote_backup"
+
+    local size
+    size=$(du -h "$output" | cut -f1)
+    print_success "Backup created: $output ($size)"
+}
+
+# Upload to S3
+upload_to_s3() {
+    local local_file="$1"
+    local s3_path="$2"
+
+    if ! command -v aws &>/dev/null; then
+        print_error "AWS CLI not installed. Install with: pip install awscli"
+        return 1
+    fi
+
+    print_status "Uploading to S3: $s3_path"
+    aws s3 cp "$local_file" "$s3_path"
+    print_success "Uploaded to S3"
+}
+
+# ==============================================================================
+# Restore Functions
+# ==============================================================================
+
+# Analyze backup contents and categorize files
+analyze_backup() {
+    local backup_file="$1"
+    local verbose="$2"
+
+    print_header "Analyzing Backup Contents"
+
+    local total_files=0
+    local user_data_files=0
+    local config_files=0
+    local system_marker_files=0
+    local will_skip=0
+
+    while IFS= read -r file; do
+        ((total_files++)) || true
+
+        # Check if this is a system marker (never restore)
+        local is_marker=false
+        for marker in "${NEVER_RESTORE[@]}"; do
+            if [[ "$file" == "$marker" ]] || [[ "$file" == "$marker/"* ]]; then
+                is_marker=true
+                ((system_marker_files++)) || true
+                ((will_skip++)) || true
+                [[ "$verbose" == "true" ]] && echo "  [SKIP] $file (system marker)"
+                break
+            fi
+        done
+
+        if [[ "$is_marker" == "false" ]]; then
+            # Categorize
+            if [[ "$file" == "workspace/projects/"* ]] || \
+               [[ "$file" == "workspace/scripts/"* ]] || \
+               [[ "$file" == "workspace/bin/"* ]] || \
+               [[ "$file" == ".claude/"* ]]; then
+                ((user_data_files++)) || true
+            else
+                ((config_files++)) || true
+            fi
+        fi
+    done < <(tar tzf "$backup_file" 2>/dev/null)
+
+    echo ""
+    echo "Backup Summary:"
+    echo "  Total files:        $total_files"
+    echo "  User data files:    $user_data_files"
+    echo "  Config files:       $config_files"
+    echo "  System markers:     $system_marker_files (will be skipped)"
+    echo ""
+}
+
+# Preview restore operation
+preview_restore() {
+    local backup_file="$1"
+    local target_dir="$2"
+    local mode="$3"
+    local verbose="$4"
+
+    print_header "Restore Preview (mode: $mode)"
+    echo ""
+    echo "Source: $backup_file"
+    echo "Target: $target_dir"
+    echo ""
+
+    local will_restore=0
+    local will_skip=0
+    local will_overwrite=0
+    local will_backup=0
+
+    while IFS= read -r file; do
+        # Skip directories
+        [[ "$file" == */ ]] && continue
+
+        # Check if system marker
+        local is_marker=false
+        for marker in "${NEVER_RESTORE[@]}"; do
+            if [[ "$file" == "$marker" ]] || [[ "$file" == "$marker/"* ]]; then
+                is_marker=true
+                ((will_skip++)) || true
+                [[ "$verbose" == "true" ]] && echo "  [SKIP]      $file (system marker)"
+                break
+            fi
+        done
+        [[ "$is_marker" == "true" ]] && continue
+
+        local target_path="$target_dir/$file"
+
+        if [[ -e "$target_path" ]]; then
+            case "$mode" in
+                safe)
+                    ((will_skip++)) || true
+                    [[ "$verbose" == "true" ]] && echo "  [SKIP]      $file (exists)"
+                    ;;
+                merge)
+                    ((will_backup++)) || true
+                    ((will_restore++)) || true
+                    [[ "$verbose" == "true" ]] && echo "  [BACKUP]    $file"
+                    ;;
+                full)
+                    ((will_overwrite++)) || true
+                    [[ "$verbose" == "true" ]] && echo "  [OVERWRITE] $file"
+                    ;;
+            esac
+        else
+            ((will_restore++)) || true
+            [[ "$verbose" == "true" ]] && echo "  [RESTORE]   $file"
+        fi
+    done < <(tar tzf "$backup_file" 2>/dev/null)
+
+    echo ""
+    echo "Restore Summary:"
+    echo "  Files to restore:   $will_restore"
+    echo "  Files to skip:      $will_skip"
+    [[ "$mode" == "merge" ]] && echo "  Files to backup:    $will_backup"
+    [[ "$mode" == "full" ]] && echo "  Files to overwrite: $will_overwrite"
+    echo ""
+    echo "Run without --dry-run to execute restore"
+}
+
+# Execute restore locally
+do_restore_local() {
+    local backup_file="$1"
+    local mode="$2"
+    local dry_run="$3"
+    local verbose="$4"
+    local interactive="$5"
+
+    local target_dir="${ALT_HOME}"
+
+    if [[ "$dry_run" == "true" ]]; then
+        preview_restore "$backup_file" "$target_dir" "$mode" "$verbose"
+        return 0
+    fi
+
+    # Show preview and confirm if interactive
+    if [[ "$interactive" == "true" ]]; then
+        analyze_backup "$backup_file" "$verbose"
+        echo ""
+        read -p "Proceed with restore? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_status "Restore cancelled"
+            return 0
+        fi
+    fi
+
+    print_header "Restoring Backup (mode: $mode)"
+
+    # Create temp directory for extraction
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    trap "rm -rf $temp_dir" EXIT
+
+    # Extract backup
+    print_status "Extracting backup..."
+    tar xzf "$backup_file" -C "$temp_dir"
+
+    local restored=0
+    local skipped=0
+    local backed_up=0
+
+    # Process each file
+    while IFS= read -r -d '' file; do
+        local rel_path="${file#$temp_dir/}"
+
+        # Skip empty or root
+        [[ -z "$rel_path" ]] && continue
+
+        # Check if system marker
+        local is_marker=false
+        for marker in "${NEVER_RESTORE[@]}"; do
+            if [[ "$rel_path" == "$marker" ]] || [[ "$rel_path" == "$marker/"* ]]; then
+                is_marker=true
+                ((skipped++)) || true
+                [[ "$verbose" == "true" ]] && print_warning "Skipping system marker: $rel_path"
+                break
+            fi
+        done
+        [[ "$is_marker" == "true" ]] && continue
+
+        local target_path="$target_dir/$rel_path"
+        local target_parent
+        target_parent=$(dirname "$target_path")
+
+        # Handle based on mode
+        if [[ -e "$target_path" ]]; then
+            case "$mode" in
+                safe)
+                    ((skipped++)) || true
+                    [[ "$verbose" == "true" ]] && print_status "Skipping (exists): $rel_path"
+                    continue
+                    ;;
+                merge)
+                    # Backup existing file
+                    if [[ -f "$target_path" ]]; then
+                        mv "$target_path" "${target_path}.bak"
+                        ((backed_up++)) || true
+                        [[ "$verbose" == "true" ]] && print_status "Backed up: $rel_path"
+                    fi
+                    ;;
+                full)
+                    # Will overwrite
+                    [[ "$verbose" == "true" ]] && print_status "Overwriting: $rel_path"
+                    ;;
+            esac
+        fi
+
+        # Create parent directory if needed
+        mkdir -p "$target_parent"
+
+        # Copy file or directory
+        if [[ -d "$file" ]]; then
+            mkdir -p "$target_path"
+        else
+            cp -p "$file" "$target_path"
+            ((restored++)) || true
+        fi
+    done < <(find "$temp_dir" -mindepth 1 -print0)
+
+    echo ""
+    print_success "Restore complete!"
+    echo "  Files restored: $restored"
+    echo "  Files skipped:  $skipped"
+    [[ "$mode" == "merge" ]] && echo "  Files backed up: $backed_up (.bak)"
+}
+
+# Download from S3
+download_from_s3() {
+    local s3_path="$1"
+    local local_file="$2"
+
+    if ! command -v aws &>/dev/null; then
+        print_error "AWS CLI not installed. Install with: pip install awscli"
+        return 1
+    fi
+
+    print_status "Downloading from S3: $s3_path"
+    aws s3 cp "$s3_path" "$local_file"
+}
+
+# Download from URL
+download_from_url() {
+    local url="$1"
+    local local_file="$2"
+
+    print_status "Downloading: $url"
+    curl -fsSL -o "$local_file" "$url"
+}
+
+# Execute restore via Docker
+do_restore_docker() {
+    local container="$1"
+    local backup_file="$2"
+    local mode="$3"
+    local dry_run="$4"
+    local verbose="$5"
+    local interactive="$6"
+
+    if [[ "$dry_run" == "true" ]]; then
+        # Download and analyze locally for preview
+        analyze_backup "$backup_file" "$verbose"
+        preview_restore "$backup_file" "/alt/home/developer" "$mode" "$verbose"
+        return 0
+    fi
+
+    if [[ "$interactive" == "true" ]]; then
+        analyze_backup "$backup_file" "$verbose"
+        read -p "Proceed with restore? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_status "Restore cancelled"
+            return 0
+        fi
+    fi
+
+    print_status "Uploading backup to container..."
+
+    # Copy backup to container
+    docker cp "$backup_file" "$container:/tmp/restore-backup.tar.gz"
+
+    # Run restore inside container
+    print_status "Executing restore (mode: $mode)..."
+
+    # Build exclude patterns for system markers
+    local exclude_args=""
+    for marker in "${NEVER_RESTORE[@]}"; do
+        exclude_args="$exclude_args --exclude=$marker"
+    done
+
+    case "$mode" in
+        safe)
+            # Extract with --keep-newer-files (skip existing)
+            docker exec "$container" bash -c \
+                "cd /alt/home/developer && tar xzf /tmp/restore-backup.tar.gz $exclude_args --keep-newer-files"
+            ;;
+        merge)
+            # More complex: backup existing, then extract
+            docker exec "$container" bash -c \
+                "cd /alt/home/developer && tar xzf /tmp/restore-backup.tar.gz $exclude_args --backup=simple"
+            ;;
+        full)
+            docker exec "$container" bash -c \
+                "cd /alt/home/developer && tar xzf /tmp/restore-backup.tar.gz $exclude_args"
+            ;;
+    esac
+
+    # Clean up
+    docker exec "$container" rm -f /tmp/restore-backup.tar.gz
+
+    # Fix permissions
+    docker exec "$container" chown -R developer:developer /alt/home/developer
+
+    print_success "Restore complete!"
+}
+
+# Execute restore via Fly.io
+do_restore_fly() {
+    local app="$1"
+    local backup_file="$2"
+    local mode="$3"
+    local dry_run="$4"
+    local verbose="$5"
+    local interactive="$6"
+
+    if [[ "$dry_run" == "true" ]]; then
+        analyze_backup "$backup_file" "$verbose"
+        preview_restore "$backup_file" "/alt/home/developer" "$mode" "$verbose"
+        return 0
+    fi
+
+    if [[ "$interactive" == "true" ]]; then
+        analyze_backup "$backup_file" "$verbose"
+        read -p "Proceed with restore? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_status "Restore cancelled"
+            return 0
+        fi
+    fi
+
+    print_status "Uploading backup to Fly.io..."
+
+    # Upload via sftp
+    flyctl ssh sftp shell -a "$app" << EOF
+put $backup_file /tmp/restore-backup.tar.gz
+EOF
+
+    # Build exclude patterns
+    local exclude_args=""
+    for marker in "${NEVER_RESTORE[@]}"; do
+        exclude_args="$exclude_args --exclude=$marker"
+    done
+
+    print_status "Executing restore (mode: $mode)..."
+
+    case "$mode" in
+        safe)
+            flyctl ssh console -a "$app" -C \
+                "cd /alt/home/developer && tar xzf /tmp/restore-backup.tar.gz $exclude_args --keep-newer-files"
+            ;;
+        merge)
+            flyctl ssh console -a "$app" -C \
+                "cd /alt/home/developer && tar xzf /tmp/restore-backup.tar.gz $exclude_args --backup=simple"
+            ;;
+        full)
+            flyctl ssh console -a "$app" -C \
+                "cd /alt/home/developer && tar xzf /tmp/restore-backup.tar.gz $exclude_args"
+            ;;
+    esac
+
+    # Clean up
+    flyctl ssh console -a "$app" -C "rm -f /tmp/restore-backup.tar.gz"
+
+    # Fix permissions
+    flyctl ssh console -a "$app" -C "chown -R developer:developer /alt/home/developer"
+
+    print_success "Restore complete!"
+}
+
+# ==============================================================================
+# List Backups
+# ==============================================================================
+
+list_backups_local() {
+    local backup_dir="${WORKSPACE}/backups"
+
+    if [[ ! -d "$backup_dir" ]]; then
+        print_warning "No backups directory found at $backup_dir"
+        return 0
+    fi
+
+    print_header "Available Backups"
+    echo ""
+
+    local count=0
+    while IFS= read -r file; do
+        local size
+        size=$(du -h "$file" | cut -f1)
+        local date
+        date=$(stat -c %y "$file" 2>/dev/null || stat -f %Sm "$file" 2>/dev/null || echo "unknown")
+        echo "  $(basename "$file") ($size) - $date"
+        ((count++)) || true
+    done < <(find "$backup_dir" -name "*.tar.gz" -type f 2>/dev/null | sort -r)
+
+    if [[ $count -eq 0 ]]; then
+        echo "  No backups found"
+    fi
+    echo ""
+}
+
+list_backups_docker() {
+    local container="$1"
+
+    print_header "Available Backups on $container"
+    docker exec "$container" bash -c \
+        "ls -lh /alt/home/developer/workspace/backups/*.tar.gz 2>/dev/null || echo '  No backups found'"
+}
+
+list_backups_fly() {
+    local app="$1"
+
+    print_header "Available Backups on $app"
+    flyctl ssh console -a "$app" -C \
+        "ls -lh ~/workspace/backups/*.tar.gz 2>/dev/null || echo '  No backups found'"
+}
+
+# ==============================================================================
+# Main Entry Points
+# ==============================================================================
+
+backup_main() {
+    local output=""
+    local profile="standard"
+    local config="sindri.yaml"
+    local dry_run="false"
+    local verbose="false"
+    local list_mode="false"
+    local extra_excludes=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -o|--output)
+                output="$2"
+                shift 2
+                ;;
+            -p|--profile)
+                profile="$2"
+                if [[ ! "${PROFILE_INCLUDES[$profile]+isset}" ]]; then
+                    print_error "Unknown profile: $profile"
+                    echo "Available profiles: user-data, standard, full"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            -c|--config)
+                config="$2"
+                shift 2
+                ;;
+            --exclude)
+                extra_excludes+=("$2")
+                shift 2
+                ;;
+            --dry-run)
+                dry_run="true"
+                shift
+                ;;
+            --list)
+                list_mode="true"
+                shift
+                ;;
+            -v|--verbose)
+                verbose="true"
+                shift
+                ;;
+            -h|--help)
+                show_backup_help
+                exit 0
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                show_backup_help
+                exit 1
+                ;;
+        esac
+    done
+
+    local name provider
+    name=$(get_instance_name "$config")
+    provider=$(get_provider "$config")
+
+    # Handle list mode
+    if [[ "$list_mode" == "true" ]]; then
+        if [[ "$RUNNING_IN_CONTAINER" == "true" ]]; then
+            list_backups_local
+        else
+            case "$provider" in
+                docker) list_backups_docker "$name" ;;
+                fly)    list_backups_fly "$name" ;;
+                *)      print_error "Unsupported provider: $provider" ;;
+            esac
+        fi
+        exit 0
+    fi
+
+    # Determine output path
+    if [[ -z "$output" ]]; then
+        output="./$(generate_backup_filename "$name")"
+    elif [[ -d "$output" ]]; then
+        output="$output/$(generate_backup_filename "$name")"
+    fi
+
+    local final_output="$output"
+    local is_s3=false
+
+    # Handle S3 output
+    if is_s3_path "$output"; then
+        is_s3=true
+        final_output=$(mktemp --suffix=.tar.gz)
+        trap "rm -f $final_output" EXIT
+    fi
+
+    # Execute backup based on context
+    if [[ "$RUNNING_IN_CONTAINER" == "true" ]]; then
+        do_backup_local "$final_output" "$profile" "$dry_run" "$verbose" "${extra_excludes[@]}"
+    else
+        case "$provider" in
+            docker)
+                do_backup_docker "$name" "$final_output" "$profile" "$dry_run" "$verbose" "${extra_excludes[@]}"
+                ;;
+            fly)
+                do_backup_fly "$name" "$final_output" "$profile" "$dry_run" "$verbose" "${extra_excludes[@]}"
+                ;;
+            devpod)
+                print_error "DevPod backup not yet implemented"
+                exit 1
+                ;;
+            *)
+                print_error "Unknown provider: $provider"
+                exit 1
+                ;;
+        esac
+    fi
+
+    # Upload to S3 if needed
+    if [[ "$is_s3" == "true" ]] && [[ "$dry_run" == "false" ]]; then
+        upload_to_s3 "$final_output" "$output"
+    fi
+}
+
+restore_main() {
+    local source=""
+    local mode="safe"
+    local config="sindri.yaml"
+    local dry_run="false"
+    local verbose="false"
+    local interactive="true"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -m|--mode)
+                mode="$2"
+                if [[ ! "$mode" =~ ^(safe|merge|full)$ ]]; then
+                    print_error "Unknown mode: $mode"
+                    echo "Available modes: safe, merge, full"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            -c|--config)
+                config="$2"
+                shift 2
+                ;;
+            --dry-run)
+                dry_run="true"
+                shift
+                ;;
+            --no-interactive)
+                interactive="false"
+                shift
+                ;;
+            -v|--verbose)
+                verbose="true"
+                shift
+                ;;
+            -h|--help)
+                show_restore_help
+                exit 0
+                ;;
+            -*)
+                print_error "Unknown option: $1"
+                show_restore_help
+                exit 1
+                ;;
+            *)
+                if [[ -z "$source" ]]; then
+                    source="$1"
+                else
+                    print_error "Unexpected argument: $1"
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$source" ]]; then
+        print_error "Missing backup source"
+        show_restore_help
+        exit 1
+    fi
+
+    local name provider
+    name=$(get_instance_name "$config")
+    provider=$(get_provider "$config")
+
+    # Handle remote sources
+    local local_backup="$source"
+    local cleanup_backup="false"
+
+    if is_s3_path "$source"; then
+        local_backup=$(mktemp --suffix=.tar.gz)
+        cleanup_backup="true"
+        download_from_s3 "$source" "$local_backup"
+    elif is_url "$source"; then
+        local_backup=$(mktemp --suffix=.tar.gz)
+        cleanup_backup="true"
+        download_from_url "$source" "$local_backup"
+    fi
+
+    if [[ ! -f "$local_backup" ]]; then
+        print_error "Backup file not found: $local_backup"
+        exit 1
+    fi
+
+    # Warn about full mode
+    if [[ "$mode" == "full" ]] && [[ "$interactive" == "true" ]]; then
+        print_warning "Full mode will overwrite existing files!"
+        read -p "Are you sure? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_status "Restore cancelled"
+            [[ "$cleanup_backup" == "true" ]] && rm -f "$local_backup"
+            exit 0
+        fi
+    fi
+
+    # Execute restore based on context
+    if [[ "$RUNNING_IN_CONTAINER" == "true" ]]; then
+        do_restore_local "$local_backup" "$mode" "$dry_run" "$verbose" "$interactive"
+    else
+        case "$provider" in
+            docker)
+                do_restore_docker "$name" "$local_backup" "$mode" "$dry_run" "$verbose" "$interactive"
+                ;;
+            fly)
+                do_restore_fly "$name" "$local_backup" "$mode" "$dry_run" "$verbose" "$interactive"
+                ;;
+            devpod)
+                print_error "DevPod restore not yet implemented"
+                [[ "$cleanup_backup" == "true" ]] && rm -f "$local_backup"
+                exit 1
+                ;;
+            *)
+                print_error "Unknown provider: $provider"
+                [[ "$cleanup_backup" == "true" ]] && rm -f "$local_backup"
+                exit 1
+                ;;
+        esac
+    fi
+
+    # Cleanup temp file
+    [[ "$cleanup_backup" == "true" ]] && rm -f "$local_backup"
+}
+
+# ==============================================================================
+# Script Entry Point
+# ==============================================================================
+
+main() {
+    local command="${1:-}"
+
+    case "$command" in
+        backup)
+            shift
+            backup_main "$@"
+            ;;
+        restore)
+            shift
+            restore_main "$@"
+            ;;
+        help|-h|--help)
+            echo "Sindri Backup/Restore Manager"
+            echo ""
+            echo "Usage:"
+            echo "  sindri backup [options]       Create workspace backup"
+            echo "  sindri restore <file> [opts]  Restore from backup"
+            echo ""
+            echo "Run 'sindri backup --help' or 'sindri restore --help' for details"
+            ;;
+        *)
+            print_error "Unknown command: $command"
+            echo "Usage: sindri backup|restore [options]"
+            exit 1
+            ;;
+    esac
+}
+
+# Run if called directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/cli/sindri
+++ b/cli/sindri
@@ -80,6 +80,12 @@ COMMANDS:
     config validate [--config <file>]
                                  Validate configuration against schema
 
+    backup [--profile <name>] [--output <path>]
+                                 Backup workspace (profiles: user-data, standard, full)
+    restore <file> [--mode <name>]
+                                 Restore from backup (modes: safe, merge, full)
+    backup list                  List backups on instance
+
 OPTIONS:
     -h, --help                   Show this help
     -V, --version                Show version information
@@ -102,6 +108,13 @@ EXAMPLES:
     sindri destroy --provider docker
     sindri destroy --force
     sindri test --config examples/fly/minimal.sindri.yaml --suite smoke
+
+    # Backup and restore
+    sindri backup                            # Standard backup
+    sindri backup --profile user-data        # User data only (migration)
+    sindri backup --output s3://bucket/path  # Backup to S3
+    sindri restore ./backup.tar.gz           # Safe restore
+    sindri restore ./backup.tar.gz --dry-run # Preview restore
 
     # Local Kubernetes cluster management
     sindri k8s create --provider kind
@@ -944,6 +957,14 @@ main() {
 
             # Execute k8s adapter
             "$BASE_DIR/deploy/adapters/k8s/k8s-adapter.sh" "${adapter_args[@]}"
+            ;;
+        backup)
+            # Delegate to backup-restore script
+            "$BASE_DIR/cli/backup-restore" backup "$@"
+            ;;
+        restore)
+            # Delegate to backup-restore script
+            "$BASE_DIR/cli/backup-restore" restore "$@"
             ;;
         help|-h|--help)
             show_help

--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -1,0 +1,565 @@
+# Backup and Restore Guide
+
+This guide covers how to safely backup, download, and restore your Sindri workspace.
+
+## Overview
+
+### Architecture: Understanding What Gets Backed Up
+
+The Sindri home directory (`/alt/home/developer`) contains multiple categories of data with different backup/restore requirements:
+
+```text
+/alt/home/developer/                    # $HOME - persistent volume
+├── workspace/                          # USER DATA - Always backup
+│   ├── projects/                       # Your development projects
+│   ├── config/                         # User configuration files
+│   ├── scripts/                        # User scripts
+│   ├── bin/                            # User binaries
+│   └── .system/                        # SYSTEM STATE - Never restore
+│       ├── manifest/                   #   Extension manifest
+│       ├── installed/                  #   Installation markers
+│       ├── logs/                       #   Extension logs
+│       └── bootstrap.yaml              #   Auto-install state
+├── .claude/                            # USER DATA - Always backup
+├── .ssh/                               # MIXED
+│   ├── host_keys/                      #   Backup (fingerprint stability)
+│   └── authorized_keys                 #   Skip (injected from env)
+├── .gitconfig                          # CONFIG - Backup (user settings)
+├── .bashrc, .profile                   # CONFIG - Backup with care
+├── .config/                            # MIXED
+│   └── mise/conf.d/*.toml              #   Regenerable (extension configs)
+├── .local/
+│   ├── share/mise/installs/            # REGENERABLE - Don't backup
+│   ├── state/mise/                     # REGENERABLE - Don't backup
+│   └── bin/                            # Mixed - tools installed here
+├── .cache/                             # CACHE - Never backup
+├── .initialized                        # SYSTEM MARKER - Never restore
+└── .welcome_shown                      # SYSTEM MARKER - Never restore
+```
+
+### Data Categories
+
+| Category           | Description                      | Backup | Restore                 |
+| ------------------ | -------------------------------- | ------ | ----------------------- |
+| **User Data**      | Projects, scripts, Claude data   | Always | Always                  |
+| **Config**         | Shell RC, gitconfig, app configs | Yes    | Merge/Skip conflicts    |
+| **Regenerable**    | Mise installs, tool caches       | No     | N/A                     |
+| **System Markers** | `.initialized`, `bootstrap.yaml` | No     | **Never** (breaks init) |
+| **Cache**          | `.cache/*`                       | No     | N/A                     |
+
+### Why System Markers Must Never Be Restored
+
+**`.initialized`**: Controls first-boot initialization
+
+- If restored to new instance: entrypoint skips setup
+- Result: Missing `.bashrc`, broken PATH, no home structure
+
+**`bootstrap.yaml`**: Controls auto-install
+
+- If restored: auto-install thinks extensions already installed
+- Result: Missing tools, broken development environment
+
+---
+
+## Quick Start
+
+### Backup Your Workspace
+
+```bash
+# Standard backup (recommended for most users)
+./cli/sindri backup --output ./backups/
+
+# User data only (smallest, safest for migration)
+./cli/sindri backup --profile user-data --output ./backups/
+
+# Full backup (disaster recovery)
+./cli/sindri backup --profile full --output ./backups/
+```
+
+### Restore to New Instance
+
+```bash
+# Safe restore (default - won't overwrite existing files)
+./cli/sindri restore ./backups/sindri-backup-2025-01-15.tar.gz
+
+# Preview what will happen
+./cli/sindri restore ./backups/backup.tar.gz --dry-run
+
+# Merge with existing (backs up conflicts first)
+./cli/sindri restore ./backups/backup.tar.gz --mode merge
+```
+
+---
+
+## Backup Profiles
+
+### `user-data` Profile (Recommended for Migration)
+
+**Size**: Small (100MB - 1GB typical)
+**Use case**: Moving to a new Sindri instance
+
+Includes:
+
+- `workspace/projects/` - All projects
+- `workspace/config/` - User configs
+- `workspace/scripts/` - User scripts
+- `workspace/bin/` - User binaries
+- `.claude/` - Claude Code settings and history
+- `.ssh/host_keys/` - SSH host keys (fingerprint stability)
+- `.gitconfig` - Git configuration
+
+Excludes:
+
+- All system markers
+- All mise installations (regenerable)
+- All caches
+- Shell RC files (regenerated on new instance)
+
+```bash
+./cli/sindri backup --profile user-data --output ./backups/
+```
+
+### `standard` Profile (Default)
+
+**Size**: Medium (1GB - 5GB typical)
+**Use case**: Regular backups, same-instance recovery
+
+Includes everything in `user-data` plus:
+
+- `.bashrc`, `.profile` - Shell configuration
+- `.config/` - Application configs (excluding mise state)
+- `.local/bin/` - Locally installed binaries
+
+```bash
+./cli/sindri backup --output ./backups/
+# or explicitly:
+./cli/sindri backup --profile standard --output ./backups/
+```
+
+### `full` Profile (Disaster Recovery)
+
+**Size**: Large (5GB - 20GB typical)
+**Use case**: Complete disaster recovery to same instance
+
+Includes everything except:
+
+- `.cache/` - Caches (always excluded)
+- `.local/share/mise/installs/` - Can be regenerated
+- `.local/state/` - Tool state
+
+**Warning**: Restoring a full backup to a different instance may cause issues.
+
+```bash
+./cli/sindri backup --profile full --output ./backups/
+```
+
+---
+
+## Restore Modes
+
+### `safe` Mode (Default)
+
+The safest option - never overwrites existing files.
+
+**Behavior**:
+
+- System markers: Never touched
+- Existing files: Skipped (preserved)
+- Missing files: Restored
+- Conflicts: Reported but not modified
+
+```bash
+./cli/sindri restore ./backup.tar.gz
+# or explicitly:
+./cli/sindri restore ./backup.tar.gz --mode safe
+```
+
+**Best for**: Migration to new instance, adding missing files
+
+### `merge` Mode
+
+Smart merge with automatic backup of conflicts.
+
+**Behavior**:
+
+- System markers: Never touched
+- Existing files: Backed up to `.bak`, then restored
+- Shell configs: Intelligently merged (preserves user sections)
+- Creates rollback capability
+
+```bash
+./cli/sindri restore ./backup.tar.gz --mode merge
+```
+
+**Best for**: Updating existing instance, recovering from partial data loss
+
+### `full` Mode
+
+Complete restore - overwrites everything.
+
+**Behavior**:
+
+- System markers: Optionally restored (with warning)
+- All files: Overwritten
+- No conflict preservation
+
+```bash
+./cli/sindri restore ./backup.tar.gz --mode full
+```
+
+**Warning**: Only use for disaster recovery on the SAME instance. Using on a different instance may break initialization.
+
+---
+
+## CLI Reference
+
+### Backup Command
+
+```bash
+./cli/sindri backup [options]
+
+Options:
+  -o, --output <path>     Output location (directory or file path)
+                          Default: ./sindri-backup-{name}-{timestamp}.tar.gz
+  -p, --profile <name>    Backup profile: user-data, standard (default), full
+  -c, --config <file>     Sindri config file (default: sindri.yaml)
+  --exclude <pattern>     Additional exclude pattern (can repeat)
+  --dry-run               Show what would be backed up without creating archive
+  --list                  List available backups on the instance
+  -v, --verbose           Verbose output
+
+Examples:
+  ./cli/sindri backup                                    # Standard backup to current dir
+  ./cli/sindri backup --profile user-data -o ./backups/  # User data only
+  ./cli/sindri backup --exclude 'node_modules'           # Exclude pattern
+  ./cli/sindri backup --dry-run                          # Preview backup contents
+```
+
+### Restore Command
+
+```bash
+./cli/sindri restore <source> [options]
+
+Arguments:
+  source                  Backup file: local path, s3://bucket/path, or https://url
+
+Options:
+  -m, --mode <name>       Restore mode: safe (default), merge, full
+  -c, --config <file>     Sindri config file (default: sindri.yaml)
+  --dry-run               Preview restore without making changes
+  --no-interactive        Skip confirmation prompts
+  -v, --verbose           Verbose output
+
+Examples:
+  ./cli/sindri restore ./backup.tar.gz                   # Safe restore
+  ./cli/sindri restore ./backup.tar.gz --mode merge      # Merge with backups
+  ./cli/sindri restore ./backup.tar.gz --dry-run         # Preview changes
+  ./cli/sindri restore s3://bucket/backup.tar.gz         # Restore from S3
+```
+
+### List Backups Command
+
+```bash
+./cli/sindri backup list [options]
+
+Options:
+  -c, --config <file>     Sindri config file (default: sindri.yaml)
+
+Lists backups stored on the Sindri instance in ~/workspace/backups/
+```
+
+---
+
+## Provider-Specific Instructions
+
+### Docker Provider
+
+#### Backup from Docker
+
+```bash
+# Via CLI (recommended)
+./cli/sindri backup --output ./backups/
+
+# Manual method
+docker exec sindri-docker tar czf - \
+  --exclude='.cache' \
+  --exclude='.local/share/mise/installs' \
+  --exclude='.local/state' \
+  --exclude='.initialized' \
+  --exclude='workspace/.system/bootstrap.yaml' \
+  --exclude='workspace/.system/installed' \
+  -C /alt/home/developer . > backup.tar.gz
+```
+
+#### Restore to Docker
+
+```bash
+# Via CLI (recommended)
+./cli/sindri restore ./backup.tar.gz
+
+# Manual method - stop container first
+docker compose stop
+docker run --rm -v sindri_dev_home:/data -v $(pwd):/backup \
+  alpine sh -c "cd /data && tar xzf /backup/backup.tar.gz"
+docker compose start
+```
+
+### Fly.io Provider
+
+#### Backup from Fly.io
+
+```bash
+# Via CLI (recommended)
+./cli/sindri backup --output ./backups/
+
+# Using Fly.io native snapshots (for disaster recovery)
+flyctl volumes list -a my-sindri-dev
+flyctl volumes snapshots create vol_abc123
+```
+
+#### Restore to Fly.io
+
+```bash
+# Via CLI (recommended)
+./cli/sindri restore ./backup.tar.gz
+
+# From Fly.io snapshot (creates new volume)
+flyctl volumes create workspace \
+  --snapshot-id snap_abc123 \
+  --region sjc --size 10 \
+  -a my-sindri-dev
+```
+
+#### Manual SFTP Access
+
+For direct SFTP access to manage backups:
+
+```bash
+# Create backup on instance
+flyctl ssh console -a my-sindri-dev -C \
+  "cd ~ && tar czf workspace/backups/backup-\$(date +%Y%m%d).tar.gz \
+   --exclude='.cache' --exclude='.local/share/mise/installs' \
+   --exclude='.initialized' --exclude='workspace/.system/bootstrap.yaml' \
+   ."
+
+# List backups
+flyctl ssh console -a my-sindri-dev -C "ls -lh ~/workspace/backups/"
+
+# Download via SFTP
+flyctl ssh sftp shell -a my-sindri-dev
+sftp> cd workspace/backups
+sftp> get backup-20250115.tar.gz
+sftp> exit
+
+# Upload for restore
+flyctl ssh sftp shell -a my-sindri-dev
+sftp> put backup.tar.gz /tmp/
+sftp> exit
+
+# Extract (after upload)
+flyctl ssh console -a my-sindri-dev -C \
+  "cd /alt/home/developer && tar xzf /tmp/backup.tar.gz && rm /tmp/backup.tar.gz"
+```
+
+---
+
+## S3 Backup Storage
+
+### Configuration
+
+```bash
+# AWS credentials
+export AWS_ACCESS_KEY_ID=your-key
+export AWS_SECRET_ACCESS_KEY=your-secret
+export AWS_DEFAULT_REGION=us-west-2
+
+# Or use AWS CLI profile
+export AWS_PROFILE=sindri-backup
+```
+
+### Backup to S3
+
+```bash
+./cli/sindri backup --output s3://my-bucket/sindri-backups/
+```
+
+### Restore from S3
+
+```bash
+./cli/sindri restore s3://my-bucket/sindri-backups/backup-2025-01-15.tar.gz
+```
+
+### S3-Compatible Storage
+
+For MinIO, Wasabi, DigitalOcean Spaces:
+
+```bash
+export AWS_ENDPOINT_URL=https://s3.wasabisys.com
+./cli/sindri backup --output s3://my-bucket/backups/
+```
+
+---
+
+## Migration Workflow
+
+### Step 1: Backup from Old Instance
+
+```bash
+# Create user-data backup (recommended for migration)
+./cli/sindri backup --profile user-data --output ./migration-backup.tar.gz
+```
+
+### Step 2: Deploy New Instance
+
+```bash
+# Create new sindri.yaml or modify existing
+./cli/sindri config init
+vim sindri.yaml
+
+# Deploy
+./cli/sindri deploy
+```
+
+### Step 3: Restore to New Instance
+
+```bash
+# Safe restore (won't conflict with new instance setup)
+./cli/sindri restore ./migration-backup.tar.gz
+
+# Verify
+./cli/sindri connect
+ls ~/workspace/projects/
+```
+
+### Step 4: Extensions Re-install Automatically
+
+The new instance will auto-install extensions based on `sindri.yaml`. Your user data is preserved, tools are fresh.
+
+---
+
+## Automated Backups
+
+### Local Cron Job
+
+```bash
+# Add to crontab: crontab -e
+# Daily backup at 2 AM
+0 2 * * * cd /path/to/sindri && ./cli/sindri backup --output ~/sindri-backups/
+```
+
+### Backup Rotation Script
+
+```bash
+#!/bin/bash
+# backup-rotate.sh
+BACKUP_DIR="$HOME/sindri-backups"
+KEEP_DAYS=7
+
+./cli/sindri backup --output "$BACKUP_DIR/"
+find "$BACKUP_DIR" -name "sindri-backup-*.tar.gz" -mtime +$KEEP_DAYS -delete
+```
+
+### S3 with Lifecycle Policy
+
+Configure S3 lifecycle rules for automatic expiration:
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "ExpireOldBackups",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "sindri-backups/" },
+      "Expiration": { "Days": 30 }
+    }
+  ]
+}
+```
+
+---
+
+## Troubleshooting
+
+### Restore Fails: Permission Denied
+
+```bash
+# Fix ownership after restore
+flyctl ssh console -a my-app -C \
+  "sudo chown -R developer:developer /alt/home/developer"
+```
+
+### Extensions Not Working After Restore
+
+This happens if `bootstrap.yaml` was accidentally restored.
+
+```bash
+# Remove bootstrap marker to trigger re-install
+rm ~/workspace/.system/bootstrap.yaml
+rm -rf ~/workspace/.system/installed/
+
+# Restart container or re-deploy
+```
+
+### Shell Environment Broken
+
+This happens if `.initialized` was restored or `.bashrc` is corrupt.
+
+```bash
+# Reset initialization (will recreate shell configs)
+rm ~/.initialized
+# Then restart container
+```
+
+### Backup Too Large
+
+```bash
+# Use user-data profile
+./cli/sindri backup --profile user-data --output ./backup.tar.gz
+
+# Or add exclusions
+./cli/sindri backup --exclude 'node_modules' --exclude '.venv'
+```
+
+### Dry Run Shows Unexpected Files
+
+```bash
+# Check what's in the backup
+tar tzf backup.tar.gz | head -50
+
+# Check categories
+./cli/sindri restore backup.tar.gz --dry-run --verbose
+```
+
+---
+
+## Security Considerations
+
+1. **Encrypt sensitive backups**:
+
+   ```bash
+   ./cli/sindri backup --output - | gpg --symmetric > backup.tar.gz.gpg
+   ```
+
+2. **Never commit backups to git**
+
+3. **Use IAM roles** for S3 instead of long-lived credentials
+
+4. **Verify backup integrity**:
+
+   ```bash
+   tar tzf backup.tar.gz > /dev/null && echo "OK"
+   ```
+
+5. **Exclude secrets** when sharing backups:
+   ```bash
+   ./cli/sindri backup --exclude '.ssh' --exclude '.env*'
+   ```
+
+---
+
+## Related Documentation
+
+- [Architecture](ARCHITECTURE.md) - Volume structure details
+- [Docker Provider](providers/DOCKER.md) - Docker-specific operations
+- [Fly.io Provider](providers/FLY.md) - Fly.io-specific operations
+- [Configuration](CONFIGURATION.md) - sindri.yaml reference


### PR DESCRIPTION
Add comprehensive backup/restore functionality for Sindri workspaces with smart profiles and restore modes:

Backup Profiles:
- user-data: Projects, scripts, Claude data, SSH keys (smallest)
- standard: user-data + shell/app configs (default)
- full: Everything except caches (disaster recovery)

Restore Modes:
- safe: Never overwrite existing files (default)
- merge: Backup existing files before restoring
- full: Overwrite everything

Features:
- Multi-provider support: Docker, Fly.io, local
- S3 upload/download support
- System marker protection (never restore .initialized, etc.)
- Dry-run preview for both backup and restore
- Interactive confirmation prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)