### PR TITLE
ci(v3): add shim to invoke centralized ci-v3.yml from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: "v3: CI (shim)"
+
+# This file exists ONLY so GitHub triggers the centralized ci-v3.yml
+# workflow that lives on the main branch. The actual CI logic is on main —
+# changes to it should be made there, not here.
+
+on:
+  push:
+    branches: [v3]
+  pull_request:
+    branches: [v3]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  ci:
+    name: CI
+    uses: pacphi/sindri/.github/workflows/ci-v3.yml@main
+    secrets: inherit


### PR DESCRIPTION
Shim that delegates push/PR-to-v3 events to main's reusable ci-v3.yml. CI logic stays on main; this is just the trigger anchor.