### PR TITLE
ci(main): fix Validate YAML and Check Links failures

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -12,6 +12,15 @@ rules:
   comments:
     min-spaces-from-content: 1
 
+  # Allow inline-flow style with one space inside braces and after commas
+  # for compact matrix declarations like:
+  #   { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  commas:
+    max-spaces-after: -1 # allow column-aligned matrix entries
+
   document-start: disable
 
   truthy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ Create pull request on GitHub with:
    extension-manager install myext
    ```
 
-See: [Extension Authoring Guide](../v2/docs/EXTENSION_AUTHORING.md)
+See: [Extension Authoring Guide](https://github.com/pacphi/sindri/blob/v2/v2/docs/EXTENSION_AUTHORING.md) (on the v2 branch)
 
 ## Testing Guidelines
 
@@ -432,18 +432,20 @@ mod tests {
 
 ### V3 Extension Development
 
-V3 uses a different extension system from V2. Extensions are defined as YAML manifests with JSON Schema validation. For full details, see the [V3 Extension Guide](../v3/docs/EXTENSIONS.md).
+V3 uses a different extension system from V2. Extensions are defined as YAML manifests with JSON Schema validation. For full details, see the [V3 Extension Guide](https://github.com/pacphi/sindri/blob/v3/v3/docs/EXTENSIONS.md).
 
 ### V3 Documentation
 
 V3-specific documentation lives in `v3/docs/`. Key guides:
 
-- [CLI Reference](../v3/docs/CLI.md)
-- [Architecture](../v3/docs/ARCHITECTURE.md)
-- [Getting Started](../v3/docs/GETTING_STARTED.md)
-- [Extensions](../v3/docs/EXTENSIONS.md)
-- [Configuration](../v3/docs/CONFIGURATION.md)
-- [Schema Reference](../v3/docs/SCHEMA.md)
+All v3 docs live on the [v3 branch](https://github.com/pacphi/sindri/tree/v3/v3/docs):
+
+- [CLI Reference](https://github.com/pacphi/sindri/blob/v3/v3/docs/CLI.md)
+- [Architecture](https://github.com/pacphi/sindri/blob/v3/v3/docs/ARCHITECTURE.md)
+- [Getting Started](https://github.com/pacphi/sindri/blob/v3/v3/docs/GETTING_STARTED.md)
+- [Extensions](https://github.com/pacphi/sindri/blob/v3/v3/docs/EXTENSIONS.md)
+- [Configuration](https://github.com/pacphi/sindri/blob/v3/v3/docs/CONFIGURATION.md)
+- [Schema Reference](https://github.com/pacphi/sindri/blob/v3/v3/docs/SCHEMA.md)
 
 ---
 
@@ -636,7 +638,7 @@ All PRs must:
 
 ## Release Process
 
-Sindri uses **automated releases** triggered by Git tags. For detailed instructions, see [RELEASE.md](RELEASE.md).
+Sindri uses **automated releases** triggered by Git tags. For detailed instructions, see [RELEASE.md](docs/RELEASE.md).
 
 ### Quick Release
 
@@ -682,7 +684,7 @@ git commit -m "fix(docker): resolve volume permission issue"
 git commit -m "docs(readme): update quickstart guide"
 ```
 
-See [RELEASE.md](RELEASE.md) for complete release documentation.
+See [RELEASE.md](docs/RELEASE.md) for complete release documentation.
 
 ## Getting Help
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,9 +63,9 @@ When reporting a vulnerability, please provide:
 
 For deployment and usage security guidelines, see:
 
-- **[v2 Security Best Practices](../v2/docs/SECURITY.md)** - Docker/Bash platform security
-- **[v2 Security Audit Report](../v2/docs/security/SECURITY_AUDIT_REPORT.md)** - Comprehensive security audit findings
-- **[v2 Security Audit Addendum](../v2/docs/security/SECURITY_AUDIT_ADDENDUM.md)** - Additional security recommendations
+- **[v2 Security Best Practices](https://github.com/pacphi/sindri/blob/v2/v2/docs/SECURITY.md)** - Docker/Bash platform security
+- **[v2 Security Audit Report](https://github.com/pacphi/sindri/blob/v2/v2/docs/security/SECURITY_AUDIT_REPORT.md)** - Comprehensive security audit findings
+- **[v2 Security Audit Addendum](https://github.com/pacphi/sindri/blob/v2/v2/docs/security/SECURITY_AUDIT_ADDENDUM.md)** - Additional security recommendations
 
 ## Security Features
 

--- a/docs/CHANGELOG_MANAGEMENT.md
+++ b/docs/CHANGELOG_MANAGEMENT.md
@@ -448,7 +448,7 @@ Found 0 breaking change(s)
 - [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [Conventional Commits](https://www.conventionalcommits.org/)
 - [Release Process](RELEASE.md)
-- [Contributing Guide](CONTRIBUTING.md)
+- [Contributing Guide](../CONTRIBUTING.md)
 
 ---
 

--- a/docs/COMPARISON_GUIDE.md
+++ b/docs/COMPARISON_GUIDE.md
@@ -1,6 +1,6 @@
 # Sindri Version Comparison Guide
 
-> 📖 **Ready to migrate?** See the [Migration Guide](MIGRATION_GUIDE.md) for step-by-step instructions.
+> 📖 **Ready to migrate?** See the [Migration Guide](https://github.com/pacphi/sindri/blob/v3/v3/docs/migration/MIGRATION_GUIDE.md) for step-by-step instructions.
 
 **Version:** 2.1.0
 **Created:** 2026-01-24
@@ -960,7 +960,7 @@ Sindri V3 represents a fundamental modernization delivering:
 - **328 new features** across all categories
 - **Enhanced security** with CVE remediation and SLSA L3
 
-For detailed migration steps, see the companion [Migration Guide](MIGRATION_GUIDE.md).
+For detailed migration steps, see the companion [Migration Guide](https://github.com/pacphi/sindri/blob/v3/v3/docs/migration/MIGRATION_GUIDE.md).
 
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,7 +5,7 @@ This guide explains how to create and publish new releases for Sindri.
 > **📚 Related Documentation**:
 >
 > - [Changelog Management Guide](CHANGELOG_MANAGEMENT.md) - Detailed changelog structure and automation
-> - [Contributing Guide](CONTRIBUTING.md) - Development workflow and conventions
+> - [Contributing Guide](../CONTRIBUTING.md) - Development workflow and conventions
 > - [Version-Specific Changelogs](../CHANGELOG.md) - Navigate to v1, v2, or v3 changelogs
 
 ## Overview
@@ -542,7 +542,7 @@ There is no fixed schedule. Releases happen when:
 
 ## Questions?
 
-- Review [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow
+- Review [CONTRIBUTING.md](../CONTRIBUTING.md) for development workflow
 - Check [GitHub Issues](https://github.com/pacphi/sindri/issues) for known problems
 - Start a [Discussion](https://github.com/pacphi/sindri/discussions) for questions
 - Contact maintainers for release-specific questions


### PR DESCRIPTION
Fixes the two failing workflows on main after the reorg cutover:

- **Validate YAML**: relaxes `.yamllint.yml` to allow inline-flow matrix style with column-aligned commas (used in ci-v4, _ci-rust, _release-cargo-dist, release-v4).
- **Check Links**: rewrites broken refs in CONTRIBUTING.md / SECURITY.md / docs/CHANGELOG_MANAGEMENT.md / docs/COMPARISON_GUIDE.md / docs/RELEASE.md to use either repo-root paths (CONTRIBUTING moved out of docs/) or branch-qualified GitHub URLs (for files that now live only on v2/v3).