### PR TITLE
docs(readme): give each CI badge a branch-specific label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Sindri
 
 [![License](https://img.shields.io/github/license/pacphi/sindri)](LICENSE)
-[![CI v2](https://github.com/pacphi/sindri/actions/workflows/ci.yml/badge.svg?branch=v2)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av2)
-[![CI v3](https://github.com/pacphi/sindri/actions/workflows/ci.yml/badge.svg?branch=v3)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av3)
-[![CI v4](https://github.com/pacphi/sindri/actions/workflows/ci.yml/badge.svg?branch=v4)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av4)
+[![v2 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci.yml?branch=v2&label=v2%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av2)
+[![v3 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci.yml?branch=v3&label=v3%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av3)
+[![v4 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci.yml?branch=v4&label=v4%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av4)
 [![FAQ](https://img.shields.io/badge/FAQ-on%20fly.dev-blue)](https://sindri-faq.fly.dev)
 [![GHCR](https://img.shields.io/badge/GHCR-container%20registry-blue)](https://github.com/pacphi/sindri/pkgs/container/sindri)
 


### PR DESCRIPTION
## Summary

GitHub's native workflow badge endpoint takes the label from the workflow's \`name:\` field. All three branches' CI shims live in \`ci.yml\`, so every badge previously rendered as just \"CI\" with no way to tell v2 from v3 from v4.

Switched the three CI badges to shields.io's \`actions/workflow/status\` endpoint with an explicit \`label=vX: CI\` per branch. Link targets are unchanged.

## Test plan

- [ ] After merge, badges show \"v2: CI / passing\", \"v3: CI / passing\", \"v4: CI / passing\" (or failing) on the rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)