### PR TITLE
ci(main): make ci-v* workflows reusable so v* shims can call them

### DIFF
--- a/.github/workflows/ci-v1.yml
+++ b/.github/workflows/ci-v1.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches: [v1]
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -57,6 +57,7 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
 
 concurrency:
   group: ci-v2-${{ github.ref }}

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -27,6 +27,7 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
 
 concurrency:
   group: ci-v3-${{ github.ref }}

--- a/.github/workflows/ci-v4.yml
+++ b/.github/workflows/ci-v4.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches: [v4]
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_call:` to ci-v1/2/3/4 so per-branch shim workflows on each v* branch can reuse them. See companion PRs to v1/v2/v3/v4 that add the shim.