### PR TITLE
fix(v4): resolve clippy warnings to unblock CI

### DIFF
--- a/v4/crates/sindri-backends/src/mise.rs
+++ b/v4/crates/sindri-backends/src/mise.rs
@@ -31,7 +31,7 @@ impl InstallBackend for MiseBackend {
     }
 
     fn is_installed(&self, comp: &ResolvedComponent) -> bool {
-        let tool = format!("{}@{}", comp.id.name, comp.version);
+        let _tool = format!("{}@{}", comp.id.name, comp.version);
         run_command("mise", &["which", &comp.id.name])
             .map(|(stdout, _)| !stdout.trim().is_empty())
             .unwrap_or(false)

--- a/v4/crates/sindri-backends/src/registry.rs
+++ b/v4/crates/sindri-backends/src/registry.rs
@@ -14,7 +14,7 @@ use crate::universal::{CargoBackend, GoInstallBackend, PipxBackend};
 use crate::winget::{ScoopBackend, WingetBackend};
 
 /// Look up the right backend implementation for a component
-pub fn backend_for(backend: &Backend, platform: &Platform) -> Option<Box<dyn InstallBackend>> {
+pub fn backend_for(backend: &Backend, _platform: &Platform) -> Option<Box<dyn InstallBackend>> {
     match backend {
         Backend::Mise => Some(Box::new(MiseBackend)),
         Backend::Apt => Some(Box::new(AptBackend)),

--- a/v4/crates/sindri-backends/src/script.rs
+++ b/v4/crates/sindri-backends/src/script.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::PathBuf;
 use sindri_core::component::Backend;
 use sindri_core::lockfile::ResolvedComponent;

--- a/v4/crates/sindri-backends/src/universal.rs
+++ b/v4/crates/sindri-backends/src/universal.rs
@@ -95,7 +95,7 @@ impl InstallBackend for GoInstallBackend {
 
     fn remove(&self, comp: &ResolvedComponent) -> Result<(), BackendError> {
         // go doesn't have a formal uninstall; remove from GOPATH/bin
-        let bin_name = comp.id.name.split('/').last().unwrap_or(&comp.id.name);
+        let bin_name = comp.id.name.split('/').next_back().unwrap_or(&comp.id.name);
         let gopath = std::env::var("GOPATH")
             .unwrap_or_else(|_| {
                 dirs_next::home_dir()
@@ -112,7 +112,7 @@ impl InstallBackend for GoInstallBackend {
     }
 
     fn is_installed(&self, comp: &ResolvedComponent) -> bool {
-        let bin_name = comp.id.name.split('/').last().unwrap_or(&comp.id.name);
+        let bin_name = comp.id.name.split('/').next_back().unwrap_or(&comp.id.name);
         crate::traits::binary_available(bin_name)
     }
 }

--- a/v4/crates/sindri-discovery/src/explain.rs
+++ b/v4/crates/sindri-discovery/src/explain.rs
@@ -49,7 +49,7 @@ pub fn render_explain(path: &[String]) -> String {
     let mut lines = Vec::new();
     for (i, node) in path.iter().enumerate() {
         if i == 0 {
-            lines.push(format!("{}", node));
+            lines.push(node.to_string());
         } else {
             lines.push(format!("{}└─ depends on: {}", "  ".repeat(i - 1), node));
         }

--- a/v4/crates/sindri-discovery/src/graph.rs
+++ b/v4/crates/sindri-discovery/src/graph.rs
@@ -40,7 +40,7 @@ fn render_node(
 
     if let Some(entry) = registry.get(addr) {
         let deps = &entry.depends_on;
-        for (i, dep) in deps.iter().enumerate() {
+        for dep in deps.iter() {
             render_node(dep, registry, depth + 1, visited, out);
         }
     }
@@ -90,8 +90,8 @@ fn render_mermaid_node(
 
     if let Some(entry) = registry.get(addr) {
         for dep in &entry.depends_on {
-            let safe_addr = addr.replace(':', "_").replace('-', "_");
-            let safe_dep = dep.replace(':', "_").replace('-', "_");
+            let safe_addr = addr.replace([':', '-'], "_");
+            let safe_dep = dep.replace([':', '-'], "_");
             lines.push(format!("    {} --> {}", safe_addr, safe_dep));
             render_mermaid_node(dep, registry, visited, lines);
         }

--- a/v4/crates/sindri-resolver/src/admission.rs
+++ b/v4/crates/sindri-resolver/src/admission.rs
@@ -1,6 +1,5 @@
-use sindri_core::component::Backend;
 use sindri_core::platform::TargetProfile;
-use sindri_core::policy::{InstallPolicy, PolicyAction, PolicyPreset};
+use sindri_core::policy::{InstallPolicy, PolicyPreset};
 use sindri_core::registry::ComponentEntry;
 use crate::error::ResolverError;
 
@@ -44,7 +43,7 @@ impl<'a> AdmissionChecker<'a> {
     }
 
     /// Gate 1: Does the component support this platform?
-    pub fn check_platform(&self, entry: &ComponentEntry) -> AdmissionResult {
+    pub fn check_platform(&self, _entry: &ComponentEntry) -> AdmissionResult {
         // For Sprint 3, all components with a non-empty depends_on set pass.
         // Full platform matrix check in Sprint 4 when ComponentManifest is fetched.
         AdmissionResult::ok()
@@ -56,8 +55,8 @@ impl<'a> AdmissionChecker<'a> {
         let license = &entry.license;
         if !license.is_empty() {
             // Strict preset: deny GPL unless explicitly allowed
-            if matches!(self.policy.preset, PolicyPreset::Strict) {
-                if (license.contains("GPL") || license.contains("AGPL"))
+            if matches!(self.policy.preset, PolicyPreset::Strict)
+                && (license.contains("GPL") || license.contains("AGPL"))
                     && !self.policy.allowed_licenses.iter().any(|l| l == license)
                 {
                     return AdmissionResult::deny(
@@ -66,7 +65,6 @@ impl<'a> AdmissionChecker<'a> {
                         Some("Use `sindri policy allow-license` or switch to default preset"),
                     );
                 }
-            }
             // Explicit denial list
             if self.policy.denied_licenses.iter().any(|l| l == license) {
                 return AdmissionResult::deny(

--- a/v4/crates/sindri-resolver/src/backend_choice.rs
+++ b/v4/crates/sindri-resolver/src/backend_choice.rs
@@ -75,12 +75,10 @@ pub fn choose_backend(
 pub fn explain_choice(entry: &ComponentEntry, platform: &Platform) -> String {
     let chain = default_preference(&platform.os);
     let chosen = choose_backend(entry, platform, None);
-    let mut lines = vec![
-        format!("Component: {}:{}", entry.backend, entry.name),
+    let lines = [format!("Component: {}:{}", entry.backend, entry.name),
         format!("Platform:  {}", platform.triple()),
         format!("Preference chain: {}", chain.iter().map(|b| b.as_str()).collect::<Vec<_>>().join(" > ")),
-        format!("Chosen: {}", chosen.as_str()),
-    ];
+        format!("Chosen: {}", chosen.as_str())];
     lines.join("\n")
 }
 

--- a/v4/crates/sindri-resolver/src/lib.rs
+++ b/v4/crates/sindri-resolver/src/lib.rs
@@ -10,13 +10,12 @@ pub mod version;
 pub use error::ResolverError;
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use sindri_core::lockfile::Lockfile;
 use sindri_core::manifest::BomManifest;
 use sindri_core::platform::{Platform, TargetProfile, Capabilities};
 use sindri_core::policy::InstallPolicy;
 use sindri_core::registry::ComponentEntry;
-use sindri_core::version::VersionSpec;
 
 /// Top-level resolver options
 pub struct ResolveOptions {

--- a/v4/crates/sindri-resolver/src/lockfile_writer.rs
+++ b/v4/crates/sindri-resolver/src/lockfile_writer.rs
@@ -38,7 +38,7 @@ pub fn read_lockfile(path: &Path) -> Result<Lockfile, ResolverError> {
 pub fn resolved_from_entry(
     entry: &ComponentEntry,
     chosen_backend: Backend,
-    bom_address: &str,
+    _bom_address: &str,
 ) -> ResolvedComponent {
     let id = ComponentId {
         backend: chosen_backend.clone(),

--- a/v4/crates/sindri-resolver/src/version.rs
+++ b/v4/crates/sindri-resolver/src/version.rs
@@ -28,9 +28,7 @@ pub fn resolve_version(
             // Simple semver-like range matching: ">=1.0, <2.0", "^1.2", "~1.2.3"
             // For Sprint 3: match prefix ranges and exact. Full semver in Sprint 3 hardening.
             let matched = available
-                .iter()
-                .filter(|v| version_satisfies_range(&v.0, range))
-                .last() // take highest satisfying
+                .iter().rfind(|v| version_satisfies_range(&v.0, range)) // take highest satisfying
                 .cloned();
             matched.ok_or_else(|| {
                 ResolverError::NotFound(format!("No version satisfies range {}", range))

--- a/v4/crates/sindri/src/commands/add.rs
+++ b/v4/crates/sindri/src/commands/add.rs
@@ -30,7 +30,7 @@ pub fn run(args: AddArgs) -> i32 {
 
     // Check for duplicate
     let clean_addr = crate::commands::manifest::address_without_version(&args.address);
-    if let Some(_) = find_entry_index(&manifest, &clean_addr) {
+    if find_entry_index(&manifest, &clean_addr).is_some() {
         eprintln!(
             "Component '{}' is already in sindri.yaml",
             clean_addr

--- a/v4/crates/sindri/src/commands/init.rs
+++ b/v4/crates/sindri/src/commands/init.rs
@@ -59,11 +59,10 @@ preferences:
     append_gitignore();
 
     // Write sindri.policy.yaml if non-default
-    if policy_preset != "default" {
-        if sindri_policy::write_global_preset(&parse_preset(policy_preset)).is_ok() {
+    if policy_preset != "default"
+        && sindri_policy::write_global_preset(&parse_preset(policy_preset)).is_ok() {
             println!("Policy set to '{}'", policy_preset);
         }
-    }
 
     println!("Created sindri.yaml for project '{}'", name);
     println!("Next steps:");

--- a/v4/crates/sindri/src/commands/ls.rs
+++ b/v4/crates/sindri/src/commands/ls.rs
@@ -77,7 +77,7 @@ pub fn run(args: LsArgs) -> i32 {
             );
         } else {
             println!("\nRegistry: {}", registry_name);
-            println!("{:<30} {:<12} {:<12} {}", "COMPONENT", "BACKEND", "LATEST", "KIND");
+            println!("{:<30} {:<12} {:<12} KIND", "COMPONENT", "BACKEND", "LATEST");
             println!("{}", "-".repeat(70));
             for comp in components {
                 let name = comp.get("name").and_then(|v| v.as_str()).unwrap_or("?");

--- a/v4/crates/sindri/src/commands/manifest.rs
+++ b/v4/crates/sindri/src/commands/manifest.rs
@@ -1,9 +1,7 @@
 //! Shared helpers for reading/modifying sindri.yaml
 
 use std::fs;
-use std::path::Path;
 use sindri_core::manifest::BomManifest;
-use sindri_core::component::BomEntry;
 
 pub fn load_manifest(path: &str) -> Result<(BomManifest, String), String> {
     let content = fs::read_to_string(path)

--- a/v4/crates/sindri/src/commands/registry.rs
+++ b/v4/crates/sindri/src/commands/registry.rs
@@ -190,11 +190,10 @@ fn lint_dir(dir: &std::path::Path, json: bool) -> i32 {
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().map(|e| e == "yaml").unwrap_or(false) {
-            if lint_file(&path, json) != EXIT_SUCCESS {
+        if path.extension().map(|e| e == "yaml").unwrap_or(false)
+            && lint_file(&path, json) != EXIT_SUCCESS {
                 any_failed = true;
             }
-        }
     }
 
     if any_failed { EXIT_SCHEMA_OR_RESOLVE_ERROR } else { EXIT_SUCCESS }

--- a/v4/crates/sindri/src/commands/resolve.rs
+++ b/v4/crates/sindri/src/commands/resolve.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use sindri_core::exit_codes::{EXIT_POLICY_DENIED, EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_core::platform::Platform;
 use sindri_core::policy::InstallPolicy;
 use sindri_core::registry::ComponentEntry;
@@ -37,12 +37,11 @@ pub fn run(args: ResolveArgs) -> i32 {
 
     // Load registry from cache
     let registry = load_registry_from_cache();
-    if registry.is_empty() && !args.offline {
-        if !args.json {
+    if registry.is_empty() && !args.offline
+        && !args.json {
             eprintln!("Warning: no registry index found. Run `sindri registry refresh` first.");
             eprintln!("Proceeding with empty registry (no components will resolve).");
         }
-    }
 
     // Load policy (defaults for now; Sprint 6 adds full policy loading)
     let mut policy = InstallPolicy {

--- a/v4/crates/sindri/src/commands/search.rs
+++ b/v4/crates/sindri/src/commands/search.rs
@@ -11,7 +11,7 @@ pub struct SearchArgs {
 }
 
 pub fn run(args: SearchArgs) -> i32 {
-    let mut registry = load_registry(args.registry.as_deref());
+    let registry = load_registry(args.registry.as_deref());
     if registry.is_empty() {
         eprintln!("No registry cache found. Run `sindri registry refresh <name> <url>` first.");
         return EXIT_SCHEMA_OR_RESOLVE_ERROR;
@@ -49,7 +49,7 @@ pub fn run(args: SearchArgs) -> i32 {
             .collect();
         println!("{}", serde_json::to_string_pretty(&serde_json::json!({"results": items})).unwrap_or_default());
     } else {
-        println!("{:<30} {:<12} {:<12} {}", "COMPONENT", "BACKEND", "LATEST", "DESCRIPTION");
+        println!("{:<30} {:<12} {:<12} DESCRIPTION", "COMPONENT", "BACKEND", "LATEST");
         println!("{}", "-".repeat(80));
         for r in &results {
             println!(

--- a/v4/crates/sindri/src/commands/target.rs
+++ b/v4/crates/sindri/src/commands/target.rs
@@ -1,5 +1,5 @@
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
-use sindri_targets::{LocalTarget, DockerTarget, SshTarget, Target};
+use sindri_targets::{LocalTarget, DockerTarget, Target};
 
 pub enum TargetCmd {
     Add { name: String, kind: String, opts: Vec<(String, String)> },
@@ -32,9 +32,9 @@ fn add_target(name: &str, kind: &str, _opts: &[(String, String)]) -> i32 {
 
 fn list_targets() -> i32 {
     // Sprint 9: show local as the always-present default (ADR-023)
-    println!("{:<20} {:<10} {}", "NAME", "KIND", "STATUS");
+    println!("{:<20} {:<10} STATUS", "NAME", "KIND");
     println!("{}", "-".repeat(50));
-    println!("{:<20} {:<10} {}", "local", "local", "ready");
+    println!("{:<20} {:<10} ready", "local", "local");
     EXIT_SUCCESS
 }
 


### PR DESCRIPTION
## Summary

The v4 branch CI was failing on the **Build & Test** job due to clippy errors enforced by `-D warnings`. This PR resolves all workspace clippy violations so CI can go green.

### Fixes
- **sindri-backends**: prefix unused vars (`_tool`, `_platform`); use `next_back()` instead of `.last()` on `DoubleEndedIterator`; drop unused `std::fs` import.
- **sindri-discovery**: remove unused `.enumerate()`, simplify `format!`, fold consecutive `str::replace` calls.
- **sindri-resolver**: remove unused imports/vars/mut; collapse nested `if`; `next_back()` over `.last()`; replace `vec![...]` with array literal.
- **sindri**: remove unused imports/mut; collapse nested `if`; `is_some()`; fix literal-with-empty-format-string warnings.

Most fixes were applied via `cargo clippy --fix`; the `DoubleEndedIterator` and unused-variable cases required manual edits.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean locally
- [x] `cargo build --workspace` succeeds
- [ ] CI on v4 turns green (`v4: CI (shim)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)