### PR TITLE
docs(main): fix v2/v3/v4 CI badges (point at canonical ci-vN.yml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Sindri
 
 [![License](https://img.shields.io/github/license/pacphi/sindri)](LICENSE)
-[![v2 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci.yml?branch=v2&label=v2%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av2)
-[![v3 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci.yml?branch=v3&label=v3%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av3)
-[![v4 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci.yml?branch=v4&label=v4%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci.yml?query=branch%3Av4)
+[![v2 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci-v2.yml?branch=main&label=v2%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci-v2.yml)
+[![v3 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci-v3.yml?branch=main&label=v3%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci-v3.yml)
+[![v4 CI](https://img.shields.io/github/actions/workflow/status/pacphi/sindri/ci-v4.yml?branch=main&label=v4%3A%20CI)](https://github.com/pacphi/sindri/actions/workflows/ci-v4.yml)
 [![FAQ](https://img.shields.io/badge/FAQ-on%20fly.dev-blue)](https://sindri-faq.fly.dev)
 [![GHCR](https://img.shields.io/badge/GHCR-container%20registry-blue)](https://github.com/pacphi/sindri/pkgs/container/sindri)
 


### PR DESCRIPTION
## Summary
The README's v2/v3/v4 CI badges show \"no status\" because they reference \`ci.yml\` — but shields.io's \`github/actions/workflow/status\` lookup operates against the repository's **default branch (main)**, where no \`ci.yml\` exists.

Each version branch carries a thin shim called \`ci.yml\` that delegates to the canonical workflow on \`main\` via \`workflow_call\` (e.g. v4's \`ci.yml\` calls \`pacphi/sindri/.github/workflows/ci-v4.yml@main\`). shields.io can't resolve those shims, so all three badges came up empty.

## Fix
Point each badge at its canonical workflow on main:
- \`v2 CI\` → \`ci-v2.yml\`
- \`v3 CI\` → \`ci-v3.yml\`
- \`v4 CI\` → \`ci-v4.yml\`

Each \`ci-vN.yml\` only fires for runs originating from the matching version branch (via \`workflow_call\` from the shim), so the badge accurately reflects per-version CI status. Click-through links updated to drop the redundant \`?query=branch%3AvN\` filter.

## Test plan
- [x] Markdown renders
- [ ] Once merged, badges should resolve to real status (green/red/yellow) within ~1 min as shields.io re-fetches

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)