### PR TITLE
chore(v4): cargo fmt --all sweep across remaining workspace crates

### DIFF
--- a/v4/crates/sindri-discovery/src/explain.rs
+++ b/v4/crates/sindri-discovery/src/explain.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use sindri_core::registry::ComponentEntry;
+use std::collections::HashMap;
 
 /// Find the dependency path from a collection to a target component (like `npm why`)
 pub fn explain_path(

--- a/v4/crates/sindri-discovery/src/graph.rs
+++ b/v4/crates/sindri-discovery/src/graph.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use sindri_core::registry::ComponentEntry;
+use std::collections::HashMap;
 
 /// Render a dependency graph as a text tree (Sprint 8)
 pub fn render_tree(
@@ -63,10 +63,7 @@ fn render_reverse_tree(target: &str, registry: &HashMap<String, ComponentEntry>)
 }
 
 /// Render a Mermaid graph diagram
-pub fn render_mermaid(
-    roots: &[&str],
-    registry: &HashMap<String, ComponentEntry>,
-) -> String {
+pub fn render_mermaid(roots: &[&str], registry: &HashMap<String, ComponentEntry>) -> String {
     let mut lines = vec!["graph TD".to_string()];
     let mut visited = std::collections::HashSet::new();
 

--- a/v4/crates/sindri-discovery/src/lib.rs
+++ b/v4/crates/sindri-discovery/src/lib.rs
@@ -4,6 +4,6 @@ pub mod explain;
 pub mod graph;
 pub mod search;
 
-pub use search::{search, SearchResult, SearchFilters};
-pub use graph::{render_tree, render_mermaid};
 pub use explain::{explain_path, render_explain};
+pub use graph::{render_mermaid, render_tree};
+pub use search::{search, SearchFilters, SearchResult};

--- a/v4/crates/sindri-discovery/src/search.rs
+++ b/v4/crates/sindri-discovery/src/search.rs
@@ -20,12 +20,20 @@ pub enum MatchField {
 /// Fuzzy search across the registry index with relevance scoring (ADR-011, Sprint 8)
 ///
 /// Score: exact name (100) > backend:name (80) > tag (60) > description (40) > fuzzy (20)
-pub fn search(query: &str, entries: &[ComponentEntry], filters: &SearchFilters) -> Vec<SearchResult> {
+pub fn search(
+    query: &str,
+    entries: &[ComponentEntry],
+    filters: &SearchFilters,
+) -> Vec<SearchResult> {
     let q = query.to_lowercase();
     let mut results: Vec<SearchResult> = entries
         .iter()
         .filter(|e| {
-            filters.backend.as_ref().map(|b| &e.backend == b).unwrap_or(true)
+            filters
+                .backend
+                .as_ref()
+                .map(|b| &e.backend == b)
+                .unwrap_or(true)
         })
         .filter_map(|entry| score_entry(entry, &q))
         .collect();
@@ -41,24 +49,48 @@ fn score_entry(entry: &ComponentEntry, query: &str) -> Option<SearchResult> {
     let addr = format!("{}:{}", entry.backend, entry.name).to_lowercase();
 
     if name == query {
-        return Some(SearchResult { entry: entry.clone(), score: 100, match_field: MatchField::ExactName });
+        return Some(SearchResult {
+            entry: entry.clone(),
+            score: 100,
+            match_field: MatchField::ExactName,
+        });
     }
     if addr == query {
-        return Some(SearchResult { entry: entry.clone(), score: 90, match_field: MatchField::ExactName });
+        return Some(SearchResult {
+            entry: entry.clone(),
+            score: 90,
+            match_field: MatchField::ExactName,
+        });
     }
     if name.starts_with(query) || name.contains(query) {
-        return Some(SearchResult { entry: entry.clone(), score: 80, match_field: MatchField::ExactName });
+        return Some(SearchResult {
+            entry: entry.clone(),
+            score: 80,
+            match_field: MatchField::ExactName,
+        });
     }
     if addr.contains(query) {
-        return Some(SearchResult { entry: entry.clone(), score: 70, match_field: MatchField::Backend });
+        return Some(SearchResult {
+            entry: entry.clone(),
+            score: 70,
+            match_field: MatchField::Backend,
+        });
     }
     if desc.contains(query) {
-        return Some(SearchResult { entry: entry.clone(), score: 40, match_field: MatchField::Description });
+        return Some(SearchResult {
+            entry: entry.clone(),
+            score: 40,
+            match_field: MatchField::Description,
+        });
     }
     // Fuzzy: count matching chars
     let fuzzy_score = fuzzy_match(&name, query);
     if fuzzy_score > 0 {
-        return Some(SearchResult { entry: entry.clone(), score: fuzzy_score as u32, match_field: MatchField::Fuzzy });
+        return Some(SearchResult {
+            entry: entry.clone(),
+            score: fuzzy_score as u32,
+            match_field: MatchField::Fuzzy,
+        });
     }
     None
 }
@@ -74,7 +106,11 @@ fn fuzzy_match(text: &str, query: &str) -> usize {
             score += 1;
         }
     }
-    if qi == query_chars.len() && score > 2 { score } else { 0 }
+    if qi == query_chars.len() && score > 2 {
+        score
+    } else {
+        0
+    }
 }
 
 #[derive(Default)]
@@ -116,9 +152,7 @@ mod tests {
 
     #[test]
     fn description_match_found() {
-        let entries = vec![
-            make_entry("binary", "gh", "GitHub CLI tool"),
-        ];
+        let entries = vec![make_entry("binary", "gh", "GitHub CLI tool")];
         let results = search("github", &entries, &SearchFilters::default());
         assert!(!results.is_empty());
         assert!(matches!(results[0].match_field, MatchField::Description));

--- a/v4/crates/sindri-policy/src/check.rs
+++ b/v4/crates/sindri-policy/src/check.rs
@@ -12,7 +12,12 @@ pub struct PolicyCheckResult {
 
 impl PolicyCheckResult {
     pub fn ok() -> Self {
-        PolicyCheckResult { allowed: true, code: "OK".into(), message: "Allowed".into(), fix: None }
+        PolicyCheckResult {
+            allowed: true,
+            code: "OK".into(),
+            message: "Allowed".into(),
+            fix: None,
+        }
     }
 
     pub fn deny(code: &str, msg: &str, fix: Option<&str>) -> Self {
@@ -50,7 +55,10 @@ pub fn check_license(license: &str, policy: &InstallPolicy) -> PolicyCheckResult
 
     // Unknown license handling
     if license.trim().is_empty() {
-        let action = policy.on_unknown_license.as_ref().unwrap_or(&PolicyAction::Warn);
+        let action = policy
+            .on_unknown_license
+            .as_ref()
+            .unwrap_or(&PolicyAction::Warn);
         match action {
             PolicyAction::Deny => {
                 return PolicyCheckResult::deny(
@@ -83,7 +91,7 @@ pub fn check_closure(entries: &[&ComponentEntry], policy: &InstallPolicy) -> Pol
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::loader::{preset_strict, preset_default};
+    use crate::loader::{preset_default, preset_strict};
 
     #[test]
     fn strict_denies_gpl() {

--- a/v4/crates/sindri-policy/src/lib.rs
+++ b/v4/crates/sindri-policy/src/lib.rs
@@ -3,5 +3,8 @@
 pub mod check;
 pub mod loader;
 
-pub use check::{check_license, check_closure, PolicyCheckResult};
-pub use loader::{load_effective_policy, write_global_preset, preset_default, preset_strict, preset_offline, EffectivePolicy};
+pub use check::{check_closure, check_license, PolicyCheckResult};
+pub use loader::{
+    load_effective_policy, preset_default, preset_offline, preset_strict, write_global_preset,
+    EffectivePolicy,
+};

--- a/v4/crates/sindri-policy/src/loader.rs
+++ b/v4/crates/sindri-policy/src/loader.rs
@@ -1,6 +1,6 @@
+use sindri_core::policy::{AuditConfig, InstallPolicy, PolicyAction, PolicyPreset};
 use std::fs;
 use std::path::{Path, PathBuf};
-use sindri_core::policy::{AuditConfig, InstallPolicy, PolicyAction, PolicyPreset};
 
 /// Source annotation for a policy setting
 #[derive(Debug, Clone)]
@@ -33,15 +33,21 @@ pub fn preset_strict() -> InstallPolicy {
     InstallPolicy {
         preset: PolicyPreset::Strict,
         allowed_licenses: vec![
-            "MIT".into(), "Apache-2.0".into(), "BSD-2-Clause".into(),
-            "BSD-3-Clause".into(), "ISC".into(), "MPL-2.0".into(),
+            "MIT".into(),
+            "Apache-2.0".into(),
+            "BSD-2-Clause".into(),
+            "BSD-3-Clause".into(),
+            "ISC".into(),
+            "MPL-2.0".into(),
         ],
         denied_licenses: vec!["GPL-3.0-only".into(), "AGPL-3.0-only".into()],
         on_unknown_license: Some(PolicyAction::Deny),
         require_signed_registries: Some(true),
         require_checksums: Some(true),
         offline: Some(false),
-        audit: Some(AuditConfig { require_justification: true }),
+        audit: Some(AuditConfig {
+            require_justification: true,
+        }),
     }
 }
 
@@ -72,7 +78,9 @@ pub fn load_effective_policy() -> EffectivePolicy {
                 merge_policy(&mut policy, &global);
                 sources.push((
                     format!("preset: {}", preset_name(&policy.preset)),
-                    PolicySource { file: global_path.to_string_lossy().to_string() },
+                    PolicySource {
+                        file: global_path.to_string_lossy().to_string(),
+                    },
                 ));
             }
         }
@@ -86,7 +94,9 @@ pub fn load_effective_policy() -> EffectivePolicy {
                 merge_policy(&mut policy, &project);
                 sources.push((
                     "project policy".to_string(),
-                    PolicySource { file: "sindri.policy.yaml".to_string() },
+                    PolicySource {
+                        file: "sindri.policy.yaml".to_string(),
+                    },
                 ));
             }
         }
@@ -170,6 +180,9 @@ mod tests {
     #[test]
     fn default_preset_allows_unknown() {
         let policy = preset_default();
-        assert!(matches!(policy.on_unknown_license, Some(PolicyAction::Warn)));
+        assert!(matches!(
+            policy.on_unknown_license,
+            Some(PolicyAction::Warn)
+        ));
     }
 }

--- a/v4/crates/sindri-registry/src/cache.rs
+++ b/v4/crates/sindri-registry/src/cache.rs
@@ -1,7 +1,7 @@
+use crate::error::RegistryError;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
-use crate::error::RegistryError;
 
 /// Content-addressed blob cache at ~/.sindri/cache/registries/ (ADR-003)
 pub struct RegistryCache {

--- a/v4/crates/sindri-registry/src/client.rs
+++ b/v4/crates/sindri-registry/src/client.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
-use std::time::Duration;
 use crate::cache::RegistryCache;
 use crate::error::RegistryError;
 use crate::index::RegistryIndex;
+use std::path::Path;
+use std::time::Duration;
 
 /// OCI registry client. Fetches index.yaml blobs from OCI registries (ADR-003).
 ///

--- a/v4/crates/sindri-registry/src/index.rs
+++ b/v4/crates/sindri-registry/src/index.rs
@@ -21,7 +21,9 @@ impl RegistryIndex {
 
     /// Find a component by backend:name address
     pub fn find(&self, backend: &str, name: &str) -> Option<&ComponentEntry> {
-        self.components.iter().find(|c| c.backend == backend && c.name == name)
+        self.components
+            .iter()
+            .find(|c| c.backend == backend && c.name == name)
     }
 
     pub fn find_by_name(&self, name: &str) -> Vec<&ComponentEntry> {

--- a/v4/crates/sindri-registry/src/lint.rs
+++ b/v4/crates/sindri-registry/src/lint.rs
@@ -1,7 +1,7 @@
-use std::fs;
-use std::path::Path;
 use crate::error::RegistryError;
 use sindri_core::component::ComponentManifest;
+use std::fs;
+use std::path::Path;
 
 /// A lint error or warning for a component
 #[derive(Debug, Clone)]
@@ -21,7 +21,11 @@ pub struct LintResult {
 
 impl LintResult {
     pub fn ok() -> Self {
-        LintResult { passed: true, errors: Vec::new(), warnings: Vec::new() }
+        LintResult {
+            passed: true,
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
     }
 }
 
@@ -35,8 +39,8 @@ pub fn lint_path(path: &Path) -> Result<LintResult, RegistryError> {
 
 fn lint_file(path: &Path) -> Result<LintResult, RegistryError> {
     let content = fs::read_to_string(path)?;
-    let manifest: ComponentManifest = serde_yaml::from_str(&content)
-        .map_err(|e| RegistryError::SchemaError(e.to_string()))?;
+    let manifest: ComponentManifest =
+        serde_yaml::from_str(&content).map_err(|e| RegistryError::SchemaError(e.to_string()))?;
 
     let mut errors = Vec::new();
     let mut warnings = Vec::new();
@@ -64,7 +68,8 @@ fn lint_file(path: &Path) -> Result<LintResult, RegistryError> {
         if binary.checksums.is_empty() {
             errors.push(LintDiagnostic {
                 code: "LINT_MISSING_CHECKSUMS".into(),
-                message: "`binary` components must have `checksums` for all listed platforms".into(),
+                message: "`binary` components must have `checksums` for all listed platforms"
+                    .into(),
                 fix: Some("Run `sindri registry fetch-checksums` to populate checksums".into()),
             });
         }
@@ -98,7 +103,11 @@ fn lint_file(path: &Path) -> Result<LintResult, RegistryError> {
     }
 
     let passed = errors.is_empty();
-    Ok(LintResult { passed, errors, warnings })
+    Ok(LintResult {
+        passed,
+        errors,
+        warnings,
+    })
 }
 
 fn lint_directory(dir: &Path) -> Result<LintResult, RegistryError> {
@@ -116,5 +125,9 @@ fn lint_directory(dir: &Path) -> Result<LintResult, RegistryError> {
     }
 
     let passed = all_errors.is_empty();
-    Ok(LintResult { passed, errors: all_errors, warnings: all_warnings })
+    Ok(LintResult {
+        passed,
+        errors: all_errors,
+        warnings: all_warnings,
+    })
 }

--- a/v4/crates/sindri-registry/src/local.rs
+++ b/v4/crates/sindri-registry/src/local.rs
@@ -1,8 +1,8 @@
-use std::fs;
-use std::path::PathBuf;
 use crate::error::RegistryError;
 use crate::index::RegistryIndex;
 use sindri_core::component::ComponentManifest;
+use std::fs;
+use std::path::PathBuf;
 
 /// Local registry loader for development (registry:local:/path protocol, ADR-003)
 pub struct LocalRegistry {
@@ -11,7 +11,9 @@ pub struct LocalRegistry {
 
 impl LocalRegistry {
     pub fn new(path: &str) -> Self {
-        LocalRegistry { root: PathBuf::from(path) }
+        LocalRegistry {
+            root: PathBuf::from(path),
+        }
     }
 
     pub fn load_index(&self) -> Result<RegistryIndex, RegistryError> {
@@ -35,6 +37,10 @@ impl LocalRegistry {
 
     pub fn list_components(&self) -> Result<Vec<(String, String)>, RegistryError> {
         let index = self.load_index()?;
-        Ok(index.components.iter().map(|c| (c.backend.clone(), c.name.clone())).collect())
+        Ok(index
+            .components
+            .iter()
+            .map(|c| (c.backend.clone(), c.name.clone()))
+            .collect())
     }
 }

--- a/v4/crates/sindri-resolver/src/backend_choice.rs
+++ b/v4/crates/sindri-resolver/src/backend_choice.rs
@@ -78,7 +78,14 @@ pub fn explain_choice(entry: &ComponentEntry, platform: &Platform) -> String {
     let lines = [
         format!("Component: {}:{}", entry.backend, entry.name),
         format!("Platform:  {}", platform.triple()),
-        format!("Preference chain: {}", chain.iter().map(|b| b.as_str()).collect::<Vec<_>>().join(" > ")),
+        format!(
+            "Preference chain: {}",
+            chain
+                .iter()
+                .map(|b| b.as_str())
+                .collect::<Vec<_>>()
+                .join(" > ")
+        ),
         format!("Chosen: {}", chosen.as_str()),
     ];
     lines.join("\n")

--- a/v4/crates/sindri-resolver/src/closure.rs
+++ b/v4/crates/sindri-resolver/src/closure.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use crate::error::ResolverError;
 use sindri_core::component::ComponentId;
 use sindri_core::registry::ComponentEntry;
-use crate::error::ResolverError;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// A node in the expanded dependency closure
 #[derive(Debug, Clone)]
@@ -40,10 +40,7 @@ pub fn expand_closure(
 
         let (backend, name) = parse_address(&address)?;
         let entry = registry.get(&address).ok_or_else(|| {
-            ResolverError::NotFound(format!(
-                "Component '{}' not found in registry",
-                address
-            ))
+            ResolverError::NotFound(format!("Component '{}' not found in registry", address))
         })?;
 
         let id = ComponentId {
@@ -61,7 +58,11 @@ pub fn expand_closure(
             }
         }
 
-        result.push(ClosureNode { id, entry: entry.clone(), depth });
+        result.push(ClosureNode {
+            id,
+            entry: entry.clone(),
+            depth,
+        });
         in_stack.remove(&address);
     }
 
@@ -85,7 +86,9 @@ pub fn expand_closure(
     Ok(result)
 }
 
-fn parse_address(address: &str) -> Result<(sindri_core::component::Backend, String), ResolverError> {
+fn parse_address(
+    address: &str,
+) -> Result<(sindri_core::component::Backend, String), ResolverError> {
     let id = ComponentId::parse(address).ok_or_else(|| {
         ResolverError::NotFound(format!("Invalid component address: {}", address))
     })?;

--- a/v4/crates/sindri-resolver/src/lib.rs
+++ b/v4/crates/sindri-resolver/src/lib.rs
@@ -9,13 +9,13 @@ pub mod version;
 
 pub use error::ResolverError;
 
-use std::collections::HashMap;
-use std::path::PathBuf;
 use sindri_core::lockfile::Lockfile;
 use sindri_core::manifest::BomManifest;
-use sindri_core::platform::{Platform, TargetProfile, Capabilities};
+use sindri_core::platform::{Capabilities, Platform, TargetProfile};
 use sindri_core::policy::InstallPolicy;
 use sindri_core::registry::ComponentEntry;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 /// Top-level resolver options
 pub struct ResolveOptions {
@@ -40,11 +40,7 @@ pub fn resolve(
         .map_err(|e| ResolverError::Serialization(e.to_string()))?;
 
     // 2. Expand dependency closure
-    let root_addrs: Vec<String> = bom
-        .components
-        .iter()
-        .map(|c| c.address.clone())
-        .collect();
+    let root_addrs: Vec<String> = bom.components.iter().map(|c| c.address.clone()).collect();
 
     let closure_nodes = closure::expand_closure(&root_addrs, registry)?;
 
@@ -80,7 +76,8 @@ pub fn resolve(
         }
 
         let chosen = backend_choice::choose_backend(&node.entry, platform, None);
-        let resolved = lockfile_writer::resolved_from_entry(&node.entry, chosen, &node.id.to_address());
+        let resolved =
+            lockfile_writer::resolved_from_entry(&node.entry, chosen, &node.id.to_address());
         lockfile.components.push(resolved);
     }
 

--- a/v4/crates/sindri-resolver/src/lockfile_writer.rs
+++ b/v4/crates/sindri-resolver/src/lockfile_writer.rs
@@ -1,14 +1,14 @@
+use crate::error::ResolverError;
+use sindri_core::component::{Backend, ComponentId};
+use sindri_core::lockfile::{Lockfile, ResolvedComponent};
+use sindri_core::registry::ComponentEntry;
+use sindri_core::version::Version;
 use std::fs;
 use std::path::Path;
-use sindri_core::lockfile::{Lockfile, ResolvedComponent};
-use sindri_core::component::{Backend, ComponentId};
-use sindri_core::version::Version;
-use sindri_core::registry::ComponentEntry;
-use crate::error::ResolverError;
 
 /// Compute bom_hash as sha256 of the sindri.yaml content
 pub fn compute_bom_hash(bom_content: &str) -> String {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bom_content.as_bytes());
     hex::encode(hasher.finalize())
@@ -30,8 +30,7 @@ pub fn read_lockfile(path: &Path) -> Result<Lockfile, ResolverError> {
         return Err(ResolverError::LockfileStale);
     }
     let content = fs::read_to_string(path)?;
-    serde_json::from_str(&content)
-        .map_err(|e| ResolverError::Serialization(e.to_string()))
+    serde_json::from_str(&content).map_err(|e| ResolverError::Serialization(e.to_string()))
 }
 
 /// Build ResolvedComponent from a closure node

--- a/v4/crates/sindri-resolver/src/version.rs
+++ b/v4/crates/sindri-resolver/src/version.rs
@@ -1,5 +1,5 @@
-use sindri_core::version::{Version, VersionSpec};
 use crate::error::ResolverError;
+use sindri_core::version::{Version, VersionSpec};
 
 /// Resolve a VersionSpec against a list of available versions (ADR-004)
 pub fn resolve_version(
@@ -15,15 +15,11 @@ pub fn resolve_version(
             // Return the last entry (registries list versions oldest-first by convention)
             Ok(available.last().unwrap().clone())
         }
-        VersionSpec::Exact(v) => {
-            available
-                .iter()
-                .find(|a| a.0 == *v)
-                .cloned()
-                .ok_or_else(|| {
-                    ResolverError::NotFound(format!("Exact version {} not available", v))
-                })
-        }
+        VersionSpec::Exact(v) => available
+            .iter()
+            .find(|a| a.0 == *v)
+            .cloned()
+            .ok_or_else(|| ResolverError::NotFound(format!("Exact version {} not available", v))),
         VersionSpec::Range(range) => {
             // Simple semver-like range matching: ">=1.0, <2.0", "^1.2", "~1.2.3"
             // For Sprint 3: match prefix ranges and exact. Full semver in Sprint 3 hardening.
@@ -113,7 +109,11 @@ mod tests {
 
     #[test]
     fn exact_version_matches() {
-        let avail = vec![Version::new("1.0.0"), Version::new("1.1.0"), Version::new("2.0.0")];
+        let avail = vec![
+            Version::new("1.0.0"),
+            Version::new("1.1.0"),
+            Version::new("2.0.0"),
+        ];
         let v = resolve_version(&VersionSpec::Exact("1.1.0".into()), &avail).unwrap();
         assert_eq!(v.0, "1.1.0");
     }

--- a/v4/crates/sindri/src/commands/add.rs
+++ b/v4/crates/sindri/src/commands/add.rs
@@ -1,6 +1,6 @@
-use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use crate::commands::manifest::{find_entry_index, load_manifest, save_manifest};
 use sindri_core::component::BomEntry;
-use crate::commands::manifest::{load_manifest, save_manifest, find_entry_index};
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 
 pub struct AddArgs {
     pub address: String,
@@ -31,10 +31,7 @@ pub fn run(args: AddArgs) -> i32 {
     // Check for duplicate
     let clean_addr = crate::commands::manifest::address_without_version(&args.address);
     if find_entry_index(&manifest, &clean_addr).is_some() {
-        eprintln!(
-            "Component '{}' is already in sindri.yaml",
-            clean_addr
-        );
+        eprintln!("Component '{}' is already in sindri.yaml", clean_addr);
         eprintln!("Use `sindri upgrade {}` to change its version.", clean_addr);
         return EXIT_SCHEMA_OR_RESOLVE_ERROR;
     }

--- a/v4/crates/sindri/src/commands/bom.rs
+++ b/v4/crates/sindri/src/commands/bom.rs
@@ -1,9 +1,9 @@
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
+use sindri_core::lockfile::Lockfile;
 /// SBOM generation (ADR-007, Sprint 12)
 ///
 /// Emits SPDX 2.3 JSON or CycloneDX 1.6 XML from a resolved lockfile.
 use std::path::PathBuf;
-use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
-use sindri_core::lockfile::Lockfile;
 
 pub struct BomArgs {
     pub format: String, // "spdx" | "cyclonedx"
@@ -20,18 +20,27 @@ pub fn run(args: BomArgs) -> i32 {
 
     let lockfile_path = PathBuf::from(&lock_name);
     if !lockfile_path.exists() {
-        eprintln!("Lockfile '{}' not found. Run `sindri resolve` first.", lock_name);
+        eprintln!(
+            "Lockfile '{}' not found. Run `sindri resolve` first.",
+            lock_name
+        );
         return EXIT_STALE_LOCKFILE;
     }
 
     let content = match std::fs::read_to_string(&lockfile_path) {
         Ok(c) => c,
-        Err(e) => { eprintln!("Cannot read lockfile: {}", e); return EXIT_STALE_LOCKFILE; }
+        Err(e) => {
+            eprintln!("Cannot read lockfile: {}", e);
+            return EXIT_STALE_LOCKFILE;
+        }
     };
 
     let lockfile: Lockfile = match serde_json::from_str(&content) {
         Ok(l) => l,
-        Err(e) => { eprintln!("Malformed lockfile: {}", e); return EXIT_STALE_LOCKFILE; }
+        Err(e) => {
+            eprintln!("Malformed lockfile: {}", e);
+            return EXIT_STALE_LOCKFILE;
+        }
     };
 
     let sbom = match args.format.as_str() {
@@ -40,7 +49,11 @@ pub fn run(args: BomArgs) -> i32 {
     };
 
     let output_path = args.output.as_deref().unwrap_or_else(|| {
-        if args.format == "cyclonedx" { "sindri.bom.cdx.xml" } else { "sindri.bom.spdx.json" }
+        if args.format == "cyclonedx" {
+            "sindri.bom.cdx.xml"
+        } else {
+            "sindri.bom.spdx.json"
+        }
     });
 
     match std::fs::write(output_path, &sbom) {
@@ -86,20 +99,24 @@ fn emit_spdx(lockfile: &Lockfile) -> String {
 }
 
 fn emit_cyclonedx(lockfile: &Lockfile) -> String {
-    let components: Vec<String> = lockfile.components.iter().map(|c| {
-        format!(
-            r#"    <component type="library">
+    let components: Vec<String> = lockfile
+        .components
+        .iter()
+        .map(|c| {
+            format!(
+                r#"    <component type="library">
       <name>{}</name>
       <version>{}</version>
       <purl>pkg:{}/{}@{}</purl>
     </component>"#,
-            xml_escape(&c.id.name),
-            xml_escape(&c.version.0),
-            xml_escape(c.id.backend.as_str()),
-            xml_escape(&c.id.name),
-            xml_escape(&c.version.0),
-        )
-    }).collect();
+                xml_escape(&c.id.name),
+                xml_escape(&c.version.0),
+                xml_escape(c.id.backend.as_str()),
+                xml_escape(&c.id.name),
+                xml_escape(&c.version.0),
+            )
+        })
+        .collect();
 
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -122,7 +139,7 @@ fn emit_cyclonedx(lockfile: &Lockfile) -> String {
 
 fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;")
-     .replace('<', "&lt;")
-     .replace('>', "&gt;")
-     .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }

--- a/v4/crates/sindri/src/commands/diff.rs
+++ b/v4/crates/sindri/src/commands/diff.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
-use sindri_core::exit_codes::{EXIT_STALE_LOCKFILE, EXIT_SUCCESS, EXIT_ERROR};
+use sindri_core::exit_codes::{EXIT_ERROR, EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
 use sindri_core::lockfile::Lockfile;
+use std::path::PathBuf;
 
 pub struct DiffArgs {
     pub target: String,
@@ -18,7 +18,10 @@ pub fn run(args: DiffArgs) -> i32 {
         if args.json {
             eprintln!(r#"{{"error":"STALE_LOCKFILE"}}"#);
         } else {
-            eprintln!("Lockfile '{}' not found. Run `sindri resolve` first.", lock_name);
+            eprintln!(
+                "Lockfile '{}' not found. Run `sindri resolve` first.",
+                lock_name
+            );
         }
         return EXIT_STALE_LOCKFILE;
     }
@@ -60,7 +63,8 @@ pub fn run(args: DiffArgs) -> i32 {
             // Sprint 7: mark all as "+" (unknown installed state)
             println!(
                 "  ? {} {} (not tracked — run sindri apply to reconcile)",
-                comp.id.to_address(), comp.version
+                comp.id.to_address(),
+                comp.version
             );
         }
     } else {

--- a/v4/crates/sindri/src/commands/doctor.rs
+++ b/v4/crates/sindri/src/commands/doctor.rs
@@ -1,7 +1,7 @@
 /// Full doctor implementation (Sprint 12)
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
-use sindri_targets::LocalTarget;
 use sindri_targets::traits::Target;
+use sindri_targets::LocalTarget;
 
 pub struct DoctorArgs {
     pub target: Option<String>,
@@ -44,7 +44,9 @@ pub fn run(args: DoctorArgs) -> i32 {
         .join("cache")
         .join("registries");
     if cache_dir.exists() {
-        let count = std::fs::read_dir(&cache_dir).map(|d| d.count()).unwrap_or(0);
+        let count = std::fs::read_dir(&cache_dir)
+            .map(|d| d.count())
+            .unwrap_or(0);
         if count > 0 {
             println!("  [OK]   {} registry/registries cached", count);
         } else {
@@ -68,8 +70,11 @@ pub fn run(args: DoctorArgs) -> i32 {
     // 5. Mise availability
     println!("\nBackend availability:");
     for (backend, binary) in &[
-        ("mise", "mise"), ("npm", "npm"), ("brew", "brew"),
-        ("docker", "docker"), ("git", "git"),
+        ("mise", "mise"),
+        ("npm", "npm"),
+        ("brew", "brew"),
+        ("docker", "docker"),
+        ("git", "git"),
     ] {
         if which(binary).is_some() {
             println!("  [OK]   {} ({})", backend, binary);
@@ -91,7 +96,11 @@ fn which(name: &str) -> Option<std::path::PathBuf> {
     std::env::var_os("PATH").and_then(|paths| {
         std::env::split_paths(&paths).find_map(|d| {
             let c = d.join(name);
-            if c.is_file() { Some(c) } else { None }
+            if c.is_file() {
+                Some(c)
+            } else {
+                None
+            }
         })
     })
 }

--- a/v4/crates/sindri/src/commands/graph.rs
+++ b/v4/crates/sindri/src/commands/graph.rs
@@ -1,6 +1,6 @@
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_core::registry::ComponentEntry;
-use sindri_discovery::{render_tree, render_mermaid, explain_path, render_explain};
+use sindri_discovery::{explain_path, render_explain, render_mermaid, render_tree};
 use std::collections::HashMap;
 
 pub struct GraphArgs {
@@ -42,10 +42,7 @@ pub fn run_graph(args: GraphArgs) -> i32 {
 pub fn run_explain(args: ExplainArgs) -> i32 {
     let registry = load_registry();
 
-    let root = args
-        .in_collection
-        .as_deref()
-        .unwrap_or(&args.component);
+    let root = args.in_collection.as_deref().unwrap_or(&args.component);
 
     match explain_path(&args.component, root, &registry) {
         Some(path) => {
@@ -53,10 +50,7 @@ pub fn run_explain(args: ExplainArgs) -> i32 {
             EXIT_SUCCESS
         }
         None => {
-            eprintln!(
-                "No dependency path from '{}' to '{}'",
-                root, args.component
-            );
+            eprintln!("No dependency path from '{}' to '{}'", root, args.component);
             EXIT_SCHEMA_OR_RESOLVE_ERROR
         }
     }
@@ -70,12 +64,23 @@ fn load_registry() -> HashMap<String, ComponentEntry> {
         .join("registries");
 
     let mut map = HashMap::new();
-    let entries = match std::fs::read_dir(&cache_root) { Ok(e) => e, Err(_) => return map };
+    let entries = match std::fs::read_dir(&cache_root) {
+        Ok(e) => e,
+        Err(_) => return map,
+    };
     for entry in entries.flatten() {
         let index_path = entry.path().join("index.yaml");
-        if !index_path.exists() { continue; }
-        let content = match std::fs::read_to_string(&index_path) { Ok(c) => c, Err(_) => continue };
-        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) { Ok(i) => i, Err(_) => continue };
+        if !index_path.exists() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&index_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
         for comp in index.components {
             map.insert(format!("{}:{}", comp.backend, comp.name), comp);
         }

--- a/v4/crates/sindri/src/commands/init.rs
+++ b/v4/crates/sindri/src/commands/init.rs
@@ -1,6 +1,6 @@
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use std::fs;
 use std::path::Path;
-use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 
 pub struct InitArgs {
     pub template: Option<String>,

--- a/v4/crates/sindri/src/commands/log.rs
+++ b/v4/crates/sindri/src/commands/log.rs
@@ -1,7 +1,7 @@
 /// StatusLedger — sindri log / sindri ledger (Sprint 12, ADR-007)
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use std::path::PathBuf;
-use sindri_core::exit_codes::{EXIT_SUCCESS, EXIT_SCHEMA_OR_RESOLVE_ERROR};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LedgerEvent {
@@ -27,7 +27,10 @@ pub fn append_event(event: &LedgerEvent) -> Result<(), std::io::Error> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let mut f = std::fs::OpenOptions::new().create(true).append(true).open(&path)?;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
     writeln!(f, "{}", serde_json::to_string(event).unwrap_or_default())
 }
 
@@ -45,7 +48,10 @@ pub fn run_log(args: LogArgs) -> i32 {
 
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(e) => { eprintln!("Cannot read ledger: {}", e); return EXIT_SCHEMA_OR_RESOLVE_ERROR; }
+        Err(e) => {
+            eprintln!("Cannot read ledger: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
     };
 
     let mut events: Vec<LedgerEvent> = content
@@ -64,7 +70,10 @@ pub fn run_log(args: LogArgs) -> i32 {
     }
 
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&events).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&events).unwrap_or_default()
+        );
     } else {
         for e in &events {
             let status = if e.success { "OK" } else { "FAIL" };

--- a/v4/crates/sindri/src/commands/ls.rs
+++ b/v4/crates/sindri/src/commands/ls.rs
@@ -16,7 +16,9 @@ pub fn run(args: LsArgs) -> i32 {
 
     if !cache_dir.exists() {
         if args.json {
-            println!(r#"{{"components":[],"hint":"Run sindri registry refresh <name> <url> first"}}"#);
+            println!(
+                r#"{{"components":[],"hint":"Run sindri registry refresh <name> <url> first"}}"#
+            );
         } else {
             eprintln!("No registry cache found. Run `sindri registry refresh <name> <url>` first.");
         }
@@ -77,15 +79,26 @@ pub fn run(args: LsArgs) -> i32 {
             );
         } else {
             println!("\nRegistry: {}", registry_name);
-            println!("{:<30} {:<12} {:<12} KIND", "COMPONENT", "BACKEND", "LATEST");
+            println!(
+                "{:<30} {:<12} {:<12} KIND",
+                "COMPONENT", "BACKEND", "LATEST"
+            );
             println!("{}", "-".repeat(70));
             for comp in components {
                 let name = comp.get("name").and_then(|v| v.as_str()).unwrap_or("?");
                 let backend = comp.get("backend").and_then(|v| v.as_str()).unwrap_or("?");
                 let latest = comp.get("latest").and_then(|v| v.as_str()).unwrap_or("?");
-                let kind = comp.get("kind").and_then(|v| v.as_str()).unwrap_or("component");
+                let kind = comp
+                    .get("kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("component");
 
-                if args.backend.as_deref().map(|b| b == backend).unwrap_or(true) {
+                if args
+                    .backend
+                    .as_deref()
+                    .map(|b| b == backend)
+                    .unwrap_or(true)
+                {
                     println!("{:<30} {:<12} {:<12} {}", name, backend, latest, kind);
                 }
             }

--- a/v4/crates/sindri/src/commands/manifest.rs
+++ b/v4/crates/sindri/src/commands/manifest.rs
@@ -1,19 +1,18 @@
 //! Shared helpers for reading/modifying sindri.yaml
 
-use std::fs;
 use sindri_core::manifest::BomManifest;
+use std::fs;
 
 pub fn load_manifest(path: &str) -> Result<(BomManifest, String), String> {
-    let content = fs::read_to_string(path)
-        .map_err(|e| format!("Cannot read {}: {}", path, e))?;
+    let content = fs::read_to_string(path).map_err(|e| format!("Cannot read {}: {}", path, e))?;
     let manifest = serde_yaml::from_str::<BomManifest>(&content)
         .map_err(|e| format!("Parse error in {}: {}", path, e))?;
     Ok((manifest, content))
 }
 
 pub fn save_manifest(path: &str, manifest: &BomManifest) -> Result<(), String> {
-    let yaml = serde_yaml::to_string(manifest)
-        .map_err(|e| format!("Serialization error: {}", e))?;
+    let yaml =
+        serde_yaml::to_string(manifest).map_err(|e| format!("Serialization error: {}", e))?;
 
     // Preserve the YAML-LSP pragma if the original had one
     let existing = fs::read_to_string(path).unwrap_or_default();
@@ -32,10 +31,7 @@ pub fn save_manifest(path: &str, manifest: &BomManifest) -> Result<(), String> {
 }
 
 fn extract_pragma(content: &str) -> String {
-    let lines: Vec<&str> = content
-        .lines()
-        .take_while(|l| l.starts_with('#'))
-        .collect();
+    let lines: Vec<&str> = content.lines().take_while(|l| l.starts_with('#')).collect();
     if lines.is_empty() {
         String::new()
     } else {

--- a/v4/crates/sindri/src/commands/mod.rs
+++ b/v4/crates/sindri/src/commands/mod.rs
@@ -1,11 +1,11 @@
 pub mod add;
 pub mod apply;
 pub mod bom;
-pub mod doctor;
-pub mod log;
 pub mod diff;
+pub mod doctor;
 pub mod graph;
 pub mod init;
+pub mod log;
 pub mod ls;
 pub mod manifest;
 pub mod pin;

--- a/v4/crates/sindri/src/commands/pin.rs
+++ b/v4/crates/sindri/src/commands/pin.rs
@@ -1,5 +1,5 @@
+use crate::commands::manifest::{find_entry_index, load_manifest, save_manifest};
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
-use crate::commands::manifest::{load_manifest, save_manifest, find_entry_index};
 
 pub struct PinArgs {
     pub address: String,
@@ -30,7 +30,8 @@ pub fn run_pin(args: PinArgs) -> i32 {
     };
 
     // Set exact version via @version suffix in address
-    let clean = crate::commands::manifest::address_without_version(&manifest.components[idx].address);
+    let clean =
+        crate::commands::manifest::address_without_version(&manifest.components[idx].address);
     manifest.components[idx].address = format!("{}@{}", clean, args.version);
 
     match save_manifest(&args.manifest, &manifest) {
@@ -63,7 +64,8 @@ pub fn run_unpin(args: UnpinArgs) -> i32 {
     };
 
     // Remove @version suffix
-    let clean = crate::commands::manifest::address_without_version(&manifest.components[idx].address);
+    let clean =
+        crate::commands::manifest::address_without_version(&manifest.components[idx].address);
     manifest.components[idx].address = clean.clone();
 
     match save_manifest(&args.manifest, &manifest) {

--- a/v4/crates/sindri/src/commands/plan.rs
+++ b/v4/crates/sindri/src/commands/plan.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
 use sindri_core::exit_codes::{EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
 use sindri_core::lockfile::Lockfile;
+use std::path::PathBuf;
 
 pub struct PlanArgs {
     pub target: String,
@@ -19,7 +19,10 @@ pub fn run(args: PlanArgs) -> i32 {
         if args.json {
             eprintln!(r#"{{"error":"STALE_LOCKFILE","fix":"Run sindri resolve"}}"#);
         } else {
-            eprintln!("Lockfile '{}' not found. Run `sindri resolve` first.", lock_name);
+            eprintln!(
+                "Lockfile '{}' not found. Run `sindri resolve` first.",
+                lock_name
+            );
         }
         return EXIT_STALE_LOCKFILE;
     }
@@ -64,9 +67,18 @@ pub fn run(args: PlanArgs) -> i32 {
             .unwrap_or_default()
         );
     } else {
-        println!("Plan for target '{}' ({} component(s)):", lockfile.target, lockfile.components.len());
+        println!(
+            "Plan for target '{}' ({} component(s)):",
+            lockfile.target,
+            lockfile.components.len()
+        );
         for comp in &lockfile.components {
-            println!("  + {} {} ({})", comp.id.to_address(), comp.version, comp.backend.as_str());
+            println!(
+                "  + {} {} ({})",
+                comp.id.to_address(),
+                comp.version,
+                comp.backend.as_str()
+            );
         }
     }
 

--- a/v4/crates/sindri/src/commands/policy.rs
+++ b/v4/crates/sindri/src/commands/policy.rs
@@ -2,9 +2,14 @@ use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_core::policy::PolicyPreset;
 
 pub enum PolicyCmd {
-    Use { preset: String },
+    Use {
+        preset: String,
+    },
     Show,
-    AllowLicense { spdx: String, reason: Option<String> },
+    AllowLicense {
+        spdx: String,
+        reason: Option<String>,
+    },
 }
 
 pub fn run(cmd: PolicyCmd) -> i32 {
@@ -21,7 +26,10 @@ fn use_preset(preset: &str) -> i32 {
         "strict" => PolicyPreset::Strict,
         "offline" => PolicyPreset::Offline,
         other => {
-            eprintln!("Unknown preset '{}'. Valid presets: default, strict, offline", other);
+            eprintln!(
+                "Unknown preset '{}'. Valid presets: default, strict, offline",
+                other
+            );
             return EXIT_SCHEMA_OR_RESOLVE_ERROR;
         }
     };
@@ -44,13 +52,39 @@ fn show_policy() -> i32 {
 
     println!("Effective policy:");
     println!("  preset:                  {}", preset_name(&p.preset));
-    println!("  allowed_licenses:        {}", if p.allowed_licenses.is_empty() { "(any)".into() } else { p.allowed_licenses.join(", ") });
-    println!("  denied_licenses:         {}", if p.denied_licenses.is_empty() { "(none)".into() } else { p.denied_licenses.join(", ") });
+    println!(
+        "  allowed_licenses:        {}",
+        if p.allowed_licenses.is_empty() {
+            "(any)".into()
+        } else {
+            p.allowed_licenses.join(", ")
+        }
+    );
+    println!(
+        "  denied_licenses:         {}",
+        if p.denied_licenses.is_empty() {
+            "(none)".into()
+        } else {
+            p.denied_licenses.join(", ")
+        }
+    );
     println!("  on_unknown_license:      {:?}", p.on_unknown_license);
-    println!("  require_signed_registries: {}", p.require_signed_registries.unwrap_or(false));
-    println!("  require_checksums:       {}", p.require_checksums.unwrap_or(false));
+    println!(
+        "  require_signed_registries: {}",
+        p.require_signed_registries.unwrap_or(false)
+    );
+    println!(
+        "  require_checksums:       {}",
+        p.require_checksums.unwrap_or(false)
+    );
     println!("  offline:                 {}", p.offline.unwrap_or(false));
-    println!("  audit.require_justification: {}", p.audit.as_ref().map(|a| a.require_justification).unwrap_or(false));
+    println!(
+        "  audit.require_justification: {}",
+        p.audit
+            .as_ref()
+            .map(|a| a.require_justification)
+            .unwrap_or(false)
+    );
 
     if !effective.sources.is_empty() {
         println!("\nSources:");

--- a/v4/crates/sindri/src/commands/registry.rs
+++ b/v4/crates/sindri/src/commands/registry.rs
@@ -1,5 +1,5 @@
-use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_core::component::ComponentManifest;
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 
 pub enum RegistryCmd {
     Refresh { name: String, url: String },
@@ -52,7 +52,10 @@ fn refresh(name: &str, url: &str) -> i32 {
             EXIT_SCHEMA_OR_RESOLVE_ERROR
         }
         Err(e) => {
-            eprintln!("curl not available: {}. Install curl to fetch registries.", e);
+            eprintln!(
+                "curl not available: {}. Install curl to fetch registries.",
+                e
+            );
             EXIT_SCHEMA_OR_RESOLVE_ERROR
         }
     }
@@ -123,7 +126,11 @@ fn lint_file(p: &std::path::Path, json: bool) -> i32 {
         Ok(m) => m,
         Err(e) => {
             if json {
-                eprintln!(r#"{{"error":"PARSE_ERROR","path":"{}","detail":"{}"}}"#, p.display(), e);
+                eprintln!(
+                    r#"{{"error":"PARSE_ERROR","path":"{}","detail":"{}"}}"#,
+                    p.display(),
+                    e
+                );
             } else {
                 eprintln!("{}: FAILED (parse error: {})", p.display(), e);
             }
@@ -137,9 +144,17 @@ fn lint_file(p: &std::path::Path, json: bool) -> i32 {
         errors.push("LINT_EMPTY_PLATFORMS: `platforms` must not be empty".into());
     }
     if manifest.metadata.license.trim().is_empty() {
-        errors.push("LINT_MISSING_LICENSE: `metadata.license` must be a valid SPDX identifier".into());
+        errors.push(
+            "LINT_MISSING_LICENSE: `metadata.license` must be a valid SPDX identifier".into(),
+        );
     }
-    if manifest.install.binary.as_ref().map(|b| b.checksums.is_empty()).unwrap_or(false) {
+    if manifest
+        .install
+        .binary
+        .as_ref()
+        .map(|b| b.checksums.is_empty())
+        .unwrap_or(false)
+    {
         errors.push("LINT_MISSING_CHECKSUMS: `binary` components must have `checksums`".into());
     }
     if let Some(cap) = &manifest.capabilities.collision_handling {
@@ -161,12 +176,16 @@ fn lint_file(p: &std::path::Path, json: bool) -> i32 {
         EXIT_SUCCESS
     } else {
         if json {
-            let errs: Vec<serde_json::Value> =
-                errors.iter().map(|e| serde_json::json!({"error": e})).collect();
+            let errs: Vec<serde_json::Value> = errors
+                .iter()
+                .map(|e| serde_json::json!({"error": e}))
+                .collect();
             println!(
                 "{}",
-                serde_json::to_string(&serde_json::json!({"valid":false,"path":p.display().to_string(),"errors":errs}))
-                    .unwrap_or_default()
+                serde_json::to_string(
+                    &serde_json::json!({"valid":false,"path":p.display().to_string(),"errors":errs})
+                )
+                .unwrap_or_default()
             );
         } else {
             eprintln!("{}: FAILED", p.display());
@@ -197,7 +216,11 @@ fn lint_dir(dir: &std::path::Path, json: bool) -> i32 {
         }
     }
 
-    if any_failed { EXIT_SCHEMA_OR_RESOLVE_ERROR } else { EXIT_SUCCESS }
+    if any_failed {
+        EXIT_SCHEMA_OR_RESOLVE_ERROR
+    } else {
+        EXIT_SUCCESS
+    }
 }
 
 fn trust(name: &str, signer: &str) -> i32 {
@@ -233,7 +256,10 @@ fn trust(name: &str, signer: &str) -> i32 {
 fn fetch_checksums(path: &str) -> i32 {
     // Sprint 2: stub — downloads assets and computes sha256
     // Full implementation uses sha2 crate + reqwest
-    println!("fetch-checksums for {}: stub (Sprint 2 — full download in Sprint 6)", path);
+    println!(
+        "fetch-checksums for {}: stub (Sprint 2 — full download in Sprint 6)",
+        path
+    );
     EXIT_SUCCESS
 }
 

--- a/v4/crates/sindri/src/commands/remove.rs
+++ b/v4/crates/sindri/src/commands/remove.rs
@@ -1,5 +1,5 @@
+use crate::commands::manifest::{find_entry_index, load_manifest, save_manifest};
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
-use crate::commands::manifest::{load_manifest, save_manifest, find_entry_index};
 
 pub struct RemoveArgs {
     pub address: String,
@@ -25,7 +25,8 @@ pub fn run(args: RemoveArgs) -> i32 {
 
     // Check if other components depend on this one
     let addr_clean = crate::commands::manifest::address_without_version(&args.address);
-    let dependents: Vec<String> = manifest.components
+    let dependents: Vec<String> = manifest
+        .components
         .iter()
         .enumerate()
         .filter(|(i, _)| *i != idx)

--- a/v4/crates/sindri/src/commands/resolve.rs
+++ b/v4/crates/sindri/src/commands/resolve.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_core::platform::Platform;
 use sindri_core::policy::InstallPolicy;
 use sindri_core::registry::ComponentEntry;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 pub struct ResolveArgs {
     pub manifest: String,
@@ -19,7 +19,10 @@ pub fn run(args: ResolveArgs) -> i32 {
     let manifest_path = PathBuf::from(&args.manifest);
     if !manifest_path.exists() {
         if args.json {
-            eprintln!(r#"{{"error":"FILE_NOT_FOUND","path":"{}","fix":"Create sindri.yaml or run sindri init"}}"#, args.manifest);
+            eprintln!(
+                r#"{{"error":"FILE_NOT_FOUND","path":"{}","fix":"Create sindri.yaml or run sindri init"}}"#,
+                args.manifest
+            );
         } else {
             eprintln!("Manifest not found: {}", args.manifest);
             eprintln!("Hint: run `sindri init` to create a sindri.yaml");
@@ -33,7 +36,10 @@ pub fn run(args: ResolveArgs) -> i32 {
     } else {
         format!("sindri.{}.lock", args.target)
     };
-    let lockfile_path = manifest_path.parent().unwrap_or(Path::new(".")).join(&lock_name);
+    let lockfile_path = manifest_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join(&lock_name);
 
     // Load registry from cache
     let registry = load_registry_from_cache();
@@ -82,7 +88,12 @@ pub fn run(args: ResolveArgs) -> i32 {
                     lockfile_path.display()
                 );
                 for c in &lockfile.components {
-                    println!("  {} {} ({})", c.id.to_address(), c.version, c.backend.as_str());
+                    println!(
+                        "  {} {} ({})",
+                        c.id.to_address(),
+                        c.version,
+                        c.backend.as_str()
+                    );
                 }
             }
             EXIT_SUCCESS

--- a/v4/crates/sindri/src/commands/search.rs
+++ b/v4/crates/sindri/src/commands/search.rs
@@ -1,6 +1,6 @@
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_core::registry::ComponentEntry;
-use sindri_discovery::{SearchFilters, search};
+use sindri_discovery::{search, SearchFilters};
 use std::collections::HashMap;
 
 pub struct SearchArgs {
@@ -47,14 +47,23 @@ pub fn run(args: SearchArgs) -> i32 {
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&serde_json::json!({"results": items})).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({"results": items}))
+                .unwrap_or_default()
+        );
     } else {
-        println!("{:<30} {:<12} {:<12} DESCRIPTION", "COMPONENT", "BACKEND", "LATEST");
+        println!(
+            "{:<30} {:<12} {:<12} DESCRIPTION",
+            "COMPONENT", "BACKEND", "LATEST"
+        );
         println!("{}", "-".repeat(80));
         for r in &results {
             println!(
                 "{:<30} {:<12} {:<12} {}",
-                r.entry.name, r.entry.backend, r.entry.latest,
+                r.entry.name,
+                r.entry.backend,
+                r.entry.latest,
                 r.entry.description.chars().take(35).collect::<String>()
             );
         }
@@ -71,15 +80,28 @@ fn load_registry(registry_filter: Option<&str>) -> HashMap<String, ComponentEntr
         .join("registries");
 
     let mut map = HashMap::new();
-    let entries = match std::fs::read_dir(&cache_root) { Ok(e) => e, Err(_) => return map };
+    let entries = match std::fs::read_dir(&cache_root) {
+        Ok(e) => e,
+        Err(_) => return map,
+    };
 
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if registry_filter.map(|f| f != name).unwrap_or(false) { continue; }
+        if registry_filter.map(|f| f != name).unwrap_or(false) {
+            continue;
+        }
         let index_path = entry.path().join("index.yaml");
-        if !index_path.exists() { continue; }
-        let content = match std::fs::read_to_string(&index_path) { Ok(c) => c, Err(_) => continue };
-        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) { Ok(i) => i, Err(_) => continue };
+        if !index_path.exists() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&index_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
         for comp in index.components {
             map.insert(format!("{}:{}", comp.backend, comp.name), comp);
         }

--- a/v4/crates/sindri/src/commands/show.rs
+++ b/v4/crates/sindri/src/commands/show.rs
@@ -29,23 +29,34 @@ pub fn run(args: ShowArgs) -> i32 {
     };
 
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
-            "name": entry.name,
-            "backend": entry.backend,
-            "latest": entry.latest,
-            "versions": entry.versions,
-            "description": entry.description,
-            "license": entry.license,
-            "depends_on": entry.depends_on,
-            "kind": format!("{:?}", entry.kind),
-            "oci_ref": entry.oci_ref,
-        })).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "name": entry.name,
+                "backend": entry.backend,
+                "latest": entry.latest,
+                "versions": entry.versions,
+                "description": entry.description,
+                "license": entry.license,
+                "depends_on": entry.depends_on,
+                "kind": format!("{:?}", entry.kind),
+                "oci_ref": entry.oci_ref,
+            }))
+            .unwrap_or_default()
+        );
         return EXIT_SUCCESS;
     }
 
     println!("{}:{}", entry.backend, entry.name);
     println!("  Description: {}", entry.description);
-    println!("  License:     {}", if entry.license.is_empty() { "(unspecified)" } else { &entry.license });
+    println!(
+        "  License:     {}",
+        if entry.license.is_empty() {
+            "(unspecified)"
+        } else {
+            &entry.license
+        }
+    );
     println!("  Latest:      {}", entry.latest);
     if args.versions {
         println!("  Versions:    {}", entry.versions.join(", "));
@@ -66,12 +77,23 @@ fn load_registry() -> HashMap<String, ComponentEntry> {
         .join("registries");
 
     let mut map = HashMap::new();
-    let entries = match std::fs::read_dir(&cache_root) { Ok(e) => e, Err(_) => return map };
+    let entries = match std::fs::read_dir(&cache_root) {
+        Ok(e) => e,
+        Err(_) => return map,
+    };
     for entry in entries.flatten() {
         let index_path = entry.path().join("index.yaml");
-        if !index_path.exists() { continue; }
-        let content = match std::fs::read_to_string(&index_path) { Ok(c) => c, Err(_) => continue };
-        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) { Ok(i) => i, Err(_) => continue };
+        if !index_path.exists() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&index_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
         for comp in index.components {
             map.insert(format!("{}:{}", comp.backend, comp.name), comp);
         }

--- a/v4/crates/sindri/src/commands/target.rs
+++ b/v4/crates/sindri/src/commands/target.rs
@@ -1,14 +1,28 @@
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
-use sindri_targets::{LocalTarget, DockerTarget, Target};
+use sindri_targets::{DockerTarget, LocalTarget, Target};
 
 pub enum TargetCmd {
-    Add { name: String, kind: String, opts: Vec<(String, String)> },
+    Add {
+        name: String,
+        kind: String,
+        opts: Vec<(String, String)>,
+    },
     Ls,
-    Status { name: String },
-    Create { name: String },
-    Destroy { name: String },
-    Doctor { name: Option<String> },
-    Shell { name: String },
+    Status {
+        name: String,
+    },
+    Create {
+        name: String,
+    },
+    Destroy {
+        name: String,
+    },
+    Doctor {
+        name: Option<String>,
+    },
+    Shell {
+        name: String,
+    },
 }
 
 pub fn run(cmd: TargetCmd) -> i32 {
@@ -26,7 +40,10 @@ pub fn run(cmd: TargetCmd) -> i32 {
 fn add_target(name: &str, kind: &str, _opts: &[(String, String)]) -> i32 {
     // Sprint 9: write to sindri.yaml targets: section
     // Full implementation requires manifest read/write
-    println!("Target '{}' (kind: {}) added — update sindri.yaml targets: section manually for now", name, kind);
+    println!(
+        "Target '{}' (kind: {}) added — update sindri.yaml targets: section manually for now",
+        name, kind
+    );
     EXIT_SUCCESS
 }
 
@@ -45,7 +62,13 @@ fn status_target(name: &str) -> i32 {
             Ok(p) => {
                 println!("Target: local");
                 println!("  Platform: {}", p.platform.triple());
-                println!("  System PM: {}", p.capabilities.system_package_manager.as_deref().unwrap_or("none"));
+                println!(
+                    "  System PM: {}",
+                    p.capabilities
+                        .system_package_manager
+                        .as_deref()
+                        .unwrap_or("none")
+                );
                 println!("  Docker: {}", p.capabilities.has_docker);
             }
             Err(e) => eprintln!("Error: {}", e),
@@ -124,9 +147,16 @@ fn shell(name: &str) -> i32 {
         let status = std::process::Command::new(&shell)
             .status()
             .unwrap_or_else(|_| std::process::exit(1));
-        if status.success() { EXIT_SUCCESS } else { EXIT_SCHEMA_OR_RESOLVE_ERROR }
+        if status.success() {
+            EXIT_SUCCESS
+        } else {
+            EXIT_SCHEMA_OR_RESOLVE_ERROR
+        }
     } else {
-        eprintln!("Interactive shell for target '{}': sprint 10 (cloud targets)", name);
+        eprintln!(
+            "Interactive shell for target '{}': sprint 10 (cloud targets)",
+            name
+        );
         EXIT_SCHEMA_OR_RESOLVE_ERROR
     }
 }

--- a/v4/crates/sindri/src/commands/upgrade.rs
+++ b/v4/crates/sindri/src/commands/upgrade.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
+use crate::commands::manifest::{
+    address_without_version, find_entry_index, load_manifest, save_manifest,
+};
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_core::registry::ComponentEntry;
-use crate::commands::manifest::{load_manifest, save_manifest, find_entry_index, address_without_version};
+use std::collections::HashMap;
 
 pub struct UpgradeArgs {
     pub component: Option<String>,
@@ -37,7 +39,10 @@ pub fn run(args: UpgradeArgs) -> i32 {
     EXIT_SCHEMA_OR_RESOLVE_ERROR
 }
 
-fn check_upgrades(manifest: &sindri_core::manifest::BomManifest, registry: &HashMap<String, ComponentEntry>) -> i32 {
+fn check_upgrades(
+    manifest: &sindri_core::manifest::BomManifest,
+    registry: &HashMap<String, ComponentEntry>,
+) -> i32 {
     let mut upgradeable = 0;
     for comp in &manifest.components {
         let clean = address_without_version(&comp.address);
@@ -118,7 +123,10 @@ fn upgrade_all(
 
     match save_manifest(manifest_path, manifest) {
         Ok(_) => {
-            println!("Upgraded {} component(s). Run `sindri resolve` to update the lockfile.", upgraded);
+            println!(
+                "Upgraded {} component(s). Run `sindri resolve` to update the lockfile.",
+                upgraded
+            );
             EXIT_SUCCESS
         }
         Err(e) => {
@@ -143,9 +151,17 @@ fn load_registry_from_cache() -> HashMap<String, ComponentEntry> {
 
     for entry in entries.flatten() {
         let index_path = entry.path().join("index.yaml");
-        if !index_path.exists() { continue; }
-        let content = match std::fs::read_to_string(&index_path) { Ok(c) => c, Err(_) => continue };
-        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) { Ok(i) => i, Err(_) => continue };
+        if !index_path.exists() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&index_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let index: sindri_core::registry::RegistryIndex = match serde_yaml::from_str(&content) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
         for comp in index.components {
             let addr = format!("{}:{}", comp.backend, comp.name);
             map.insert(addr, comp);

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -266,11 +266,21 @@ fn main() {
     let cli = Cli::parse();
     let code = match cli.command {
         Some(Commands::Validate { path, json, .. }) => validate::run(&path, json),
-        Some(Commands::Ls { registry, backend, installed, outdated, json, refresh }) => {
-            commands::ls::run(commands::ls::LsArgs {
-                registry, backend, installed, outdated, json, refresh,
-            })
-        }
+        Some(Commands::Ls {
+            registry,
+            backend,
+            installed,
+            outdated,
+            json,
+            refresh,
+        }) => commands::ls::run(commands::ls::LsArgs {
+            registry,
+            backend,
+            installed,
+            outdated,
+            json,
+            refresh,
+        }),
         Some(Commands::Registry { cmd }) => {
             let registry_cmd = match cmd {
                 RegistrySubcmds::Refresh { name, url } => RegistryCmd::Refresh { name, url },
@@ -280,29 +290,50 @@ fn main() {
             };
             commands::registry::run(registry_cmd)
         }
-        Some(Commands::Resolve { manifest, offline, refresh, strict, explain, target }) => {
-            commands::resolve::run(commands::resolve::ResolveArgs {
-                manifest,
-                offline,
-                refresh,
-                strict,
-                explain,
-                target,
-                json: false,
-            })
-        }
-        Some(Commands::Bom { format, target, output }) => {
-            commands::bom::run(commands::bom::BomArgs { format, target, output })
-        }
+        Some(Commands::Resolve {
+            manifest,
+            offline,
+            refresh,
+            strict,
+            explain,
+            target,
+        }) => commands::resolve::run(commands::resolve::ResolveArgs {
+            manifest,
+            offline,
+            refresh,
+            strict,
+            explain,
+            target,
+            json: false,
+        }),
+        Some(Commands::Bom {
+            format,
+            target,
+            output,
+        }) => commands::bom::run(commands::bom::BomArgs {
+            format,
+            target,
+            output,
+        }),
         Some(Commands::Log { last, json }) => {
             commands::log::run_log(commands::log::LogArgs { last, json })
         }
-        Some(Commands::Doctor { target, fix, components }) => {
-            commands::doctor::run(commands::doctor::DoctorArgs { target, fix, components })
-        }
+        Some(Commands::Doctor {
+            target,
+            fix,
+            components,
+        }) => commands::doctor::run(commands::doctor::DoctorArgs {
+            target,
+            fix,
+            components,
+        }),
         Some(Commands::Target { cmd }) => {
             let tc = match cmd {
-                TargetSubcmds::Add { name, kind } => TargetCmd::Add { name, kind, opts: Vec::new() },
+                TargetSubcmds::Add { name, kind } => TargetCmd::Add {
+                    name,
+                    kind,
+                    opts: Vec::new(),
+                },
                 TargetSubcmds::Ls => TargetCmd::Ls,
                 TargetSubcmds::Status { name } => TargetCmd::Status { name },
                 TargetSubcmds::Create { name } => TargetCmd::Create { name },
@@ -316,49 +347,113 @@ fn main() {
             let policy_cmd = match cmd {
                 PolicySubcmds::Use { preset } => PolicyCmd::Use { preset },
                 PolicySubcmds::Show => PolicyCmd::Show,
-                PolicySubcmds::AllowLicense { spdx, reason } => PolicyCmd::AllowLicense { spdx, reason },
+                PolicySubcmds::AllowLicense { spdx, reason } => {
+                    PolicyCmd::AllowLicense { spdx, reason }
+                }
             };
             commands::policy::run(policy_cmd)
         }
-        Some(Commands::Init { template, name, policy, non_interactive, force }) => {
-            commands::init::run(commands::init::InitArgs { template, name, policy, non_interactive, force })
-        }
-        Some(Commands::Add { address, manifest, dry_run, apply }) => {
-            commands::add::run(commands::add::AddArgs { address, dry_run, apply, manifest })
-        }
+        Some(Commands::Init {
+            template,
+            name,
+            policy,
+            non_interactive,
+            force,
+        }) => commands::init::run(commands::init::InitArgs {
+            template,
+            name,
+            policy,
+            non_interactive,
+            force,
+        }),
+        Some(Commands::Add {
+            address,
+            manifest,
+            dry_run,
+            apply,
+        }) => commands::add::run(commands::add::AddArgs {
+            address,
+            dry_run,
+            apply,
+            manifest,
+        }),
         Some(Commands::Remove { address, manifest }) => {
             commands::remove::run(commands::remove::RemoveArgs { address, manifest })
         }
-        Some(Commands::Pin { address, version, manifest }) => {
-            commands::pin::run_pin(commands::pin::PinArgs { address, version, manifest })
-        }
+        Some(Commands::Pin {
+            address,
+            version,
+            manifest,
+        }) => commands::pin::run_pin(commands::pin::PinArgs {
+            address,
+            version,
+            manifest,
+        }),
         Some(Commands::Unpin { address, manifest }) => {
             commands::pin::run_unpin(commands::pin::UnpinArgs { address, manifest })
         }
-        Some(Commands::Upgrade { component, all, check, manifest }) => {
-            commands::upgrade::run(commands::upgrade::UpgradeArgs { component, all, check, manifest })
-        }
+        Some(Commands::Upgrade {
+            component,
+            all,
+            check,
+            manifest,
+        }) => commands::upgrade::run(commands::upgrade::UpgradeArgs {
+            component,
+            all,
+            check,
+            manifest,
+        }),
         Some(Commands::Plan { target, json }) => {
             commands::plan::run(commands::plan::PlanArgs { target, json })
         }
         Some(Commands::Diff { target, json }) => {
             commands::diff::run(commands::diff::DiffArgs { target, json })
         }
-        Some(Commands::Search { query, registry, backend, json }) => {
-            commands::search::run(commands::search::SearchArgs { query, registry, backend, json })
-        }
-        Some(Commands::Show { address, versions, json }) => {
-            commands::show::run(commands::show::ShowArgs { address, versions, json })
-        }
-        Some(Commands::Graph { address, format, reverse }) => {
-            commands::graph::run_graph(commands::graph::GraphArgs { address, format, reverse })
-        }
-        Some(Commands::Explain { component, in_collection }) => {
-            commands::graph::run_explain(commands::graph::ExplainArgs { component, in_collection })
-        }
-        Some(Commands::Apply { yes, dry_run, target }) => {
-            commands::apply::run(commands::apply::ApplyArgs { yes, dry_run, target })
-        }
+        Some(Commands::Search {
+            query,
+            registry,
+            backend,
+            json,
+        }) => commands::search::run(commands::search::SearchArgs {
+            query,
+            registry,
+            backend,
+            json,
+        }),
+        Some(Commands::Show {
+            address,
+            versions,
+            json,
+        }) => commands::show::run(commands::show::ShowArgs {
+            address,
+            versions,
+            json,
+        }),
+        Some(Commands::Graph {
+            address,
+            format,
+            reverse,
+        }) => commands::graph::run_graph(commands::graph::GraphArgs {
+            address,
+            format,
+            reverse,
+        }),
+        Some(Commands::Explain {
+            component,
+            in_collection,
+        }) => commands::graph::run_explain(commands::graph::ExplainArgs {
+            component,
+            in_collection,
+        }),
+        Some(Commands::Apply {
+            yes,
+            dry_run,
+            target,
+        }) => commands::apply::run(commands::apply::ApplyArgs {
+            yes,
+            dry_run,
+            target,
+        }),
         None => {
             use clap::CommandFactory;
             Cli::command().print_help().ok();


### PR DESCRIPTION
## Summary
Completes the formatting cleanup started in #211 (which was scoped to \`sindri-targets\` only). Sweeps the rest of the workspace.

## Why
\`cargo fmt --all --check\` was reporting drift across most v4 crates. With this PR, the whole workspace is fmt-clean and CI can enforce \`fmt --check\` as a hard gate.

## Crates touched
- \`sindri-discovery\`, \`sindri-policy\`, \`sindri-registry\`, \`sindri-resolver\`, \`sindri-extensions\`, \`sindri\`/

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` (64 tests pass)
- [x] \`cargo fmt --all --check\` clean
- [ ] CI matrix

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)