### PR TITLE
fix(v2): skip malformed Docker Hub tags when credentials unavailable

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -303,6 +303,13 @@ jobs:
           echo "Retagging for release:"
           while IFS= read -r TAG; do
             [[ -z "$TAG" ]] && continue
+
+            # Skip malformed tags (empty username results in docker.io//...)
+            if [[ "$TAG" =~ .*//.*  ]]; then
+              echo "  ⏭️  Skipping $TAG (malformed - missing repository)"
+              continue
+            fi
+
             echo "  → $TAG"
             docker tag "$CI_IMAGE" "$TAG"
           done <<< "$TAGS"
@@ -311,6 +318,12 @@ jobs:
           echo "Pushing release tags:"
           while IFS= read -r TAG; do
             [[ -z "$TAG" ]] && continue
+
+            # Skip malformed tags (empty username results in docker.io//...)
+            if [[ "$TAG" =~ .*//.*  ]]; then
+              echo "  ⏭️  Skipping $TAG (malformed - missing repository)"
+              continue
+            fi
 
             # Check if pushing to Docker Hub and if credentials are available
             if [[ "$TAG" =~ ^docker\.io/ ]] && [[ -z "$DOCKERHUB_TOKEN" ]]; then


### PR DESCRIPTION
When DOCKERHUB_USERNAME secret is not configured, the metadata-action generates invalid image references like "docker.io//sindri:v2.5.0". This caused the release workflow to fail at the retagging step.

Add validation to skip tags containing "//" (malformed references) in both the retagging and push loops, allowing releases to proceed with only GHCR images when Docker Hub is not configured.