### PR TITLE
ci(v4): grant full permission set in shim so security-scan can run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,22 @@ on:
     branches: [v4]
   workflow_dispatch:
 
+# Permissions must be a SUPERSET of every nested permission the called
+# workflow (and its callees) requires. Reusable workflows cannot exceed
+# the caller's grant. Keep this list up to date when ci-v4.yml gains new
+# permissions.
 permissions:
-  contents: read
+  contents: write
   packages: write
   id-token: write
   attestations: write
   pull-requests: write
   issues: write
+  security-events: write
+  actions: read
+  checks: write
+  deployments: write
+  statuses: write
 
 jobs:
   ci:


### PR DESCRIPTION
Fixes startup_failure: 'security-scan is requesting security-events: write, but is only allowed security-events: none'. Adds the missing permissions to the shim. Reusable workflows can't request permissions exceeding the caller's grant, so the shim must declare every permission the callee chain needs.