### PR TITLE
docs(v1): redirect to pacphi/sindri-legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
-# Sindri v1 (END OF LIFE)
+# Sindri v1 — moved
 
-v1 is the original Bash implementation. It is end-of-life and accepts only
-critical security backports. See [`CHANGELOG.md`](CHANGELOG.md) for the
-historical record.
+The original Bash implementation of Sindri (alpha through `v1.0.0-rc.5`) lives in a separate, archived repository:
 
-For active development, switch to the [`v3`](https://github.com/pacphi/sindri/tree/v3)
-or [`v4`](https://github.com/pacphi/sindri/tree/v4) branch.
+**→ [pacphi/sindri-legacy](https://github.com/pacphi/sindri-legacy)**
+
+That repo is the canonical home for v1 and contains:
+
+- The complete v1 source and commit history.
+- All eight v1 release tags and their assets: <https://github.com/pacphi/sindri-legacy/releases>
+- A pre-archive notice on its default branch.
+
+## Why this branch exists
+
+The `v1` branch in this repository is a near-empty stub left behind when the original monorepo was split into the per-version `v1` / `v2` / `v3` / `v4` branches. Rather than re-import the legacy commit history (releases can't be migrated cross-repo), v1 users are routed to `pacphi/sindri-legacy`, which already holds the source, tags, and release artifacts.
+
+## What you probably want
+
+| If you're… | Go here |
+| --- | --- |
+| Looking for v1 source / tags / releases | <https://github.com/pacphi/sindri-legacy> |
+| Looking for the actively maintained CLI | [`v3` branch](https://github.com/pacphi/sindri/tree/v3) |
+| Following the next-architecture redesign | [`v4` branch](https://github.com/pacphi/sindri/tree/v4) |
+| Choosing between versions | [Migration Hub](https://github.com/pacphi/sindri/blob/main/docs/migration/README.md) |
+
+See also the [main repository README](https://github.com/pacphi/sindri/blob/main/README.md) for the full version table.


### PR DESCRIPTION
## Summary

The \`v1\` branch in this repo is a near-empty stub left over from the monorepo split. The complete v1 source, full commit history, and all eight release tags (\`v1.0.0-alpha.1\` through \`v1.0.0-rc.5\`) live in the separate, archived repo [\`pacphi/sindri-legacy\`](https://github.com/pacphi/sindri-legacy), which already carries a "pre-archive notice" commit on its default branch.

GitHub releases cannot be migrated across repos, so importing the legacy commit history into this branch would only create a dual-lineage with no upside. This PR replaces the v1 README with a short redirect that:

- Points users at the canonical repo and its [release page](https://github.com/pacphi/sindri-legacy/releases).
- Explains why this branch exists at all.
- Routes "what you probably want" traffic to v3, v4, or the migration hub.

The companion change on \`main\` ([PR #194](https://github.com/pacphi/sindri/pull/194)) repoints every v1 reference in the umbrella docs and the root README to \`pacphi/sindri-legacy\`.

## Test plan

- [x] README renders cleanly on GitHub
- [ ] Verify after merge that \`https://github.com/pacphi/sindri/blob/v1/README.md\` shows the redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)