### PR TITLE
chore(v4): cargo fmt sindri-targets crate

### DIFF
--- a/v4/crates/sindri-targets/src/auth.rs
+++ b/v4/crates/sindri-targets/src/auth.rs
@@ -52,9 +52,17 @@ impl AuthValue {
             AuthValue::Cli(cmd) => {
                 let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
                 let out = std::process::Command::new(parts[0])
-                    .args(parts.get(1).map(|s| s.split_whitespace().collect::<Vec<_>>()).unwrap_or_default())
+                    .args(
+                        parts
+                            .get(1)
+                            .map(|s| s.split_whitespace().collect::<Vec<_>>())
+                            .unwrap_or_default(),
+                    )
                     .output()
-                    .map_err(|e| TargetError::AuthFailed { target: "(cli)".into(), detail: e.to_string() })?;
+                    .map_err(|e| TargetError::AuthFailed {
+                        target: "(cli)".into(),
+                        detail: e.to_string(),
+                    })?;
                 Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
             }
             AuthValue::Plain(val) => {

--- a/v4/crates/sindri-targets/src/cloud.rs
+++ b/v4/crates/sindri-targets/src/cloud.rs
@@ -1,12 +1,12 @@
+use crate::error::TargetError;
+use crate::traits::{PrereqCheck, Target};
+use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
 /// Cloud target stubs (ADR-017, Sprint 10)
 ///
 /// Each cloud target implements the Target trait. Sprint 10 provides the
 /// struct/trait scaffolding with CLI delegation stubs. Full API integrations
 /// are Sprint 10 hardening work.
 use std::path::Path;
-use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
-use crate::error::TargetError;
-use crate::traits::{PrereqCheck, Target};
 
 // ─── E2b Sandbox ────────────────────────────────────────────────────────────
 
@@ -18,17 +18,28 @@ pub struct E2bTarget {
 
 impl E2bTarget {
     pub fn new(name: &str, template: &str) -> Self {
-        E2bTarget { name: name.to_string(), template: template.to_string(), sandbox_id: None }
+        E2bTarget {
+            name: name.to_string(),
+            template: template.to_string(),
+            sandbox_id: None,
+        }
     }
 }
 
 impl Target for E2bTarget {
-    fn name(&self) -> &str { &self.name }
-    fn kind(&self) -> &str { "e2b" }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn kind(&self) -> &str {
+        "e2b"
+    }
 
     fn profile(&self) -> Result<TargetProfile, TargetError> {
         Ok(TargetProfile {
-            platform: Platform { os: Os::Linux, arch: Arch::X86_64 },
+            platform: Platform {
+                os: Os::Linux,
+                arch: Arch::X86_64,
+            },
             capabilities: Capabilities {
                 system_package_manager: Some("apt-get".into()),
                 has_docker: false,
@@ -41,7 +52,16 @@ impl Target for E2bTarget {
     fn exec(&self, cmd: &str, _env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
         // Sprint 10 stub: shell out to e2b CLI
         let output = std::process::Command::new("e2b")
-            .args(["sandbox", "exec", "--sandbox", self.sandbox_id.as_deref().unwrap_or(""), "--", "sh", "-c", cmd])
+            .args([
+                "sandbox",
+                "exec",
+                "--sandbox",
+                self.sandbox_id.as_deref().unwrap_or(""),
+                "--",
+                "sh",
+                "-c",
+                cmd,
+            ])
             .output()
             .map_err(|e| TargetError::Prerequisites {
                 target: self.name.clone(),
@@ -54,18 +74,27 @@ impl Target for E2bTarget {
     }
 
     fn upload(&self, _local: &Path, _remote: &str) -> Result<(), TargetError> {
-        Err(TargetError::Unavailable { name: self.name.clone(), reason: "upload via e2b CLI not yet implemented".into() })
+        Err(TargetError::Unavailable {
+            name: self.name.clone(),
+            reason: "upload via e2b CLI not yet implemented".into(),
+        })
     }
 
     fn download(&self, _remote: &str, _local: &Path) -> Result<(), TargetError> {
-        Err(TargetError::Unavailable { name: self.name.clone(), reason: "download via e2b CLI not yet implemented".into() })
+        Err(TargetError::Unavailable {
+            name: self.name.clone(),
+            reason: "download via e2b CLI not yet implemented".into(),
+        })
     }
 
     fn create(&self) -> Result<(), TargetError> {
         std::process::Command::new("e2b")
             .args(["sandbox", "create", "--template", &self.template])
             .status()
-            .map_err(|e| TargetError::Prerequisites { target: self.name.clone(), detail: e.to_string() })?;
+            .map_err(|e| TargetError::Prerequisites {
+                target: self.name.clone(),
+                detail: e.to_string(),
+            })?;
         Ok(())
     }
 
@@ -88,17 +117,28 @@ pub struct FlyTarget {
 
 impl FlyTarget {
     pub fn new(name: &str, app_name: &str) -> Self {
-        FlyTarget { name: name.to_string(), app_name: app_name.to_string(), region: None }
+        FlyTarget {
+            name: name.to_string(),
+            app_name: app_name.to_string(),
+            region: None,
+        }
     }
 }
 
 impl Target for FlyTarget {
-    fn name(&self) -> &str { &self.name }
-    fn kind(&self) -> &str { "fly" }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn kind(&self) -> &str {
+        "fly"
+    }
 
     fn profile(&self) -> Result<TargetProfile, TargetError> {
         Ok(TargetProfile {
-            platform: Platform { os: Os::Linux, arch: Arch::X86_64 },
+            platform: Platform {
+                os: Os::Linux,
+                arch: Arch::X86_64,
+            },
             capabilities: Capabilities::default(),
         })
     }
@@ -107,7 +147,10 @@ impl Target for FlyTarget {
         let output = std::process::Command::new("flyctl")
             .args(["ssh", "console", "--app", &self.app_name, "--command", cmd])
             .output()
-            .map_err(|e| TargetError::Prerequisites { target: self.name.clone(), detail: format!("flyctl not found: {}", e) })?;
+            .map_err(|e| TargetError::Prerequisites {
+                target: self.name.clone(),
+                detail: format!("flyctl not found: {}", e),
+            })?;
         Ok((
             String::from_utf8_lossy(&output.stdout).to_string(),
             String::from_utf8_lossy(&output.stderr).to_string(),
@@ -115,18 +158,27 @@ impl Target for FlyTarget {
     }
 
     fn upload(&self, _local: &Path, _remote: &str) -> Result<(), TargetError> {
-        Err(TargetError::Unavailable { name: self.name.clone(), reason: "use flyctl deploy for file transfer".into() })
+        Err(TargetError::Unavailable {
+            name: self.name.clone(),
+            reason: "use flyctl deploy for file transfer".into(),
+        })
     }
 
     fn download(&self, _remote: &str, _local: &Path) -> Result<(), TargetError> {
-        Err(TargetError::Unavailable { name: self.name.clone(), reason: "use flyctl ssh sftp for downloads".into() })
+        Err(TargetError::Unavailable {
+            name: self.name.clone(),
+            reason: "use flyctl ssh sftp for downloads".into(),
+        })
     }
 
     fn create(&self) -> Result<(), TargetError> {
         std::process::Command::new("flyctl")
             .args(["apps", "create", &self.app_name, "--json"])
             .status()
-            .map_err(|e| TargetError::Prerequisites { target: self.name.clone(), detail: e.to_string() })?;
+            .map_err(|e| TargetError::Prerequisites {
+                target: self.name.clone(),
+                detail: e.to_string(),
+            })?;
         Ok(())
     }
 
@@ -158,21 +210,40 @@ impl KubernetesTarget {
 }
 
 impl Target for KubernetesTarget {
-    fn name(&self) -> &str { &self.name }
-    fn kind(&self) -> &str { "kubernetes" }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn kind(&self) -> &str {
+        "kubernetes"
+    }
 
     fn profile(&self) -> Result<TargetProfile, TargetError> {
         Ok(TargetProfile {
-            platform: Platform { os: Os::Linux, arch: Arch::X86_64 },
+            platform: Platform {
+                os: Os::Linux,
+                arch: Arch::X86_64,
+            },
             capabilities: Capabilities::default(),
         })
     }
 
     fn exec(&self, cmd: &str, _env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
         let output = std::process::Command::new("kubectl")
-            .args(["exec", "-n", &self.namespace, &self.pod_name, "--", "sh", "-c", cmd])
+            .args([
+                "exec",
+                "-n",
+                &self.namespace,
+                &self.pod_name,
+                "--",
+                "sh",
+                "-c",
+                cmd,
+            ])
             .output()
-            .map_err(|e| TargetError::Prerequisites { target: self.name.clone(), detail: format!("kubectl not found: {}", e) })?;
+            .map_err(|e| TargetError::Prerequisites {
+                target: self.name.clone(),
+                detail: format!("kubectl not found: {}", e),
+            })?;
         Ok((
             String::from_utf8_lossy(&output.stdout).to_string(),
             String::from_utf8_lossy(&output.stderr).to_string(),
@@ -181,17 +252,35 @@ impl Target for KubernetesTarget {
 
     fn upload(&self, local: &Path, remote: &str) -> Result<(), TargetError> {
         std::process::Command::new("kubectl")
-            .args(["cp", "-n", &self.namespace, &local.to_string_lossy(), &format!("{}/{}", self.pod_name, remote)])
+            .args([
+                "cp",
+                "-n",
+                &self.namespace,
+                &local.to_string_lossy(),
+                &format!("{}/{}", self.pod_name, remote),
+            ])
             .status()
-            .map_err(|e| TargetError::ExecFailed { target: self.name.clone(), detail: e.to_string() })?;
+            .map_err(|e| TargetError::ExecFailed {
+                target: self.name.clone(),
+                detail: e.to_string(),
+            })?;
         Ok(())
     }
 
     fn download(&self, remote: &str, local: &Path) -> Result<(), TargetError> {
         std::process::Command::new("kubectl")
-            .args(["cp", "-n", &self.namespace, &format!("{}/{}", self.pod_name, remote), &local.to_string_lossy()])
+            .args([
+                "cp",
+                "-n",
+                &self.namespace,
+                &format!("{}/{}", self.pod_name, remote),
+                &local.to_string_lossy(),
+            ])
             .status()
-            .map_err(|e| TargetError::ExecFailed { target: self.name.clone(), detail: e.to_string() })?;
+            .map_err(|e| TargetError::ExecFailed {
+                target: self.name.clone(),
+                detail: e.to_string(),
+            })?;
         Ok(())
     }
 
@@ -199,7 +288,10 @@ impl Target for KubernetesTarget {
         vec![if crate::traits::which("kubectl").is_some() {
             PrereqCheck::ok("kubectl CLI")
         } else {
-            PrereqCheck::fail("kubectl CLI", "Install kubectl: https://kubernetes.io/docs/tasks/tools/")
+            PrereqCheck::fail(
+                "kubectl CLI",
+                "Install kubectl: https://kubernetes.io/docs/tasks/tools/",
+            )
         }]
     }
 }

--- a/v4/crates/sindri-targets/src/docker.rs
+++ b/v4/crates/sindri-targets/src/docker.rs
@@ -1,7 +1,7 @@
-use std::path::Path;
-use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
+use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
+use std::path::Path;
 
 /// Docker container target (ADR-017)
 pub struct DockerTarget {
@@ -53,7 +53,9 @@ impl Target for DockerTarget {
 
     fn profile(&self) -> Result<TargetProfile, TargetError> {
         if !self.is_running() {
-            return Err(TargetError::NotProvisioned { name: self.name.clone() });
+            return Err(TargetError::NotProvisioned {
+                name: self.name.clone(),
+            });
         }
         // Query the container's OS/arch
         let (stdout, _) = self.exec("uname -m", &[])?;
@@ -63,7 +65,10 @@ impl Target for DockerTarget {
             Arch::X86_64
         };
         Ok(TargetProfile {
-            platform: Platform { os: Os::Linux, arch },
+            platform: Platform {
+                os: Os::Linux,
+                arch,
+            },
             capabilities: Capabilities {
                 system_package_manager: detect_container_pm(self),
                 has_docker: false,
@@ -109,9 +114,20 @@ impl Target for DockerTarget {
     }
 
     fn create(&self) -> Result<(), TargetError> {
-        tracing::info!("docker: creating container {} from {}", self.container_name, self.image);
+        tracing::info!(
+            "docker: creating container {} from {}",
+            self.container_name,
+            self.image
+        );
         let (_, stderr) = self.run_docker(&[
-            "run", "--name", &self.container_name, "-d", "--rm", &self.image, "sleep", "infinity",
+            "run",
+            "--name",
+            &self.container_name,
+            "-d",
+            "--rm",
+            &self.image,
+            "sleep",
+            "infinity",
         ])?;
         if !stderr.is_empty() && stderr.contains("Error") {
             return Err(TargetError::ExecFailed {
@@ -130,19 +146,24 @@ impl Target for DockerTarget {
     }
 
     fn check_prerequisites(&self) -> Vec<PrereqCheck> {
-        vec![
-            if crate::traits::which("docker").is_some() {
-                PrereqCheck::ok("docker CLI")
-            } else {
-                PrereqCheck::fail("docker CLI", "Install Docker: https://docs.docker.com/get-docker/")
-            },
-        ]
+        vec![if crate::traits::which("docker").is_some() {
+            PrereqCheck::ok("docker CLI")
+        } else {
+            PrereqCheck::fail(
+                "docker CLI",
+                "Install Docker: https://docs.docker.com/get-docker/",
+            )
+        }]
     }
 }
 
 fn detect_container_pm(target: &DockerTarget) -> Option<String> {
     for pm in &["apt-get", "dnf", "apk"] {
-        if target.exec(&format!("which {}", pm), &[]).map(|(o, _)| !o.trim().is_empty()).unwrap_or(false) {
+        if target
+            .exec(&format!("which {}", pm), &[])
+            .map(|(o, _)| !o.trim().is_empty())
+            .unwrap_or(false)
+        {
             return Some(pm.to_string());
         }
     }

--- a/v4/crates/sindri-targets/src/lib.rs
+++ b/v4/crates/sindri-targets/src/lib.rs
@@ -13,4 +13,4 @@ pub use docker::DockerTarget;
 pub use error::TargetError;
 pub use local::LocalTarget;
 pub use ssh::SshTarget;
-pub use traits::{Target, PrereqCheck};
+pub use traits::{PrereqCheck, Target};

--- a/v4/crates/sindri-targets/src/local.rs
+++ b/v4/crates/sindri-targets/src/local.rs
@@ -1,7 +1,7 @@
-use std::path::Path;
-use sindri_core::platform::{Capabilities, Platform, TargetProfile};
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
+use sindri_core::platform::{Capabilities, Platform, TargetProfile};
+use std::path::Path;
 
 /// Local machine target — the implicit default (ADR-023)
 pub struct LocalTarget {
@@ -16,11 +16,15 @@ impl Default for LocalTarget {
 
 impl LocalTarget {
     pub fn new() -> Self {
-        LocalTarget { name: "local".to_string() }
+        LocalTarget {
+            name: "local".to_string(),
+        }
     }
 
     pub fn named(name: &str) -> Self {
-        LocalTarget { name: name.to_string() }
+        LocalTarget {
+            name: name.to_string(),
+        }
     }
 }
 
@@ -36,7 +40,10 @@ impl Target for LocalTarget {
     fn profile(&self) -> Result<TargetProfile, TargetError> {
         let platform = Platform::current();
         let caps = detect_capabilities();
-        Ok(TargetProfile { platform, capabilities: caps })
+        Ok(TargetProfile {
+            platform,
+            capabilities: caps,
+        })
     }
 
     fn exec(&self, cmd: &str, env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
@@ -75,7 +82,12 @@ fn detect_capabilities() -> Capabilities {
     let has_docker = crate::traits::which("docker").is_some();
     let has_sudo = crate::traits::which("sudo").is_some();
     let shell = std::env::var("SHELL").ok();
-    Capabilities { system_package_manager: system_pm, has_docker, has_sudo, shell }
+    Capabilities {
+        system_package_manager: system_pm,
+        has_docker,
+        has_sudo,
+        shell,
+    }
 }
 
 fn detect_system_pm() -> Option<String> {

--- a/v4/crates/sindri-targets/src/ssh.rs
+++ b/v4/crates/sindri-targets/src/ssh.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
-use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
 use crate::auth::AuthValue;
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
+use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
+use std::path::Path;
 
 /// SSH remote target (ADR-017, ADR-020)
 /// Sprint 9: shells out to the `ssh`/`scp` CLI binaries.
@@ -66,16 +66,26 @@ impl Target for SshTarget {
     fn profile(&self) -> Result<TargetProfile, TargetError> {
         let (stdout, _) = self.exec("uname -m && uname -s", &[])?;
         let parts: Vec<&str> = stdout.trim().lines().collect();
-        let arch = parts.first().map(|s| if s.contains("aarch64") || s.contains("arm") {
-            Arch::Aarch64
-        } else {
-            Arch::X86_64
-        }).unwrap_or(Arch::X86_64);
-        let os = parts.get(1).map(|s| if s.contains("Darwin") {
-            Os::Macos
-        } else {
-            Os::Linux
-        }).unwrap_or(Os::Linux);
+        let arch = parts
+            .first()
+            .map(|s| {
+                if s.contains("aarch64") || s.contains("arm") {
+                    Arch::Aarch64
+                } else {
+                    Arch::X86_64
+                }
+            })
+            .unwrap_or(Arch::X86_64);
+        let os = parts
+            .get(1)
+            .map(|s| {
+                if s.contains("Darwin") {
+                    Os::Macos
+                } else {
+                    Os::Linux
+                }
+            })
+            .unwrap_or(Os::Linux);
 
         Ok(TargetProfile {
             platform: Platform { os, arch },
@@ -89,9 +99,7 @@ impl Target for SshTarget {
     }
 
     fn exec(&self, cmd: &str, env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
-        let env_prefix: String = env.iter()
-            .map(|(k, v)| format!("{}={} ", k, v))
-            .collect();
+        let env_prefix: String = env.iter().map(|(k, v)| format!("{}={} ", k, v)).collect();
         let full_cmd = format!("{}{}", env_prefix, cmd);
 
         let mut args = self.ssh_args();

--- a/v4/crates/sindri-targets/src/traits.rs
+++ b/v4/crates/sindri-targets/src/traits.rs
@@ -3,14 +3,18 @@ pub fn which(name: &str) -> Option<std::path::PathBuf> {
     std::env::var_os("PATH").and_then(|paths| {
         std::env::split_paths(&paths).find_map(|dir| {
             let candidate = dir.join(name);
-            if candidate.is_file() { Some(candidate) } else { None }
+            if candidate.is_file() {
+                Some(candidate)
+            } else {
+                None
+            }
         })
     })
 }
 
+use crate::error::TargetError;
 /// The Target trait — replaces Provider from v3 (ADR-017)
 use sindri_core::platform::TargetProfile;
-use crate::error::TargetError;
 
 pub trait Target: Send + Sync {
     /// Human-readable name of this target instance
@@ -60,10 +64,18 @@ pub struct PrereqCheck {
 
 impl PrereqCheck {
     pub fn ok(name: &str) -> Self {
-        PrereqCheck { name: name.to_string(), passed: true, fix: None }
+        PrereqCheck {
+            name: name.to_string(),
+            passed: true,
+            fix: None,
+        }
     }
 
     pub fn fail(name: &str, fix: &str) -> Self {
-        PrereqCheck { name: name.to_string(), passed: false, fix: Some(fix.to_string()) }
+        PrereqCheck {
+            name: name.to_string(),
+            passed: false,
+            fix: Some(fix.to_string()),
+        }
     }
 }


### PR DESCRIPTION
## Summary
Runs \`cargo fmt -p sindri-targets\` to clear formatting drift across that crate.

## Why
\`cargo fmt --all --check\` was failing on v4 — first reported during Wave 2 dispatch, blocks the addition of a workspace-wide fmt CI step.

## Scope
One crate, formatting only:
- \`auth.rs\`, \`cloud.rs\`, \`docker.rs\`, \`lib.rs\`, \`local.rs\`, \`ssh.rs\`, \`traits.rs\`

No logic changes. No public-API changes.

## Note on remaining drift
\`cargo fmt --all --check\` will still report drift in other v4 crates (\`sindri-resolver\`, \`sindri-discovery\`, \`sindri-policy\`, \`sindri-registry\`, \`sindri/\`, \`sindri-extensions\`). Those crates have an open PR (#210) or recently-landed work (#209) that will fold formatting into their own diffs. A follow-up workspace-wide \`cargo fmt\` sweep is queued for after #210 merges. This PR is scoped to one crate to minimise churn while #210 is in flight.

## Test plan
- [x] \`cargo fmt -p sindri-targets --check\` clean
- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [ ] CI matrix

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)