### PR TITLE
fix(ci): update deploy-provider action paths from examples/v2 to v2/examples

### DIFF
--- a/.github/actions/shared/deploy-provider/action.yml
+++ b/.github/actions/shared/deploy-provider/action.yml
@@ -57,25 +57,25 @@ runs:
           # Map provider + profile to example config
           case "${{ inputs.provider }}" in
             docker)
-              CONFIG="examples/v2/docker/${PROFILE}.sindri.yaml"
+              CONFIG="v2/examples/docker/${PROFILE}.sindri.yaml"
               ;;
             fly)
-              CONFIG="examples/v2/fly/${PROFILE}.sindri.yaml"
+              CONFIG="v2/examples/fly/${PROFILE}.sindri.yaml"
               ;;
             devpod-aws)
-              CONFIG="examples/v2/devpod/aws/${PROFILE}.sindri.yaml"
+              CONFIG="v2/examples/devpod/aws/${PROFILE}.sindri.yaml"
               ;;
             devpod-gcp)
-              CONFIG="examples/v2/devpod/gcp/${PROFILE}.sindri.yaml"
+              CONFIG="v2/examples/devpod/gcp/${PROFILE}.sindri.yaml"
               ;;
             devpod-azure)
-              CONFIG="examples/v2/devpod/azure/${PROFILE}.sindri.yaml"
+              CONFIG="v2/examples/devpod/azure/${PROFILE}.sindri.yaml"
               ;;
             devpod-do)
-              CONFIG="examples/v2/devpod/digitalocean/${PROFILE}.sindri.yaml"
+              CONFIG="v2/examples/devpod/digitalocean/${PROFILE}.sindri.yaml"
               ;;
             devpod-k8s|kubernetes)
-              CONFIG="examples/v2/devpod/kubernetes/${PROFILE}.sindri.yaml"
+              CONFIG="v2/examples/devpod/kubernetes/${PROFILE}.sindri.yaml"
               ;;
             *)
               echo "::error::Unknown provider: ${{ inputs.provider }}"
@@ -87,13 +87,13 @@ runs:
           if [[ ! -f "$CONFIG" ]]; then
             echo "::warning::Profile config $CONFIG not found, falling back to minimal"
             case "${{ inputs.provider }}" in
-              docker) CONFIG="examples/v2/docker/minimal.sindri.yaml" ;;
-              fly) CONFIG="examples/v2/fly/minimal.sindri.yaml" ;;
-              devpod-aws) CONFIG="examples/v2/devpod/aws/minimal.sindri.yaml" ;;
-              devpod-gcp) CONFIG="examples/v2/devpod/gcp/minimal.sindri.yaml" ;;
-              devpod-azure) CONFIG="examples/v2/devpod/azure/minimal.sindri.yaml" ;;
-              devpod-do) CONFIG="examples/v2/devpod/digitalocean/minimal.sindri.yaml" ;;
-              devpod-k8s|kubernetes) CONFIG="examples/v2/devpod/kubernetes/minimal.sindri.yaml" ;;
+              docker) CONFIG="v2/examples/docker/minimal.sindri.yaml" ;;
+              fly) CONFIG="v2/examples/fly/minimal.sindri.yaml" ;;
+              devpod-aws) CONFIG="v2/examples/devpod/aws/minimal.sindri.yaml" ;;
+              devpod-gcp) CONFIG="v2/examples/devpod/gcp/minimal.sindri.yaml" ;;
+              devpod-azure) CONFIG="v2/examples/devpod/azure/minimal.sindri.yaml" ;;
+              devpod-do) CONFIG="v2/examples/devpod/digitalocean/minimal.sindri.yaml" ;;
+              devpod-k8s|kubernetes) CONFIG="v2/examples/devpod/kubernetes/minimal.sindri.yaml" ;;
             esac
           fi
         fi


### PR DESCRIPTION
Continues v2 CI green-up. After PR #189 fixed the action-resolution path issue, the deploy-provider action itself now runs but hits `examples/v2/...` paths that no longer exist post-reorg. This PR translates those to `v2/examples/...`. The remaining `profiles/minimal.sindri.yaml` mismatch is tracked in issue #183.