### PR TITLE
docs(v2): restore IDE setup guides

### DIFF
--- a/v2/docs/ides/ECLIPSE.md
+++ b/v2/docs/ides/ECLIPSE.md
@@ -1,0 +1,299 @@
+# Eclipse IDE - Remote Development Setup
+
+Eclipse IDE offers remote development capabilities through the Remote System Explorer (RSE) plugin and Docker integration, enabling connection to Sindri environments for Java and other language development.
+
+## Prerequisites
+
+- [Eclipse IDE](https://www.eclipse.org/downloads/) (2023-12 or later recommended)
+- Install the following components:
+  - **Remote System Explorer (RSE)** - For SSH connections
+  - **Docker Tools** - For Docker container integration
+  - **CDT (C/C++ Development Tools)** - For enhanced Docker container support (optional)
+- Java 17 or later
+
+## Connection Methods
+
+### Method 1: Remote System Explorer (SSH to Fly.io VM)
+
+RSE provides SSH-based remote file access, terminal access, and remote debugging capabilities.
+
+**Setup Steps:**
+
+1. **Install Remote System Explorer:**
+   - Help > Eclipse Marketplace
+   - Search for "Remote System Explorer"
+   - Install and restart Eclipse
+
+2. **Configure SSH connection:**
+   - Window > Perspective > Open Perspective > Remote System Explorer
+   - In "Remote Systems" view, right-click > New > Connection
+   - Select "SSH Only"
+   - Enter connection details:
+     - Host name: `your-app.fly.dev`
+     - Connection name: `Sindri Fly.io`
+     - Description: `Sindri development environment`
+
+3. **Configure authentication:**
+   - Expand connection in Remote Systems view
+   - Right-click "Sftp Files" > Properties
+   - Configure SSH key or password authentication
+   - Recommended: Use SSH key-based authentication
+
+4. **Connect and browse files:**
+   - Right-click connection > Connect
+   - Navigate to `/alt/home/developer/workspace`
+   - Double-click files to edit remotely
+
+**Best Practices:**
+
+- Use SSH key-based authentication for security
+- Configure SSH agent for seamless key management
+- Create filters to show only relevant directories
+- Use "Show in Remote Shell" for terminal access
+
+### Method 2: Docker Integration (Local Containers)
+
+Eclipse's Docker Tools plugin provides container management and development capabilities.
+
+**Setup Steps:**
+
+1. **Install Docker Tools plugin:**
+   - Help > Eclipse Marketplace
+   - Search for "Docker Tooling"
+   - Install and restart Eclipse
+
+2. **Configure Docker connection:**
+   - Window > Show View > Other > Docker > Docker Explorer
+   - Click "Connect to Docker daemon"
+   - Select connection type:
+     - **Unix socket:** `unix:///var/run/docker.sock` (macOS/Linux)
+     - **TCP:** `tcp://localhost:2375` (if Docker daemon exposed)
+
+3. **View and manage containers:**
+   - Docker Explorer shows images, containers, networks, volumes
+   - Right-click container > Start/Stop/Remove
+   - Right-click running container > Display Log
+
+4. **Develop in container:**
+   - Create container with Sindri image
+   - Mount workspace as volume:
+     ```bash
+     docker run -d -v /path/to/workspace:/workspace \
+       --name sindri-dev your-sindri-image:latest
+     ```
+   - Use RSE to connect to container via exposed SSH port
+
+**Best Practices:**
+
+- Use docker-compose.yml for multi-service applications
+- Configure volume mounts for persistent data
+- Use .dockerignore to exclude build artifacts
+- Monitor container resource usage
+
+### Method 3: Remote Docker Host
+
+Connect to Docker running on a remote machine for container development.
+
+**Setup Steps:**
+
+1. **Set up Docker context on remote host:**
+
+   ```bash
+   # On your local machine
+   docker context create remote-sindri \
+     --docker "host=ssh://user@remote-host"
+   docker context use remote-sindri
+   ```
+
+2. **Configure Eclipse Docker Tools:**
+   - Open Docker Explorer
+   - Add new connection
+   - Connection name: `Remote Sindri Docker`
+   - TCP Connection: Point to SSH-tunneled Docker socket
+
+3. **SSH tunnel to remote Docker (alternative):**
+
+   ```bash
+   ssh -NfL localhost:2375:/var/run/docker.sock user@remote-host
+   ```
+
+4. **Connect Eclipse to tunneled Docker:**
+   - Docker Explorer > New Connection
+   - TCP Connection: `tcp://localhost:2375`
+
+**Best Practices:**
+
+- Use SSH tunneling for secure remote Docker access
+- Don't expose Docker daemon over plain TCP (security risk)
+- Use Docker contexts for managing multiple remote hosts
+- Implement proper authentication and authorization
+
+## Advanced Configuration
+
+### SSH Configuration for RSE
+
+**Configure SSH key authentication:**
+
+1. **Generate SSH key (if needed):**
+
+   ```bash
+   ssh-keygen -t ed25519 -C "your_email@example.com"
+   ```
+
+2. **Copy public key to remote server:**
+
+   ```bash
+   ssh-copy-id -i ~/.ssh/id_ed25519.pub developer@your-app.fly.dev
+   ```
+
+3. **Configure RSE to use key:**
+   - Right-click SSH connection > Properties
+   - SSH Settings > Authentication
+   - Select "Public Key" authentication
+   - Browse to private key file: `~/.ssh/id_ed25519`
+
+### Remote Debugging
+
+**Debug Java applications running in containers:**
+
+1. **Start application with debug port exposed:**
+
+   ```bash
+   docker run -p 8000:8000 -e JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000" \
+     your-sindri-image:latest
+   ```
+
+2. **Configure debug configuration in Eclipse:**
+   - Run > Debug Configurations
+   - Create new "Remote Java Application"
+   - Set connection properties:
+     - Host: `localhost` (or remote host)
+     - Port: `8000`
+
+3. **Start debugging:**
+   - Click "Debug"
+   - Set breakpoints in your code
+   - Trigger application logic
+
+### Docker Container with Development Tools
+
+**Create enhanced container for Eclipse development:**
+
+```dockerfile
+FROM your-sindri-image:latest
+
+# Install Java and development tools
+RUN apt-get update && apt-get install -y \
+    openjdk-17-jdk \
+    maven \
+    gradle
+
+# Configure SSH for RSE access
+RUN apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN echo 'developer:password' | chpasswd
+
+EXPOSE 22 8000
+
+CMD ["/usr/sbin/sshd", "-D"]
+```
+
+## Eclipse-Specific Features
+
+### Project Synchronization
+
+**Synchronize local and remote projects:**
+
+1. Create local project in Eclipse
+2. Use RSE to upload/download files to/from remote
+3. Right-click project > Synchronize > Remote System
+
+### Terminal Access
+
+**Open terminal to remote system:**
+
+1. Right-click connection in Remote Systems view
+2. Select "Launch Terminal"
+3. Choose terminal type (SSH)
+4. Execute commands on remote system
+
+### File Transfer
+
+**Efficient file transfer with RSE:**
+
+- Drag and drop files between local and remote
+- Right-click files > Export/Import for batch operations
+- Configure filters to exclude unnecessary files
+
+## Troubleshooting
+
+### SSH Connection Issues
+
+- **"Connection refused":** Verify SSH server is running on remote host
+- **"Permission denied":** Check SSH key permissions (chmod 600)
+- **"Host key verification failed":** Remove old host key from ~/.ssh/known_hosts
+- **Timeout errors:** Check firewall rules and network connectivity
+
+### Docker Integration Issues
+
+- **"Cannot connect to Docker daemon":** Ensure Docker is running
+- **"Permission denied" on socket:** Add user to docker group (Linux)
+- **Container not starting:** Check Docker logs with `docker logs container_name`
+- **Volume mount issues:** Verify paths and permissions
+
+### Performance Issues
+
+- **Slow file operations:** Check network latency and bandwidth
+- **High memory usage:** Increase Eclipse heap size in eclipse.ini
+- **Indexing problems:** Exclude large directories from indexing
+
+## Security Best Practices
+
+### SSH Security
+
+- Never store passwords in Eclipse - use SSH keys
+- Use strong passphrases for SSH keys
+- Keep private keys secure (chmod 600)
+- Rotate SSH keys periodically
+
+### Docker Security
+
+- Don't expose Docker daemon over unencrypted TCP
+- Use SSH tunneling for remote Docker access
+- Don't store secrets in Docker images
+- Follow principle of least privilege for container access
+- Implement audit logging for container access
+
+## Resources
+
+- [Eclipse Remote System Explorer](https://www.eclipse.org/community/eclipse_newsletter/2017/april/article1.php)
+- [Docker Tools for Eclipse](https://www.eclipse.org/community/eclipse_newsletter/2015/june/article3.php)
+- [Advanced Remote Development - Eclipse](https://www.swiftorial.com/tutorials/development_tools/eclipse/remote_development/advanced_remote_development)
+- [Docker Best Practices 2025 - ThinkSys](https://thinksys.com/devops/docker-best-practices/)
+- [Remote Debugging with Eclipse](https://medium.com/@ravi.ajmera/connecting-eclipse-to-docker-container-for-remote-debugging-d459b5d53249)
+
+## Limitations
+
+- No native devcontainer.json support
+- Remote development features less mature than VS Code/IntelliJ
+- Limited container-aware language server support
+- Manual setup required for most remote workflows
+
+## Next Steps
+
+After connecting to your Sindri environment:
+
+1. Import existing projects or create new ones
+2. Configure build tools (Maven, Gradle)
+3. Set up run and debug configurations
+4. Install additional plugins as needed
+5. Configure code formatters and style checkers
+
+---
+
+**Related Documentation:**
+
+- [VS Code Setup](VSCODE.md) - For modern dev container support
+- [IntelliJ IDEA Setup](INTELLIJ.md) - For JetBrains remote development
+- [Zed Editor Setup](ZED.md)
+- [Warp Terminal Setup](WARP.md)

--- a/v2/docs/ides/INTELLIJ.md
+++ b/v2/docs/ides/INTELLIJ.md
@@ -1,0 +1,258 @@
+# IntelliJ IDEA - Remote Development Setup
+
+JetBrains IntelliJ IDEA provides powerful remote development capabilities through JetBrains Gateway and the Dev Containers plugin, enabling seamless work with Sindri environments.
+
+## Prerequisites
+
+- [IntelliJ IDEA](https://www.jetbrains.com/idea/) (2023.3 or later recommended)
+- [JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/) (standalone or built-in)
+- [Dev Containers plugin](https://plugins.jetbrains.com/plugin/21962-dev-containers) (for container support)
+- Docker CLI installed locally (for remote Docker connections)
+- Java 17 or later on remote servers
+
+## Connection Methods
+
+### Method 1: Dev Containers (DevPod)
+
+IntelliJ IDEA supports the devcontainer.json specification through the Dev Containers plugin.
+
+**Setup Steps:**
+
+1. **Install the Dev Containers plugin:**
+   - Settings > Plugins > Marketplace
+   - Search for "Dev Containers"
+   - Install and restart
+
+2. **Create a Dev Container:**
+   - Welcome Screen > Remote Development
+   - Select "Dev Containers"
+   - Click "Create Dev Container"
+   - Choose your Sindri project directory
+
+3. **Configure devcontainer.json:**
+
+   ```json
+   {
+     "name": "Sindri Development",
+     "image": "your-sindri-image:latest",
+     "customizations": {
+       "jetbrains": {
+         "backend": "IntelliJ",
+         "plugins": ["com.intellij.java", "org.jetbrains.plugins.yaml"]
+       }
+     },
+     "forwardPorts": [3000, 8080],
+     "remoteUser": "developer"
+   }
+   ```
+
+4. **Connect to the container:**
+   - IntelliJ reads the configuration
+   - Builds the container automatically
+   - Connects as a remote development environment
+
+**Best Practices:**
+
+- Use the Dev Containers plugin for seamless devcontainer.json support
+- Ensure Docker is installed on both local and remote machines
+- Configure JVM options for remote IDE backend performance
+- Use persistent volumes for workspace and IDE settings
+
+### Method 2: Remote SSH (Fly.io VM)
+
+Connect to remote VMs using JetBrains Gateway with SSH.
+
+**Setup Steps:**
+
+1. **Configure SSH access:**
+
+   ```bash
+   # Add to ~/.ssh/config
+   Host sindri-flyio
+     HostName your-app.fly.dev
+     User developer
+     Port 22
+     IdentityFile ~/.ssh/your_key
+     ServerAliveInterval 60
+     ServerAliveCountMax 3
+   ```
+
+2. **Connect via JetBrains Gateway:**
+   - Launch JetBrains Gateway
+   - Select "SSH Connection"
+   - Click "New Connection"
+   - Enter connection details:
+     - Host: `your-app.fly.dev`
+     - User: `developer`
+     - Port: `22`
+   - Choose authentication method (SSH key recommended)
+
+3. **Select IDE and project:**
+   - Gateway downloads and starts IntelliJ backend on remote server
+   - Choose the IDE version to use
+   - Select project directory: `/alt/home/developer/workspace`
+
+**System Requirements for Remote Server:**
+
+- Linux AMD64 distribution (Ubuntu 16.04+, RHEL/CentOS 7+)
+- 2+ CPU cores
+- 4GB+ RAM
+- 5GB+ disk space
+- OpenSSH server 7.9p1 or later
+- Java 17 or later
+
+**Network Requirements:**
+
+- Minimum 20 Mbps bandwidth
+- Maximum 200ms latency
+- SSH port forwarding enabled
+
+**Best Practices:**
+
+- Use SSH key-based authentication (not password)
+- Run an SSH agent for seamless key management
+- Ensure correct permissions on SSH key files (chmod 600)
+- Configure SSH keepalive to maintain connection stability
+- Close unused remote connections to free server resources
+
+### Method 3: Docker (Local Development)
+
+Connect to local Docker containers for development.
+
+**Setup Steps:**
+
+1. **Install Docker Desktop or Docker CLI:**
+   - Ensure Docker daemon is running
+   - Verify with: `docker ps`
+
+2. **Connect via Dev Containers plugin:**
+   - Install Dev Containers plugin (see Method 1)
+   - Use "Attach to Running Container" if container is already running
+   - Or create new container from devcontainer.json
+
+3. **Alternative: Docker plugin for management:**
+   - Install Docker plugin from marketplace
+   - Open Docker tool window
+   - View and manage containers
+   - Connect to containers for file browsing
+
+**Best Practices:**
+
+- Use Docker CLI (minimum requirement) or Docker Desktop
+- Configure Docker socket access for plugin integration
+- Use multi-stage builds for optimized images
+- Mount source code as volumes for live development
+
+## Advanced Configuration
+
+### Remote Docker via SSH
+
+Connect to Docker running on a remote machine:
+
+1. **Configure SSH tunnel to remote Docker:**
+
+   ```bash
+   ssh -NfL localhost:2375:/var/run/docker.sock user@remote-host
+   ```
+
+2. **Set Docker host environment variable:**
+
+   ```bash
+   export DOCKER_HOST=tcp://localhost:2375
+   ```
+
+3. **Use Dev Containers plugin with remote Docker:**
+   - Plugin will use DOCKER_HOST environment variable
+   - Create or attach to containers on remote Docker daemon
+
+### SSH Authentication Best Practices
+
+**Key Generation:**
+
+```bash
+# Generate SSH key pair (if needed)
+ssh-keygen -t ed25519 -C "your_email@example.com"
+
+# Copy public key to remote server
+ssh-copy-id -i ~/.ssh/id_ed25519.pub developer@your-app.fly.dev
+```
+
+**SSH Agent Setup:**
+
+```bash
+# Start SSH agent
+eval "$(ssh-agent -s)"
+
+# Add key to agent
+ssh-add ~/.ssh/id_ed25519
+```
+
+**Common Authentication Issues:**
+
+- **Incorrect key permissions:** Run `chmod 600 ~/.ssh/id_ed25519`
+- **Key not in agent:** Run `ssh-add ~/.ssh/id_ed25519`
+- **Public key not on server:** Verify `~/.ssh/authorized_keys` on remote
+
+### Performance Tuning
+
+**Increase JVM memory for IDE backend:**
+
+```bash
+# Add to remote server's ~/.bashrc or IDE settings
+export IDEA_VM_OPTIONS="-Xmx4g -Xms2g"
+```
+
+**Optimize indexing:**
+
+- Exclude build directories from indexing
+- Use "Power Save Mode" for resource-constrained environments
+- Configure IDE heap size based on project size
+
+## Troubleshooting
+
+### Connection Issues
+
+- **Connection timeout:** Check network latency and bandwidth requirements
+- **SSH key rejected:** Verify key permissions and authorized_keys on server
+- **Port forwarding fails:** Ensure SSH config allows port forwarding
+- **Gateway can't start backend:** Verify Java 17+ is installed on remote server
+
+### Dev Container Issues
+
+- **Container build fails:** Check Docker daemon is running and accessible
+- **Plugin not detecting devcontainer.json:** Ensure file is in .devcontainer/ or project root
+- **Extensions not loading:** Add JetBrains-specific plugin IDs to customizations
+
+### Performance Issues
+
+- **High latency UI:** Check network connection meets minimum requirements (20 Mbps, <200ms latency)
+- **Slow indexing:** Exclude unnecessary directories, increase IDE heap size
+- **Connection drops:** Configure SSH keepalive settings
+
+## Resources
+
+- [Remote Development Overview - JetBrains](https://www.jetbrains.com/help/idea/remote-development-overview.html)
+- [JetBrains Gateway Documentation](https://www.jetbrains.com/help/idea/remote-development-a.html)
+- [Dev Containers in IntelliJ IDEA](https://www.jetbrains.com/help/idea/start-dev-container-for-a-remote-project.html)
+- [System Requirements for Remote Development](https://www.jetbrains.com/help/idea/prerequisites.html)
+- [FAQ about Dev Containers](https://www.jetbrains.com/help/idea/faq-about-dev-containers.html)
+- [Dev Containers Setup Guide 2025 - BytePlus](https://www.byteplus.com/en/topic/504503)
+
+## Next Steps
+
+After connecting to your Sindri environment:
+
+1. Configure code style and inspections
+2. Set up run/debug configurations
+3. Install additional plugins as needed
+4. Configure version control integration
+5. Set up database tools if using databases
+
+---
+
+**Related Documentation:**
+
+- [VS Code Setup](VSCODE.md)
+- [Zed Editor Setup](ZED.md)
+- [Eclipse Setup](ECLIPSE.md)
+- [Warp Terminal Setup](WARP.md)

--- a/v2/docs/ides/README.md
+++ b/v2/docs/ides/README.md
@@ -1,0 +1,298 @@
+# IDE Integration Guide
+
+Connect to your Sindri development environment using your favorite IDE or editor. Whether you prefer a full-featured IDE, a modern lightweight editor, or a powerful terminal, we've got you covered.
+
+## Quick Start
+
+Sindri supports three primary connection methods:
+
+- **Dev Containers (DevPod):** Full IDE integration with containerized environments
+- **Remote SSH (Fly.io VM):** Connect to cloud-hosted development VMs
+- **Docker (Local):** Develop in local Docker containers
+
+Choose your IDE below to get started with step-by-step setup instructions.
+
+## Supported IDEs and Editors
+
+### Visual Studio Code
+
+**Best for:** Modern web development, cross-platform teams, devcontainer workflows
+
+VS Code offers industry-leading remote development with the Remote-SSH and Dev Containers extensions, making it the most mature option for all Sindri connection methods.
+
+**Key Features:**
+
+- Native devcontainer.json support
+- Seamless SSH remote development
+- Extensive extension ecosystem
+- Free and open-source
+
+[**→ VS Code Setup Guide**](VSCODE.md)
+
+---
+
+### JetBrains IntelliJ IDEA
+
+**Best for:** Java/Kotlin development, JVM ecosystems, enterprise projects
+
+IntelliJ IDEA provides powerful remote development through JetBrains Gateway with excellent dev container support via the Dev Containers plugin.
+
+**Key Features:**
+
+- JetBrains Gateway for SSH connections
+- Dev Containers plugin for devcontainer.json
+- Advanced Java/JVM tooling
+- Professional refactoring capabilities
+
+[**→ IntelliJ IDEA Setup Guide**](INTELLIJ.md)
+
+---
+
+### Zed Editor
+
+**Best for:** Performance-focused developers, minimalists, SSH-based workflows
+
+Zed is a modern, high-performance editor with native SSH remote development running at 120 FPS. Dev container support is in development.
+
+**Key Features:**
+
+- Ultra-fast SSH remote development
+- Native Rust performance
+- Auto-reconnection on network drops
+- Modern collaborative features
+
+[**→ Zed Editor Setup Guide**](ZED.md)
+
+---
+
+### Eclipse IDE
+
+**Best for:** Java/JEE development, legacy projects, educational settings
+
+Eclipse offers remote development through Remote System Explorer (RSE) and Docker Tools plugin, suitable for traditional enterprise Java development.
+
+**Key Features:**
+
+- Remote System Explorer for SSH
+- Docker Tools for container management
+- Mature plugin ecosystem
+- Strong Java/JEE support
+
+[**→ Eclipse Setup Guide**](ECLIPSE.md)
+
+---
+
+### Warp Terminal
+
+**Best for:** Terminal-focused developers, DevOps workflows, Docker power users
+
+Warp is a modern terminal with AI assistance and Docker integration. While not a full IDE, it excels at terminal-based development workflows.
+
+**Key Features:**
+
+- AI-powered command search
+- Docker Desktop integration (macOS)
+- Workflows for common operations
+- Modern terminal features (blocks, sharing)
+
+[**→ Warp Terminal Setup Guide**](WARP.md)
+
+---
+
+## Feature Comparison
+
+| Feature                | VS Code         | IntelliJ             | Zed               | Eclipse         | Warp                  |
+| ---------------------- | --------------- | -------------------- | ----------------- | --------------- | --------------------- |
+| **Dev Containers**     | ✅ Native       | ✅ Plugin            | 🚧 In Development | ❌ Manual Setup | ❌ No                 |
+| **Remote SSH**         | ✅ Excellent    | ✅ Gateway           | ✅ Native         | ✅ RSE Plugin   | ✅ Standard SSH       |
+| **Docker Integration** | ✅ Excellent    | ✅ Good              | ⚠️ Via SSH        | ✅ Plugin       | ✅ Extension (macOS)  |
+| **Language Servers**   | ✅ Full Support | ✅ Full Support      | ✅ Remote         | ✅ Full Support | ❌ N/A                |
+| **Free/Open Source**   | ✅ Yes          | ⚠️ Community Edition | ✅ Yes            | ✅ Yes          | ⚠️ Freemium           |
+| **Platform Support**   | All             | All                  | All               | All             | macOS, Linux, Windows |
+| **Performance**        | Good            | Good                 | Excellent         | Moderate        | Excellent             |
+| **Learning Curve**     | Low             | Medium               | Low               | Medium          | Low                   |
+
+**Legend:**
+
+- ✅ Full support
+- ⚠️ Limited or partial support
+- 🚧 In development
+- ❌ Not supported
+
+## Choosing the Right IDE
+
+### For Web Development
+
+**Recommended:** VS Code
+
+VS Code has the best support for modern web frameworks, TypeScript, and JavaScript ecosystems, with excellent dev container integration.
+
+### For Java/JVM Development
+
+**Recommended:** IntelliJ IDEA or Eclipse
+
+Both offer mature Java tooling. IntelliJ provides a more modern experience, while Eclipse is well-suited for traditional enterprise projects.
+
+### For Performance-Critical SSH Workflows
+
+**Recommended:** Zed Editor
+
+Zed's 120 FPS UI and native SSH support make it the fastest option for remote development over SSH.
+
+### For Terminal-Centric Workflows
+
+**Recommended:** Warp + VS Code
+
+Use Warp for terminal operations and Docker management, combined with VS Code for editing and IDE features.
+
+### For Cross-Platform Teams
+
+**Recommended:** VS Code or IntelliJ IDEA
+
+Both work consistently across macOS, Windows, and Linux, with strong remote development support on all platforms.
+
+## Connection Method Details
+
+### Dev Containers (DevPod)
+
+Dev containers provide the most integrated experience, where your IDE runs locally but all tools, dependencies, and execution happen inside a Docker container.
+
+**Supported IDEs:**
+
+- ✅ VS Code (Native)
+- ✅ IntelliJ IDEA (Dev Containers Plugin)
+- 🚧 Zed (In Development)
+- ⚠️ Eclipse (Manual Setup)
+- ❌ Warp (Not Applicable)
+
+**When to use:**
+
+- You want reproducible development environments
+- Your team uses the devcontainer.json standard
+- You're developing containerized applications
+- You need isolation between projects
+
+### Remote SSH (Fly.io VM)
+
+SSH remote development connects your local IDE to a remote server running on Fly.io, with all processing happening on the remote machine.
+
+**Supported IDEs:**
+
+- ✅ VS Code (Remote-SSH Extension)
+- ✅ IntelliJ IDEA (JetBrains Gateway)
+- ✅ Zed (Native SSH Support)
+- ✅ Eclipse (Remote System Explorer)
+- ✅ Warp (Standard SSH)
+
+**When to use:**
+
+- You need more computing power than your local machine
+- Your team shares cloud-based development environments
+- You want to develop from multiple devices
+- You're working with large datasets or intensive workloads
+
+### Docker (Local)
+
+Local Docker development runs containers on your machine, with your IDE connecting to or managing those containers.
+
+**Supported IDEs:**
+
+- ✅ VS Code (Dev Containers + Docker Extension)
+- ✅ IntelliJ IDEA (Docker Plugin + Dev Containers)
+- ⚠️ Zed (SSH to Container Workaround)
+- ✅ Eclipse (Docker Tools Plugin)
+- ✅ Warp (Docker Extension - macOS only)
+
+**When to use:**
+
+- You're developing locally with Docker Desktop
+- You need quick iteration cycles
+- You want offline development capability
+- You're testing containerized applications
+
+## Prerequisites
+
+### All Methods
+
+- Git installed and configured
+- SSH key-based authentication set up
+- Basic understanding of your chosen IDE
+
+### Dev Containers
+
+- Docker Desktop or Docker CLI
+- Dev container support in your IDE (see guides)
+
+### Remote SSH
+
+- SSH client configured
+- Access to Fly.io VM or remote server
+- Stable internet connection (20+ Mbps, <200ms latency recommended)
+
+### Docker Local
+
+- Docker Desktop or Docker daemon running
+- Sufficient local system resources (varies by IDE)
+
+## Getting Started
+
+1. **Choose your IDE** from the list above
+2. **Review the feature comparison** to ensure it meets your needs
+3. **Follow the setup guide** for your chosen IDE
+4. **Configure your connection** (Dev Container, SSH, or Docker)
+5. **Start developing** in your Sindri environment
+
+## Common Issues
+
+### Can't Connect to Remote Server
+
+- Verify SSH configuration in `~/.ssh/config`
+- Check SSH key permissions (`chmod 600 ~/.ssh/id_ed25519`)
+- Ensure remote server is running and accessible
+
+### Dev Container Won't Start
+
+- Verify Docker is running: `docker ps`
+- Check devcontainer.json syntax
+- Review Docker logs: `docker logs container_name`
+
+### Performance Issues
+
+- Check network latency and bandwidth
+- Increase IDE heap size if needed
+- Exclude large directories from indexing
+- Use pre-built images to reduce build time
+
+### Extension/Plugin Issues
+
+- Reinstall extensions in remote environment
+- Check IDE version compatibility
+- Review extension logs for errors
+
+## Additional Resources
+
+- [Sindri Architecture](../ARCHITECTURE.md)
+- [Sindri Deployment Guide](../DEPLOYMENT.md)
+- [Sindri Configuration](../CONFIGURATION.md)
+- [Troubleshooting Guide](../TROUBLESHOOTING.md)
+
+## Contributing
+
+Found an issue with these guides or want to add support for another IDE? Contributions are welcome:
+
+1. Open an issue describing the problem or feature request
+2. Submit a pull request with your improvements
+3. Share your IDE setup tips with the community
+
+## Need Help?
+
+If you're having trouble connecting your IDE to Sindri:
+
+1. Check the [Troubleshooting Guide](../TROUBLESHOOTING.md)
+2. Review your IDE's specific setup guide above
+3. Check IDE-specific logs and error messages
+4. Open an issue with details about your setup and error
+
+---
+
+**Happy coding with Sindri!**

--- a/v2/docs/ides/VSCODE.md
+++ b/v2/docs/ides/VSCODE.md
@@ -1,0 +1,192 @@
+# Visual Studio Code - Remote Development Setup
+
+Visual Studio Code offers industry-leading remote development capabilities through extensions, making it an excellent choice for connecting to Sindri environments.
+
+## Prerequisites
+
+- [Visual Studio Code](https://code.visualstudio.com/) (latest stable version)
+- Install the following extensions:
+  - [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)
+  - [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+  - [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) (optional, for Docker management)
+
+## Connection Methods
+
+### Method 1: Dev Containers (DevPod)
+
+Dev Containers provide the best developer experience for containerized environments with full IDE integration.
+
+**Setup Steps:**
+
+1. **Install the Dev Containers extension** from the VS Code marketplace
+2. **Open your project in a container:**
+   - Open Command Palette (`Cmd/Ctrl+Shift+P`)
+   - Select "Dev Containers: Open Folder in Container"
+   - Choose your Sindri project directory
+3. **Configure devcontainer.json** (if not already present):
+   ```json
+   {
+     "name": "Sindri Development",
+     "image": "your-sindri-image:latest",
+     "customizations": {
+       "vscode": {
+         "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+       }
+     },
+     "forwardPorts": [3000, 8080],
+     "remoteUser": "developer"
+   }
+   ```
+
+**Best Practices:**
+
+- Use [Features](https://code.visualstudio.com/docs/devcontainers/containers#_dev-container-features) to modularize tool installation
+- Leverage volume mounts for persistent user data
+- Configure port forwarding for all services you'll access
+- Use pre-built images to reduce startup time
+
+### Method 2: Remote SSH (Fly.io VM)
+
+Connect to remote VMs running on Fly.io using SSH.
+
+**Setup Steps:**
+
+1. **Configure SSH access** to your Fly.io VM:
+
+   ```bash
+   # Add to ~/.ssh/config
+   Host sindri-flyio
+     HostName your-app.fly.dev
+     User developer
+     Port 22
+     IdentityFile ~/.ssh/your_key
+   ```
+
+2. **Connect via VS Code:**
+   - Open Command Palette (`Cmd/Ctrl+Shift+P`)
+   - Select "Remote-SSH: Connect to Host"
+   - Choose "sindri-flyio" from the list
+   - VS Code will install the VS Code Server on the remote machine
+
+3. **Open your workspace:**
+   - File > Open Folder
+   - Navigate to `/alt/home/developer/workspace`
+
+**Best Practices:**
+
+- Enable SSH agent for key-based authentication
+- Use SSH ControlMaster for faster reconnection
+- Configure bandwidth and latency-appropriate settings
+- Set up automatic reconnection in case of network drops
+
+### Method 3: Docker (Local Development)
+
+Connect directly to local Docker containers for development.
+
+**Setup Steps:**
+
+1. **Using Docker Desktop + Dev Containers:**
+   - Ensure Docker Desktop is running
+   - Follow the Dev Containers method above
+
+2. **Using Remote - Containers for existing containers:**
+   - Open Command Palette
+   - Select "Dev Containers: Attach to Running Container"
+   - Choose your Sindri container from the list
+
+**Best Practices:**
+
+- Use docker-compose.yml for multi-service applications
+- Mount your source code as a volume for live editing
+- Configure resource limits appropriate to your machine
+- Use .dockerignore to exclude unnecessary files
+
+## Advanced Configuration
+
+### Remote Development on Remote Docker Host
+
+For connecting to Docker running on a remote machine:
+
+1. **Set up Docker context:**
+
+   ```bash
+   docker context create remote-sindri --docker "host=ssh://user@remote-host"
+   docker context use remote-sindri
+   ```
+
+2. **Configure VS Code settings:**
+   ```json
+   {
+     "dev.containers.dockerPath": "docker",
+     "dev.containers.dockerComposePath": "docker-compose"
+   }
+   ```
+
+### Custom Instructions for AI Copilot
+
+Enhance GitHub Copilot's context awareness in dev containers:
+
+```json
+{
+  "github.copilot.advanced": {
+    "debug.overrideEngine": "gpt-4",
+    "devcontainer.environment": {
+      "description": "Sindri development environment with mise and Claude Code"
+    }
+  }
+}
+```
+
+### Volume Management
+
+Persist user profile and settings across container rebuilds:
+
+```json
+{
+  "mounts": [
+    "source=vscode-server,target=/home/developer/.vscode-server,type=volume",
+    "source=sindri-home,target=/alt/home/developer,type=volume"
+  ]
+}
+```
+
+## Troubleshooting
+
+### Connection Issues
+
+- **Server installation fails:** Check SSH permissions and ensure you have write access to `~/.vscode-server`
+- **Port forwarding not working:** Verify firewall rules and ensure ports are exposed in your container/VM
+- **Extensions not loading:** Reinstall extensions in the remote environment using the Extensions panel
+
+### Performance Optimization
+
+- **Slow file watching:** Add workspace to watcherExclude settings
+- **High CPU usage:** Disable unnecessary extensions in remote environment
+- **Slow initial connection:** Use pre-built images with VS Code Server pre-installed
+
+## Resources
+
+- [Developing inside a Container - VS Code Docs](https://code.visualstudio.com/docs/devcontainers/containers)
+- [Dev Containers Tips and Tricks](https://code.visualstudio.com/docs/devcontainers/tips-and-tricks)
+- [Remote Development using SSH](https://code.visualstudio.com/docs/remote/ssh)
+- [Develop on a remote Docker host](https://code.visualstudio.com/remote/advancedcontainers/develop-remote-host)
+- [Ultimate Guide to Dev Containers - Daytona](https://www.daytona.io/dotfiles/ultimate-guide-to-dev-containers)
+- [Mastering Dev Containers in VS Code - Rost Glukhov](https://www.glukhov.org/post/2025/10/vs-code-dev-containers/)
+
+## Next Steps
+
+After connecting to your Sindri environment:
+
+1. Install project-specific extensions
+2. Configure integrated terminal settings
+3. Set up debugging configurations
+4. Explore workspace trust settings for security
+
+---
+
+**Related Documentation:**
+
+- [IntelliJ IDEA Setup](INTELLIJ.md)
+- [Zed Editor Setup](ZED.md)
+- [Eclipse Setup](ECLIPSE.md)
+- [Warp Terminal Setup](WARP.md)

--- a/v2/docs/ides/WARP.md
+++ b/v2/docs/ides/WARP.md
@@ -1,0 +1,398 @@
+# Warp Terminal - Remote Development Setup
+
+Warp is a modern, Rust-based terminal with AI assistance and Docker integration. While not a full IDE, Warp provides excellent terminal-based development workflows for Sindri environments.
+
+## Prerequisites
+
+- [Warp Terminal](https://www.warp.dev/) (latest version)
+- macOS, Linux, or Windows (with WSL2)
+- Docker Desktop (for Docker integration features)
+- SSH client configured
+
+## Connection Methods
+
+### Method 1: SSH to Remote VM (Fly.io)
+
+Warp provides a standard SSH experience with modern terminal features.
+
+**Setup Steps:**
+
+1. **Configure SSH in ~/.ssh/config:**
+
+   ```bash
+   Host sindri-flyio
+     HostName your-app.fly.dev
+     User developer
+     Port 22
+     IdentityFile ~/.ssh/your_key
+     ServerAliveInterval 60
+     ServerAliveCountMax 3
+   ```
+
+2. **Connect via Warp:**
+   - Open Warp terminal
+   - Run: `ssh sindri-flyio`
+   - Or use full connection string: `ssh developer@your-app.fly.dev`
+
+3. **Navigate to workspace:**
+   ```bash
+   cd /alt/home/developer/workspace
+   ```
+
+**Warp-Specific Features:**
+
+- **AI Command Search:** Use Cmd+P to search for commands with natural language
+- **Blocks:** Each command output is a block you can select, copy, or share
+- **Workflows:** Save commonly used command sequences
+- **Command History:** Smart search across all command history
+
+**Best Practices:**
+
+- Use SSH key-based authentication
+- Configure SSH multiplexing for faster reconnection
+- Save frequently used SSH commands as Warp workflows
+- Use Warp's AI to discover new commands and tools
+
+### Method 2: Docker Integration (Local Containers)
+
+Warp's Docker extension simplifies container access on macOS.
+
+**Setup Steps:**
+
+1. **Install Warp Docker Extension (macOS only):**
+   - Visit [Docker Hub - Warp Extension](https://hub.docker.com/extensions/warpdotdev/warp)
+   - Install via Docker Desktop Extensions
+   - Or install from Warp's integrations panel
+
+2. **Access containers via Warp:**
+   - Extension lists all running Docker containers
+   - Click to open container in Warpified subshell
+   - No need to manually type `docker exec` or container IDs
+
+3. **Manual container access (all platforms):**
+
+   ```bash
+   # List running containers
+   docker ps
+
+   # Execute shell in container
+   docker exec -it container_name bash
+
+   # Or for Sindri containers
+   docker exec -it sindri-dev bash
+   ```
+
+**Docker Extension Features (macOS only):**
+
+- One-click container access
+- Automatic container ID completion
+- Quick container switching
+- Warp features work inside container shells
+
+**Best Practices:**
+
+- Use named containers for easier identification
+- Leverage Warp's command completion inside containers
+- Create workflows for common container commands
+- Use Warp AI to learn Docker commands
+
+### Method 3: SSH to Docker Container (DevPod Workaround)
+
+Since Warp doesn't have native devcontainer support, use SSH to access containers.
+
+**Setup Steps:**
+
+1. **Create Dockerfile with SSH server:**
+
+   ```dockerfile
+   FROM your-sindri-image:latest
+
+   # Install OpenSSH server
+   RUN apt-get update && apt-get install -y openssh-server
+
+   # Configure SSH
+   RUN mkdir /var/run/sshd
+   RUN echo 'developer:password' | chpasswd
+
+   # Expose SSH port
+   EXPOSE 22
+
+   CMD ["/usr/sbin/sshd", "-D"]
+   ```
+
+2. **Run container with SSH:**
+
+   ```bash
+   docker run -d -p 2222:22 --name sindri-ssh your-sindri-image:latest
+   ```
+
+3. **Configure SSH connection:**
+
+   ```bash
+   # Add to ~/.ssh/config
+   Host sindri-container
+     HostName localhost
+     User developer
+     Port 2222
+   ```
+
+4. **Connect via Warp:**
+   ```bash
+   ssh sindri-container
+   ```
+
+**Limitations:**
+
+- Not native devcontainer support
+- Manual SSH server setup required
+- Additional container complexity
+
+## Warp Features for Remote Development
+
+### Workflows
+
+Save common command sequences for quick access.
+
+**Create a workflow:**
+
+1. Open Warp Settings > Workflows
+2. Click "New Workflow"
+3. Example workflow for Sindri:
+   ```yaml
+   name: "Connect to Sindri Fly.io"
+   command: "ssh sindri-flyio && cd /alt/home/developer/workspace"
+   ```
+
+**Access workflows:**
+
+- Cmd+Shift+R to open workflows panel
+- Search and execute saved workflows
+
+### AI Command Search
+
+Use natural language to find commands.
+
+**Examples:**
+
+- "How do I check disk usage" → `df -h`
+- "List files by size" → `ls -lhS`
+- "Find large files" → `find . -type f -size +100M`
+
+**Access AI:**
+
+- Cmd+P or click sparkle icon
+- Type natural language query
+- Execute suggested command
+
+### Blocks
+
+Each command and its output is a block you can manipulate.
+
+**Block features:**
+
+- Click to select entire block
+- Cmd+C to copy block content
+- Share blocks with team members
+- Navigate between blocks with keyboard
+
+### Command History
+
+Smart search across all command history.
+
+**Access:**
+
+- Cmd+R for history search
+- Type to filter commands
+- Arrow keys to navigate
+- Enter to execute
+
+## Advanced Configuration
+
+### SSH Connection Optimization
+
+**Multiplexing for faster reconnection:**
+
+```bash
+# Add to ~/.ssh/config
+Host *
+  ControlMaster auto
+  ControlPath ~/.ssh/control-%r@%h:%p
+  ControlPersist 10m
+```
+
+**Connection keepalive:**
+
+```bash
+# Add to ~/.ssh/config
+Host sindri-flyio
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+  TCPKeepAlive yes
+```
+
+### Custom SSH Scripts
+
+Create shell scripts for common operations:
+
+```bash
+#!/bin/bash
+# ~/bin/sindri-connect
+
+ssh sindri-flyio << 'EOF'
+  cd /alt/home/developer/workspace
+  mise install
+  exec $SHELL
+EOF
+```
+
+Make executable and use:
+
+```bash
+chmod +x ~/bin/sindri-connect
+~/bin/sindri-connect
+```
+
+### Warp Drive (Shared Context)
+
+Share terminal sessions with team members:
+
+1. Click "Share" button in Warp
+2. Select blocks to share
+3. Generate shareable link
+4. Team members can view and copy commands
+
+## Docker-Specific Features
+
+### Container Management Commands
+
+**Quick reference for Warp:**
+
+```bash
+# List containers
+docker ps -a
+
+# Start/stop containers
+docker start sindri-dev
+docker stop sindri-dev
+
+# View logs
+docker logs -f sindri-dev
+
+# Execute commands
+docker exec -it sindri-dev bash
+
+# Remove containers
+docker rm sindri-dev
+
+# View container resource usage
+docker stats sindri-dev
+```
+
+### Warp AI for Docker
+
+Use Warp AI to learn Docker commands:
+
+- "How do I see running containers" → `docker ps`
+- "How do I enter a container" → `docker exec -it container_name bash`
+- "How do I view container logs" → `docker logs container_name`
+
+## Limitations
+
+### No Native Remote Development Features
+
+Warp is a terminal, not an IDE:
+
+- No language server support
+- No integrated file browser
+- No code completion (beyond shell completion)
+- No debugging capabilities
+- Limited devcontainer support
+
+### Workarounds
+
+**For full remote development experience, combine Warp with:**
+
+- **VS Code:** Use Warp for terminal, VS Code for editing
+- **tmux/screen:** Persistent sessions on remote servers
+- **vim/neovim:** Terminal-based code editing
+- **Language-specific REPLs:** Interactive development
+
+### macOS-Only Features
+
+Some features only work on macOS:
+
+- Docker Desktop extension
+- Native macOS integration
+- Some performance optimizations
+
+## Troubleshooting
+
+### SSH Connection Issues
+
+- **"Connection refused":** Verify SSH server is running
+- **"Permission denied":** Check SSH key configuration
+- **Timeout errors:** Check network and firewall settings
+
+### Docker Integration Issues
+
+- **Extension not available:** Ensure you're on macOS with Docker Desktop
+- **Can't connect to container:** Verify container is running with `docker ps`
+- **Permission errors:** Add user to docker group (Linux)
+
+### Performance Issues
+
+- **Slow rendering:** Check GPU acceleration in Warp settings
+- **High memory usage:** Restart Warp or limit scroll buffer
+- **Laggy SSH sessions:** Check network latency and bandwidth
+
+## Resources
+
+- [Warp Terminal Documentation](https://docs.warp.dev/)
+- [Warp Docker Extension](https://hub.docker.com/extensions/warpdotdev/warp)
+- [SSH in Docker Container - Warp Guide](https://www.warp.dev/terminus/ssh-docker-container)
+- [Warp Integrations and Plugins](https://docs.warp.dev/terminal/integrations-and-plugins)
+- [Remote connection management discussion](https://github.com/warpdotdev/warp/discussions/442)
+
+## Recommended Workflows
+
+### Daily Development
+
+1. Use Warp for terminal operations and SSH connections
+2. Use VS Code or IntelliJ for code editing and IDE features
+3. Use Warp's AI for discovering commands
+4. Save common operations as Warp workflows
+
+### Container Development
+
+1. Use Docker Desktop for container management
+2. Use Warp Docker extension for quick container access (macOS)
+3. Use `docker exec` commands for container interaction
+4. Combine with IDE remote features for full development experience
+
+### Remote Server Development
+
+1. Configure SSH connections in ~/.ssh/config
+2. Use Warp for all terminal operations
+3. Use tmux/screen for persistent sessions
+4. Combine with VS Code Remote-SSH for editing
+
+## Next Steps
+
+After setting up Warp for Sindri development:
+
+1. Configure SSH keys for all remote connections
+2. Install useful terminal tools (tmux, vim, fzf)
+3. Create workflows for common operations
+4. Explore Warp AI for learning new commands
+5. Consider combining Warp with a full-featured IDE
+
+---
+
+**Related Documentation:**
+
+- [VS Code Setup](VSCODE.md) - For full IDE integration
+- [IntelliJ IDEA Setup](INTELLIJ.md) - For JetBrains development
+- [Zed Editor Setup](ZED.md) - For modern editing
+- [Eclipse Setup](ECLIPSE.md) - For Java development
+
+**Note:** Warp is excellent for terminal operations but should be combined with a full IDE (VS Code, IntelliJ, etc.) for comprehensive remote development capabilities.

--- a/v2/docs/ides/ZED.md
+++ b/v2/docs/ides/ZED.md
@@ -1,0 +1,267 @@
+# Zed Editor - Remote Development Setup
+
+Zed is a modern, high-performance code editor with built-in SSH remote development capabilities. While dev container support is still evolving, Zed offers excellent performance and seamless remote editing over SSH.
+
+## Prerequisites
+
+- [Zed Editor](https://zed.dev/) v0.159 or later
+- SSH access configured to remote servers
+- Basic understanding of SSH key-based authentication
+
+## Connection Methods
+
+### Method 1: SSH Remote Development (Fly.io VM)
+
+Zed's native remote development runs the UI locally at 120 FPS while language servers, tasks, and terminals run on the remote server.
+
+**Setup Steps:**
+
+1. **Configure SSH access:**
+
+   ```bash
+   # Add to ~/.ssh/config
+   Host sindri-flyio
+     HostName your-app.fly.dev
+     User developer
+     Port 22
+     IdentityFile ~/.ssh/your_key
+     ServerAliveInterval 60
+     ServerAliveCountMax 3
+   ```
+
+2. **Connect from Zed:**
+   - **Method A - Command Palette:**
+     - Open Command Palette (`Cmd/Ctrl+Shift+P`)
+     - Type "remote" and select "Projects: Open Remote"
+     - Enter SSH connection string: `ssh://developer@your-app.fly.dev:22/alt/home/developer/workspace`
+
+   - **Method B - Terminal Command:**
+     ```bash
+     zed ssh://developer@your-app.fly.dev:22/alt/home/developer/workspace
+     ```
+
+3. **First connection:**
+   - Zed downloads and installs headless server on remote machine
+   - Connection establishes automatically
+   - Your project opens in Zed UI
+
+**Architecture:**
+
+- **Local:** Zed UI running at 120 FPS
+- **Remote:** Headless Zed server, language servers, terminals, tasks
+- **Communication:** Secure SSH tunnel
+- **Resilience:** Language servers keep running if connection drops; Zed reconnects automatically
+
+**Best Practices:**
+
+- Use SSH key-based authentication (required)
+- Configure SSH keepalive to maintain connection stability
+- Ensure stable network connection for best experience
+- Close remote sessions when finished to free server resources
+
+### Method 2: Docker via SSH (Workaround for DevPod/Containers)
+
+Zed does not natively support dev containers yet, but you can use SSH to connect to containers running SSH servers.
+
+**Setup Steps:**
+
+1. **Create Dockerfile with SSH server:**
+
+   ```dockerfile
+   FROM your-sindri-image:latest
+
+   # Install OpenSSH server
+   RUN apt-get update && apt-get install -y openssh-server
+
+   # Configure SSH
+   RUN mkdir /var/run/sshd
+   RUN echo 'developer:password' | chpasswd
+   RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+   # SSH login fix for SSH clients
+   RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+   EXPOSE 22
+
+   CMD ["/usr/sbin/sshd", "-D"]
+   ```
+
+2. **Run container with SSH:**
+
+   ```bash
+   docker run -d -p 2222:22 --name sindri-dev your-sindri-image:latest
+   ```
+
+3. **Configure SSH connection:**
+
+   ```bash
+   # Add to ~/.ssh/config
+   Host sindri-container
+     HostName localhost
+     User developer
+     Port 2222
+   ```
+
+4. **Connect via Zed:**
+   ```bash
+   zed ssh://developer@localhost:2222/workspace
+   ```
+
+**Limitations:**
+
+- Not true dev container support
+- Requires manual SSH server setup in container
+- Extensions not managed separately for containers
+- Workaround until native dev container support arrives
+
+**Best Practices:**
+
+- Use this only as a temporary workaround
+- Consider VS Code or IntelliJ for native dev container support
+- Monitor [Zed dev containers roadmap](https://github.com/zed-industries/zed/issues/5347) for updates
+
+### Method 3: Local Docker (File Editing Only)
+
+For local Docker containers, you can mount volumes and edit files directly.
+
+**Setup Steps:**
+
+1. **Mount project directory as volume:**
+
+   ```bash
+   docker run -v $(pwd):/workspace your-sindri-image:latest
+   ```
+
+2. **Edit files locally with Zed:**
+
+   ```bash
+   zed /path/to/mounted/project
+   ```
+
+3. **Execute commands in container:**
+   ```bash
+   docker exec -it container_name bash
+   ```
+
+**Limitations:**
+
+- No integrated terminal in container
+- No language server running in container context
+- Manual command execution required
+- Not a true remote development experience
+
+## Advanced Configuration
+
+### SSH Connection Optimization
+
+**Multiplexing for faster reconnection:**
+
+```bash
+# Add to ~/.ssh/config
+Host *
+  ControlMaster auto
+  ControlPath ~/.ssh/control-%r@%h:%p
+  ControlPersist 10m
+```
+
+**Connection keepalive:**
+
+```bash
+# Add to ~/.ssh/config
+Host sindri-flyio
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+  TCPKeepAlive yes
+```
+
+### SSH Key Setup
+
+**Generate SSH key:**
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+**Copy to remote server:**
+
+```bash
+ssh-copy-id -i ~/.ssh/id_ed25519.pub developer@your-app.fly.dev
+```
+
+**Add to SSH agent:**
+
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+## Remote Development Features
+
+### What Works Over SSH
+
+- **Language servers:** Run on remote server, full IntelliSense
+- **Terminals:** Execute commands on remote server
+- **Tasks:** Build and run tasks on remote server
+- **File operations:** Full read/write access to remote files
+- **Auto-reconnection:** Seamless reconnection after network interruptions
+
+### Current Limitations
+
+- **No native dev container support** (as of v0.159)
+- **Extensions not container-aware** (when using SSH-to-container workaround)
+- **No devcontainer.json parsing** (use SSH configuration instead)
+
+## Troubleshooting
+
+### Connection Issues
+
+- **"Connection refused":** Verify SSH server is running on remote host
+- **"Permission denied":** Check SSH key is added to authorized_keys on remote
+- **"Headless server install fails":** Ensure write permissions in remote home directory
+- **Connection drops frequently:** Configure SSH keepalive settings
+
+### Performance Issues
+
+- **Laggy UI:** Check network latency (Zed performs best with <100ms latency)
+- **Slow file operations:** Verify network bandwidth is sufficient
+- **High CPU on remote:** Check language server processes, restart if needed
+
+### SSH Container Workaround Issues
+
+- **SSH server won't start:** Check container logs with `docker logs container_name`
+- **Can't connect to container:** Verify port mapping with `docker port container_name`
+- **Authentication fails:** Check user credentials in Dockerfile
+
+## Resources
+
+- [Zed Remote Development Documentation](https://zed.dev/docs/remote-development)
+- [SSH Remoting Launch Blog Post](https://zed.dev/blog/remote-development)
+- [Dev Containers in Zed (Experimental)](https://zed.dev/docs/dev-containers)
+- [Zed with devcontainer SSH Workaround](https://www.tay-tec.de/en/blog/zed-devcontainer-ssh/index.html)
+- [Remote Development Architecture](https://deepwiki.com/zed-industries/zed/5.1-remote-development-and-ssh)
+
+## Future Development
+
+Zed is actively working on native dev container support. Track progress:
+
+- [Dev Containers Support Issue](https://github.com/zed-industries/zed/issues/5347)
+- [Remote Development in Docker Discussion](https://github.com/zed-industries/zed/discussions/15787)
+
+## Next Steps
+
+After connecting to your Sindri environment:
+
+1. Configure language servers for your project
+2. Set up tasks for building and testing
+3. Customize keybindings for remote workflows
+4. Explore Zed's collaboration features
+5. Monitor Zed's dev container roadmap for updates
+
+---
+
+**Related Documentation:**
+
+- [VS Code Setup](VSCODE.md) - For full dev container support
+- [IntelliJ IDEA Setup](INTELLIJ.md) - For JetBrains dev container support
+- [Eclipse Setup](ECLIPSE.md)
+- [Warp Terminal Setup](WARP.md)


### PR DESCRIPTION
Restores docs/ides/* (Eclipse, IntelliJ, VSCode, Warp, Zed) under v2/docs/ides/. Companion to v3 PR #161. See pre-reorg-2026-04-25 tag for source.