### PR TITLE
ci(v3): restore path-filter optimizations on shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,23 @@ name: "v3: CI (shim)"
 on:
   push:
     branches: [v3]
+    paths:
+      - 'v3/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/ci.yml'
+      - '.dockerignore'
+      - '.npmrc'
+      - '.shellcheckrc'
+      - '.yamllint.yml'
+      - 'Makefile'
   pull_request:
     branches: [v3]
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'RELEASE_NOTES*.md'
+      - '**/*.md'
   workflow_dispatch:
 
 # Permissions must be a SUPERSET of every nested permission the called


### PR DESCRIPTION
Part of #186. Restores pre-reorg path filters; `v3/Cargo.toml` triggers, markdown-only outside v3/** does not.