### PR TITLE
fix(v4): partial clippy lint cleanup (sindri-core, sindri-policy, sindri-targets)

### DIFF
--- a/v4/crates/sindri-core/src/component.rs
+++ b/v4/crates/sindri-core/src/component.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use crate::version::VersionSpec;
 use crate::platform::Platform;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 /// ADR-002: The atomic unit of v4.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -18,7 +19,7 @@ impl ComponentId {
     pub fn parse(s: &str) -> Option<Self> {
         let (backend_str, rest) = s.split_once(':')?;
         let name = rest.split('@').next()?.to_string();
-        let backend = Backend::from_str(backend_str)?;
+        let backend = Backend::from_str(backend_str).ok()?;
         Some(ComponentId { backend, name })
     }
 
@@ -79,26 +80,31 @@ impl Backend {
         }
     }
 
-    pub fn from_str(s: &str) -> Option<Self> {
+}
+
+impl FromStr for Backend {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "mise" => Some(Backend::Mise),
-            "apt" => Some(Backend::Apt),
-            "dnf" => Some(Backend::Dnf),
-            "zypper" => Some(Backend::Zypper),
-            "pacman" => Some(Backend::Pacman),
-            "apk" => Some(Backend::Apk),
-            "brew" => Some(Backend::Brew),
-            "winget" => Some(Backend::Winget),
-            "scoop" => Some(Backend::Scoop),
-            "npm" => Some(Backend::Npm),
-            "pipx" => Some(Backend::Pipx),
-            "cargo" => Some(Backend::Cargo),
-            "go-install" => Some(Backend::GoInstall),
-            "binary" => Some(Backend::Binary),
-            "script" => Some(Backend::Script),
-            "sdkman" => Some(Backend::Sdkman),
-            "collection" => Some(Backend::Collection),
-            _ => None,
+            "mise" => Ok(Backend::Mise),
+            "apt" => Ok(Backend::Apt),
+            "dnf" => Ok(Backend::Dnf),
+            "zypper" => Ok(Backend::Zypper),
+            "pacman" => Ok(Backend::Pacman),
+            "apk" => Ok(Backend::Apk),
+            "brew" => Ok(Backend::Brew),
+            "winget" => Ok(Backend::Winget),
+            "scoop" => Ok(Backend::Scoop),
+            "npm" => Ok(Backend::Npm),
+            "pipx" => Ok(Backend::Pipx),
+            "cargo" => Ok(Backend::Cargo),
+            "go-install" => Ok(Backend::GoInstall),
+            "binary" => Ok(Backend::Binary),
+            "script" => Ok(Backend::Script),
+            "sdkman" => Ok(Backend::Sdkman),
+            "collection" => Ok(Backend::Collection),
+            _ => Err(()),
         }
     }
 }

--- a/v4/crates/sindri-core/src/platform.rs
+++ b/v4/crates/sindri-core/src/platform.rs
@@ -59,21 +59,10 @@ pub struct TargetProfile {
     pub capabilities: Capabilities,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct Capabilities {
     pub system_package_manager: Option<String>,
     pub has_docker: bool,
     pub has_sudo: bool,
     pub shell: Option<String>,
-}
-
-impl Default for Capabilities {
-    fn default() -> Self {
-        Self {
-            system_package_manager: None,
-            has_docker: false,
-            has_sudo: false,
-            shell: None,
-        }
-    }
 }

--- a/v4/crates/sindri-core/src/policy.rs
+++ b/v4/crates/sindri-core/src/policy.rs
@@ -2,18 +2,13 @@
 use serde::{Deserialize, Serialize};
 use schemars::JsonSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum PolicyPreset {
+    #[default]
     Default,
     Strict,
     Offline,
-}
-
-impl Default for PolicyPreset {
-    fn default() -> Self {
-        PolicyPreset::Default
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/v4/crates/sindri-core/src/version.rs
+++ b/v4/crates/sindri-core/src/version.rs
@@ -16,18 +16,13 @@ impl std::fmt::Display for Version {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum VersionSpec {
+    #[default]
     Latest,
     Exact(String),
     Range(String),
-}
-
-impl Default for VersionSpec {
-    fn default() -> Self {
-        VersionSpec::Latest
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/v4/crates/sindri-policy/src/check.rs
+++ b/v4/crates/sindri-policy/src/check.rs
@@ -37,16 +37,15 @@ pub fn check_license(license: &str, policy: &InstallPolicy) -> PolicyCheckResult
     }
 
     // Strict preset: only allow-listed licenses pass
-    if matches!(policy.preset, PolicyPreset::Strict) {
-        if !policy.allowed_licenses.is_empty()
-            && !policy.allowed_licenses.iter().any(|a| a == license)
-        {
-            return PolicyCheckResult::deny(
-                "ADM_LICENSE_DENIED",
-                &format!("License `{}` not in strict-mode allow list", license),
-                Some("Run `sindri policy allow-license <spdx>` to add it"),
-            );
-        }
+    if matches!(policy.preset, PolicyPreset::Strict)
+        && !policy.allowed_licenses.is_empty()
+        && !policy.allowed_licenses.iter().any(|a| a == license)
+    {
+        return PolicyCheckResult::deny(
+            "ADM_LICENSE_DENIED",
+            &format!("License `{}` not in strict-mode allow list", license),
+            Some("Run `sindri policy allow-license <spdx>` to add it"),
+        );
     }
 
     // Unknown license handling

--- a/v4/crates/sindri-policy/src/loader.rs
+++ b/v4/crates/sindri-policy/src/loader.rs
@@ -106,9 +106,7 @@ pub fn write_global_preset(preset: &PolicyPreset) -> Result<(), std::io::Error> 
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let yaml = serde_yaml::to_string(&policy).map_err(|e| {
-        std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-    })?;
+    let yaml = serde_yaml::to_string(&policy).map_err(|e| std::io::Error::other(e.to_string()))?;
     fs::write(&path, yaml)
 }
 

--- a/v4/crates/sindri-resolver/src/backend_choice.rs
+++ b/v4/crates/sindri-resolver/src/backend_choice.rs
@@ -1,6 +1,7 @@
 use sindri_core::component::Backend;
 use sindri_core::platform::{Os, Platform};
 use sindri_core::registry::ComponentEntry;
+use std::str::FromStr;
 
 /// Built-in backend preference chains per OS (ADR-009, ADR-010, Sprint 3)
 ///
@@ -95,7 +96,7 @@ impl BackendStr {
 impl std::str::FromStr for BackendStr {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if sindri_core::component::Backend::from_str(s).is_some() {
+        if sindri_core::component::Backend::from_str(s).is_ok() {
             Ok(BackendStr(s.to_string()))
         } else {
             Err(())

--- a/v4/crates/sindri-targets/src/auth.rs
+++ b/v4/crates/sindri-targets/src/auth.rs
@@ -5,7 +5,6 @@
 ///   `file:~/.token`      → read from file
 ///   `cli:gh`             → delegate to gh CLI
 ///   `plain:secret`       → inline string (warned on validate)
-use std::path::Path;
 use crate::error::TargetError;
 
 #[derive(Debug, Clone)]

--- a/v4/crates/sindri-targets/src/cloud.rs
+++ b/v4/crates/sindri-targets/src/cloud.rs
@@ -5,7 +5,6 @@
 /// are Sprint 10 hardening work.
 use std::path::Path;
 use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
-use crate::auth::AuthValue;
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
 

--- a/v4/crates/sindri-targets/src/local.rs
+++ b/v4/crates/sindri-targets/src/local.rs
@@ -1,11 +1,17 @@
 use std::path::Path;
-use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
+use sindri_core::platform::{Capabilities, Platform, TargetProfile};
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
 
 /// Local machine target — the implicit default (ADR-023)
 pub struct LocalTarget {
     name: String,
+}
+
+impl Default for LocalTarget {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LocalTarget {


### PR DESCRIPTION
First batch of clippy fixes, addressing 6 of the original 8 lint sites in 3 crates. Remaining ~20 lints tracked separately. v4 CI may stay red until full cleanup completes.