### PR TITLE
feat(v4): expand Component aggregate to DDD-01 (qualifier, options, validate/configure/remove, per-platform overrides)

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 2.0.18",
 ]
 

--- a/v4/crates/sindri-backends/src/binary.rs
+++ b/v4/crates/sindri-backends/src/binary.rs
@@ -132,6 +132,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Binary,
                 name: "ripgrep".into(),
+                qualifier: None,
             },
             version: Version::new("14.1.0"),
             backend: Backend::Binary,

--- a/v4/crates/sindri-backends/src/brew.rs
+++ b/v4/crates/sindri-backends/src/brew.rs
@@ -91,6 +91,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Brew,
                 name: "ripgrep".into(),
+                qualifier: None,
             },
             version: Version::new("14.1.0"),
             backend: Backend::Brew,

--- a/v4/crates/sindri-backends/src/cargo.rs
+++ b/v4/crates/sindri-backends/src/cargo.rs
@@ -114,6 +114,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Cargo,
                 name: "ripgrep".into(),
+                qualifier: None,
             },
             version: Version::new("14.1.0"),
             backend: Backend::Cargo,

--- a/v4/crates/sindri-backends/src/go_install.rs
+++ b/v4/crates/sindri-backends/src/go_install.rs
@@ -136,6 +136,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::GoInstall,
                 name: name.into(),
+                qualifier: None,
             },
             version: Version::new(ver),
             backend: Backend::GoInstall,

--- a/v4/crates/sindri-backends/src/mise.rs
+++ b/v4/crates/sindri-backends/src/mise.rs
@@ -55,6 +55,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Mise,
                 name: "node".into(),
+                qualifier: None,
             },
             version: Version::new("20.0.0"),
             backend: Backend::Mise,

--- a/v4/crates/sindri-backends/src/npm.rs
+++ b/v4/crates/sindri-backends/src/npm.rs
@@ -86,6 +86,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Npm,
                 name: "typescript".into(),
+                qualifier: None,
             },
             version: Version::new("5.4.0"),
             backend: Backend::Npm,

--- a/v4/crates/sindri-backends/src/pipx.rs
+++ b/v4/crates/sindri-backends/src/pipx.rs
@@ -101,6 +101,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Pipx,
                 name: "black".into(),
+                qualifier: None,
             },
             version: Version::new("24.10.0"),
             backend: Backend::Pipx,

--- a/v4/crates/sindri-backends/src/script.rs
+++ b/v4/crates/sindri-backends/src/script.rs
@@ -138,6 +138,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Script,
                 name: "tool".into(),
+                qualifier: None,
             },
             version: Version::new("1.0.0"),
             backend: Backend::Script,

--- a/v4/crates/sindri-backends/src/sdkman.rs
+++ b/v4/crates/sindri-backends/src/sdkman.rs
@@ -95,6 +95,7 @@ mod tests {
             id: ComponentId {
                 backend: Backend::Sdkman,
                 name: "java".into(),
+                qualifier: None,
             },
             version: Version::new("21.0.2-tem"),
             backend: Backend::Sdkman,

--- a/v4/crates/sindri-backends/src/system_pm.rs
+++ b/v4/crates/sindri-backends/src/system_pm.rs
@@ -139,6 +139,7 @@ mod tests {
             id: ComponentId {
                 backend: backend.clone(),
                 name: name.into(),
+                qualifier: None,
             },
             version: Version::new("1.0.0"),
             backend,

--- a/v4/crates/sindri-backends/src/winget.rs
+++ b/v4/crates/sindri-backends/src/winget.rs
@@ -114,6 +114,7 @@ mod tests {
             id: ComponentId {
                 backend: backend.clone(),
                 name: name.into(),
+                qualifier: None,
             },
             version: Version::new("1.0.0"),
             backend,

--- a/v4/crates/sindri-core/Cargo.toml
+++ b/v4/crates/sindri-core/Cargo.toml
@@ -12,3 +12,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_yaml = { workspace = true }

--- a/v4/crates/sindri-core/src/component.rs
+++ b/v4/crates/sindri-core/src/component.rs
@@ -1,6 +1,9 @@
 // ADR-002: Atomic Component replaces Extension
-// ADR-004: Backend-addressed manifest syntax
-use crate::platform::Platform;
+// ADR-004: Backend-addressed manifest syntax (`backend:name[@qualifier]`)
+// ADR-024: Script-component lifecycle contract (validate/configure/remove)
+// DDD-01: Component domain — full aggregate (id, manifest, options,
+//         install/validate/configure/remove, per-platform overrides, capabilities)
+use crate::platform::{Arch, Os, Platform};
 use crate::version::VersionSpec;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -8,23 +11,81 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 /// ADR-002: The atomic unit of v4.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+///
+/// A `ComponentId` addresses a component by backend, name, and an optional
+/// **qualifier** (ADR-004). The qualifier is *not* a version; it is an
+/// alternative-flavour selector that disambiguates two same-named packages
+/// available through the same backend (e.g. `npm:codex@openai` distinguishes
+/// the OpenAI re-publish of the `codex` npm package from the upstream).
+///
+/// The version, when relevant, is stored separately on [`BomEntry`] (or as
+/// the YAML map value in `sindri.yaml`) — never on the address itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ComponentId {
+    /// Backend that installs this component.
     pub backend: Backend,
+    /// Component name within the backend's namespace.
     pub name: String,
+    /// Optional alternative-flavour selector (ADR-004).
+    ///
+    /// Distinct from version. `npm:codex@openai` has qualifier `Some("openai")`;
+    /// the version (if any) is recorded separately on [`BomEntry`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qualifier: Option<String>,
 }
 
 impl ComponentId {
-    /// Parse `backend:name[@version]` syntax (ADR-004)
+    /// Parse a `backend:name[@qualifier]` address (ADR-004).
+    ///
+    /// Per ADR-004 the version is **not** part of the address — it is the YAML
+    /// map value. A trailing `@token` on the address is therefore always
+    /// interpreted as a qualifier.
+    ///
+    /// # Disambiguation note
+    ///
+    /// To remain compatible with informal call sites that historically wrote
+    /// `backend:name@version`, this parser does not validate that the trailing
+    /// token "looks like" a qualifier vs. a semver string — the address grammar
+    /// makes no such distinction. Callers that want to record a version should
+    /// use [`BomEntry::version`].
+    ///
+    /// Returns `None` if the input is missing the `backend:` prefix or the
+    /// backend identifier is unknown.
     pub fn parse(s: &str) -> Option<Self> {
         let (backend_str, rest) = s.split_once(':')?;
-        let name = rest.split('@').next()?.to_string();
         let backend = Backend::from_str(backend_str).ok()?;
-        Some(ComponentId { backend, name })
+        let (name, qualifier) = match rest.split_once('@') {
+            Some((n, q)) if !n.is_empty() => {
+                // If `q` itself contains another `@<version>`, keep only the
+                // first segment as the qualifier.
+                let qualifier = q.split('@').next().unwrap_or(q).to_string();
+                let qualifier = if qualifier.is_empty() {
+                    None
+                } else {
+                    Some(qualifier)
+                };
+                (n.to_string(), qualifier)
+            }
+            _ => (rest.to_string(), None),
+        };
+        if name.is_empty() {
+            return None;
+        }
+        Some(ComponentId {
+            backend,
+            name,
+            qualifier,
+        })
     }
 
+    /// Render the address back to its canonical `backend:name[@qualifier]` form.
+    ///
+    /// The version is never included — see the type docs.
     pub fn to_address(&self) -> String {
-        format!("{}:{}", self.backend.as_str(), self.name)
+        match &self.qualifier {
+            Some(q) => format!("{}:{}@{}", self.backend.as_str(), self.name, q),
+            None => format!("{}:{}", self.backend.as_str(), self.name),
+        }
     }
 }
 
@@ -108,7 +169,16 @@ impl FromStr for Backend {
     }
 }
 
-/// The v4 component manifest shape (component.yaml)
+/// The v4 component manifest shape (component.yaml).
+///
+/// Fully aligned with DDD-01: in addition to install metadata, a manifest may
+/// declare typed user-facing [`Options`], post-install [`ValidateConfig`],
+/// post-validate [`ConfigureConfig`] (env + template files), and removal
+/// instructions ([`RemoveConfig`]). Per-platform overrides are supported via
+/// the [`overrides`](Self::overrides) map.
+///
+/// All new fields are additive and `#[serde(default)]`-protected: existing
+/// component.yaml files in `registry-core/components/` deserialize unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ComponentManifest {
     pub metadata: ComponentMetadata,
@@ -118,6 +188,26 @@ pub struct ComponentManifest {
     pub depends_on: Vec<String>,
     #[serde(default)]
     pub capabilities: ComponentCapabilities,
+
+    // ----- DDD-01 additions (all backward-compatible) -----
+    /// Typed user-facing options schema (DDD-01 §Options). Empty by default.
+    #[serde(default)]
+    pub options: Options,
+    /// Post-install health checks (ADR-024).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validate: Option<ValidateConfig>,
+    /// Post-install configuration: environment vars + rendered template files
+    /// (DDD-01 §Configure).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub configure: Option<ConfigureConfig>,
+    /// Removal instructions executed by `sindri remove` (ADR-024).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remove: Option<RemoveConfig>,
+    /// Per-platform overrides for any of: install, configure, validate, remove.
+    /// Keyed by `{os}-{arch}` string (e.g. `"linux-x86_64"`, `"macos-aarch64"`).
+    /// See [`platform_key`].
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub overrides: HashMap<String, PlatformOverride>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -298,12 +388,530 @@ pub struct ProjectInitStep {
     pub priority: u32,
 }
 
+// =============================================================================
+// DDD-01: Options schema
+// =============================================================================
+
+/// Typed schema of user-configurable options exposed by the component
+/// (DDD-01 §Options).
+///
+/// Each field name maps to an [`OptionSpec`] that declares the option's type,
+/// default value, and validation hints. Empty by default; deserializes from
+/// either an absent `options:` key or an empty map.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct Options {
+    #[serde(flatten)]
+    pub fields: HashMap<String, OptionSpec>,
+}
+
+/// One typed option entry in [`Options`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum OptionSpec {
+    /// Boolean flag.
+    Bool {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
+    /// Free-form string, optionally constrained by an `enum_values` whitelist.
+    String {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        /// Optional allowed-values list (rendered as `enum:` in YAML).
+        #[serde(
+            default,
+            rename = "enum",
+            alias = "enum_values",
+            skip_serializing_if = "Option::is_none"
+        )]
+        enum_values: Option<Vec<String>>,
+    },
+    /// Numeric option, optionally bounded.
+    Number {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max: Option<f64>,
+    },
+    /// Filesystem path (executor expands `~`).
+    Path {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
+}
+
+// =============================================================================
+// DDD-01: Validate / Configure / Remove configs (ADR-024)
+// =============================================================================
+
+/// Post-install health-check commands (ADR-024).
+///
+/// Each [`ValidateCommand`] is run by the active target; all must exit 0 (and
+/// match optional `expected_output`/`version_match` assertions) for the
+/// component to be considered installed successfully.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct ValidateConfig {
+    /// Validation commands run after install. All must succeed.
+    #[serde(default)]
+    pub commands: Vec<ValidateCommand>,
+}
+
+/// One health-check command in [`ValidateConfig`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct ValidateCommand {
+    /// Shell command line to execute.
+    pub command: String,
+    /// Optional regex/literal expected as a substring of stdout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_output: Option<String>,
+    /// Optional version assertion (e.g. `">=22.0.0"`) parsed against stdout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_match: Option<String>,
+}
+
+/// Post-install configuration: environment variables + rendered template
+/// files (DDD-01 §Configure, ADR-024).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct ConfigureConfig {
+    #[serde(default)]
+    pub environment: Vec<EnvSetting>,
+    #[serde(default)]
+    pub files: Vec<FileTemplate>,
+}
+
+/// A single environment variable to apply at the configured [`EnvScope`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct EnvSetting {
+    pub name: String,
+    pub value: String,
+    /// Where to apply: see [`EnvScope`]. Defaults to [`EnvScope::ShellRc`].
+    #[serde(default = "default_env_scope")]
+    pub scope: EnvScope,
+}
+
+/// Where an [`EnvSetting`] is applied (per implementation-plan §5.5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum EnvScope {
+    /// Append to user's interactive shell rc file (e.g. `~/.bashrc`).
+    ShellRc,
+    /// Append to login profile (e.g. `~/.profile`, `~/.zprofile`).
+    Login,
+    /// Set only for the current sindri session/process.
+    Session,
+    /// Persist as a user-level env var (Windows: registry; Unix: shell-rc fallback).
+    UserEnvVar,
+}
+
+fn default_env_scope() -> EnvScope {
+    EnvScope::ShellRc
+}
+
+/// A rendered template file to write during configure.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct FileTemplate {
+    /// Destination path (executor expands a leading `~`).
+    pub path: String,
+    /// Inline template body (Mustache-style `{{var}}` substitution).
+    pub template: String,
+    /// Whether to overwrite an existing file at `path`.
+    #[serde(default)]
+    pub overwrite: bool,
+}
+
+/// Removal instructions executed by `sindri remove <component>` (ADR-024).
+///
+/// The backend's own uninstall runs first; these commands and file deletions
+/// are extra cleanup (e.g. wiping a config directory).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct RemoveConfig {
+    /// Extra shell commands to run during remove.
+    #[serde(default)]
+    pub commands: Vec<String>,
+    /// Files or directories to delete (executor expands a leading `~`).
+    #[serde(default)]
+    pub files: Vec<String>,
+}
+
+/// Per-platform override of any subset of install/configure/validate/remove
+/// (DDD-01 §Per-platform overrides). Each field is optional; when present,
+/// it fully replaces the top-level value for the matching platform.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct PlatformOverride {
+    pub install: Option<InstallConfig>,
+    pub configure: Option<ConfigureConfig>,
+    pub validate: Option<ValidateConfig>,
+    pub remove: Option<RemoveConfig>,
+}
+
+/// Canonical platform key string used for [`ComponentManifest::overrides`]:
+/// `"{os}-{arch}"`, e.g. `"linux-x86_64"`, `"macos-aarch64"`.
+pub fn platform_key(platform: &Platform) -> String {
+    let os = match platform.os {
+        Os::Linux => "linux",
+        Os::Macos => "macos",
+        Os::Windows => "windows",
+    };
+    let arch = match platform.arch {
+        Arch::X86_64 => "x86_64",
+        Arch::Aarch64 => "aarch64",
+    };
+    format!("{}-{}", os, arch)
+}
+
+impl ComponentManifest {
+    /// Returns the effective install config for `platform`: the per-platform
+    /// override if present, else the top-level [`Self::install`].
+    pub fn effective_install(&self, platform: &Platform) -> &InstallConfig {
+        let key = platform_key(platform);
+        self.overrides
+            .get(&key)
+            .and_then(|o| o.install.as_ref())
+            .unwrap_or(&self.install)
+    }
+
+    /// Returns the effective validate config for `platform`, or `None` if
+    /// neither the override nor the top-level manifest declares one.
+    pub fn effective_validate(&self, platform: &Platform) -> Option<&ValidateConfig> {
+        let key = platform_key(platform);
+        self.overrides
+            .get(&key)
+            .and_then(|o| o.validate.as_ref())
+            .or(self.validate.as_ref())
+    }
+
+    /// Returns the effective configure config for `platform`, or `None`.
+    pub fn effective_configure(&self, platform: &Platform) -> Option<&ConfigureConfig> {
+        let key = platform_key(platform);
+        self.overrides
+            .get(&key)
+            .and_then(|o| o.configure.as_ref())
+            .or(self.configure.as_ref())
+    }
+
+    /// Returns the effective remove config for `platform`, or `None`.
+    pub fn effective_remove(&self, platform: &Platform) -> Option<&RemoveConfig> {
+        let key = platform_key(platform);
+        self.overrides
+            .get(&key)
+            .and_then(|o| o.remove.as_ref())
+            .or(self.remove.as_ref())
+    }
+}
+
 /// An entry in the BOM manifest referencing a component
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct BomEntry {
-    /// `backend:name[@version]` address
+    /// `backend:name[@qualifier]` address (ADR-004).
     pub address: String,
+    /// Pinned version or version range (resolved to exact in `sindri.lock`).
     pub version: Option<VersionSpec>,
     #[serde(default)]
     pub options: HashMap<String, serde_json::Value>,
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn registry_root() -> PathBuf {
+        // crates/sindri-core/src/component.rs -> ../../../registry-core/components
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("registry-core")
+            .join("components")
+    }
+
+    // ----- ComponentId parsing -----
+
+    #[test]
+    fn component_id_parse_qualifier_only() {
+        let id = ComponentId::parse("npm:codex@openai").expect("valid address");
+        assert_eq!(id.backend, Backend::Npm);
+        assert_eq!(id.name, "codex");
+        assert_eq!(id.qualifier.as_deref(), Some("openai"));
+    }
+
+    #[test]
+    fn component_id_parse_no_qualifier() {
+        let id = ComponentId::parse("mise:nodejs").expect("valid address");
+        assert_eq!(id.backend, Backend::Mise);
+        assert_eq!(id.name, "nodejs");
+        assert!(id.qualifier.is_none());
+    }
+
+    #[test]
+    fn component_id_round_trip_with_qualifier() {
+        let id = ComponentId::parse("npm:codex@openai").unwrap();
+        let addr = id.to_address();
+        assert_eq!(addr, "npm:codex@openai");
+        let id2 = ComponentId::parse(&addr).unwrap();
+        assert_eq!(id, id2);
+    }
+
+    #[test]
+    fn component_id_round_trip_no_qualifier() {
+        let id = ComponentId::parse("mise:nodejs").unwrap();
+        assert_eq!(id.to_address(), "mise:nodejs");
+    }
+
+    #[test]
+    fn component_id_parse_unknown_backend_returns_none() {
+        assert!(ComponentId::parse("nope:thing").is_none());
+        assert!(ComponentId::parse("no-colon").is_none());
+        assert!(ComponentId::parse("mise:").is_none());
+    }
+
+    #[test]
+    fn component_id_parse_strips_secondary_at_segment() {
+        // `npm:codex@openai@1.2.3` — qualifier is `openai`; trailing version segment is dropped
+        // (versions live on BomEntry, not on the address).
+        let id = ComponentId::parse("npm:codex@openai@1.2.3").unwrap();
+        assert_eq!(id.name, "codex");
+        assert_eq!(id.qualifier.as_deref(), Some("openai"));
+    }
+
+    // ----- DDD-01 manifest deserialization -----
+
+    #[test]
+    fn manifest_with_validate_round_trip() {
+        let yaml = r#"
+metadata:
+  name: t
+  version: "1.0.0"
+  description: x
+  license: MIT
+platforms:
+  - { os: linux, arch: x86_64 }
+install: {}
+validate:
+  commands:
+    - command: "node --version"
+      version-match: ">=22.0.0"
+    - command: "echo ok"
+      expected-output: "ok"
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        let v = m.validate.as_ref().expect("validate present");
+        assert_eq!(v.commands.len(), 2);
+        assert_eq!(v.commands[0].version_match.as_deref(), Some(">=22.0.0"));
+        assert_eq!(v.commands[1].expected_output.as_deref(), Some("ok"));
+
+        // Round-trip
+        let s = serde_yaml::to_string(&m).unwrap();
+        let m2: ComponentManifest = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(
+            m2.validate.unwrap().commands[0].command,
+            "node --version".to_string()
+        );
+    }
+
+    #[test]
+    fn manifest_with_configure_environment() {
+        let yaml = r#"
+metadata: { name: t, version: "1.0.0", description: x, license: MIT }
+platforms: [{ os: linux, arch: x86_64 }]
+install: {}
+configure:
+  environment:
+    - { name: FOO, value: "1" }
+    - { name: BAR, value: "2", scope: login }
+    - { name: BAZ, value: "3", scope: session }
+    - { name: QUX, value: "4", scope: user-env-var }
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        let c = m.configure.unwrap();
+        assert_eq!(c.environment.len(), 4);
+        assert_eq!(c.environment[0].scope, EnvScope::ShellRc); // default applied
+        assert_eq!(c.environment[1].scope, EnvScope::Login);
+        assert_eq!(c.environment[2].scope, EnvScope::Session);
+        assert_eq!(c.environment[3].scope, EnvScope::UserEnvVar);
+    }
+
+    #[test]
+    fn manifest_with_remove_files() {
+        let yaml = r#"
+metadata: { name: t, version: "1.0.0", description: x, license: MIT }
+platforms: [{ os: linux, arch: x86_64 }]
+install: {}
+remove:
+  commands:
+    - "rm -rf ~/.cache/t"
+  files:
+    - "~/.config/t"
+    - "/opt/t"
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        let r = m.remove.unwrap();
+        assert_eq!(r.commands, vec!["rm -rf ~/.cache/t".to_string()]);
+        assert_eq!(r.files.len(), 2);
+    }
+
+    #[test]
+    fn manifest_with_platform_override_install() {
+        let yaml = r#"
+metadata: { name: t, version: "1.0.0", description: x, license: MIT }
+platforms:
+  - { os: linux, arch: x86_64 }
+  - { os: macos, arch: aarch64 }
+install:
+  mise:
+    tools:
+      node: "22.0.0"
+overrides:
+  linux-x86_64:
+    install:
+      apt:
+        packages: ["nodejs"]
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        let linux = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let mac = Platform {
+            os: Os::Macos,
+            arch: Arch::Aarch64,
+        };
+        let inst_linux = m.effective_install(&linux);
+        assert!(inst_linux.apt.is_some(), "linux override picks apt");
+        assert!(inst_linux.mise.is_none());
+
+        let inst_mac = m.effective_install(&mac);
+        assert!(
+            inst_mac.mise.is_some(),
+            "macos falls back to top-level mise"
+        );
+    }
+
+    #[test]
+    fn effective_install_falls_back_when_no_override() {
+        let yaml = r#"
+metadata: { name: t, version: "1.0.0", description: x, license: MIT }
+platforms: [{ os: linux, arch: x86_64 }]
+install:
+  mise:
+    tools: { node: "22.0.0" }
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let inst = m.effective_install(&p);
+        assert!(inst.mise.is_some());
+        assert!(m.effective_validate(&p).is_none());
+        assert!(m.effective_configure(&p).is_none());
+        assert!(m.effective_remove(&p).is_none());
+    }
+
+    #[test]
+    fn default_env_scope_is_shell_rc() {
+        assert_eq!(default_env_scope(), EnvScope::ShellRc);
+    }
+
+    #[test]
+    fn options_string_with_enum_round_trips() {
+        let yaml = r#"
+metadata: { name: t, version: "1.0.0", description: x, license: MIT }
+platforms: [{ os: linux, arch: x86_64 }]
+install: {}
+options:
+  log_level:
+    type: string
+    default: info
+    enum: [debug, info, warn, error]
+    description: "Verbosity"
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        let spec = m
+            .options
+            .fields
+            .get("log_level")
+            .expect("log_level present");
+        match spec {
+            OptionSpec::String {
+                default,
+                enum_values,
+                ..
+            } => {
+                assert_eq!(default.as_deref(), Some("info"));
+                assert_eq!(
+                    enum_values.as_ref().unwrap(),
+                    &vec![
+                        "debug".to_string(),
+                        "info".to_string(),
+                        "warn".to_string(),
+                        "error".to_string(),
+                    ]
+                );
+            }
+            other => panic!("expected String spec, got {:?}", other),
+        }
+
+        let s = serde_yaml::to_string(&m).unwrap();
+        let m2: ComponentManifest = serde_yaml::from_str(&s).unwrap();
+        assert!(m2.options.fields.contains_key("log_level"));
+    }
+
+    #[test]
+    fn platform_key_format() {
+        assert_eq!(
+            platform_key(&Platform {
+                os: Os::Linux,
+                arch: Arch::X86_64
+            }),
+            "linux-x86_64"
+        );
+        assert_eq!(
+            platform_key(&Platform {
+                os: Os::Macos,
+                arch: Arch::Aarch64
+            }),
+            "macos-aarch64"
+        );
+    }
+
+    #[test]
+    fn existing_registry_components_still_deserialize() {
+        // Hard requirement: the 97 component.yaml files in registry-core/components
+        // must all deserialize unchanged. We sample 5 representative components
+        // covering different install backends.
+        let names = ["nodejs", "gh", "claude-code", "clarity", "guacamole"];
+        let root = registry_root();
+        for name in names {
+            let path = root.join(name).join("component.yaml");
+            let yaml = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+            let m: ComponentManifest = serde_yaml::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("parse {}: {}", path.display(), e));
+            assert_eq!(m.metadata.name, name, "metadata.name mismatch for {name}");
+            // New fields default cleanly:
+            assert!(m.options.fields.is_empty());
+            assert!(m.overrides.is_empty());
+        }
+    }
 }

--- a/v4/crates/sindri-extensions/src/collision/mod.rs
+++ b/v4/crates/sindri-extensions/src/collision/mod.rs
@@ -212,6 +212,11 @@ mod tests {
                 hooks: None,
                 project_init: None,
             },
+            options: Default::default(),
+            validate: None,
+            configure: None,
+            remove: None,
+            overrides: Default::default(),
         }
     }
 

--- a/v4/crates/sindri-extensions/src/project_init.rs
+++ b/v4/crates/sindri-extensions/src/project_init.rs
@@ -231,6 +231,7 @@ mod tests {
             component_id: ComponentId {
                 backend: Backend::Mise,
                 name: name.into(),
+                qualifier: None,
             },
             name: name.into(),
         }

--- a/v4/crates/sindri-resolver/src/admission.rs
+++ b/v4/crates/sindri-resolver/src/admission.rs
@@ -392,6 +392,11 @@ mod tests {
                 hooks: None,
                 project_init: None,
             },
+            options: Default::default(),
+            validate: None,
+            configure: None,
+            remove: None,
+            overrides: Default::default(),
         }
     }
 

--- a/v4/crates/sindri-resolver/src/closure.rs
+++ b/v4/crates/sindri-resolver/src/closure.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use crate::error::ResolverError;
 use sindri_core::component::ComponentId;
 use sindri_core::registry::ComponentEntry;
-use crate::error::ResolverError;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// A node in the expanded dependency closure
 #[derive(Debug, Clone)]
@@ -40,15 +40,13 @@ pub fn expand_closure(
 
         let (backend, name) = parse_address(&address)?;
         let entry = registry.get(&address).ok_or_else(|| {
-            ResolverError::NotFound(format!(
-                "Component '{}' not found in registry",
-                address
-            ))
+            ResolverError::NotFound(format!("Component '{}' not found in registry", address))
         })?;
 
         let id = ComponentId {
             backend: backend.clone(),
             name,
+            qualifier: None,
         };
 
         visited.insert(address.clone(), depth);
@@ -61,7 +59,11 @@ pub fn expand_closure(
             }
         }
 
-        result.push(ClosureNode { id, entry: entry.clone(), depth });
+        result.push(ClosureNode {
+            id,
+            entry: entry.clone(),
+            depth,
+        });
         in_stack.remove(&address);
     }
 
@@ -85,7 +87,9 @@ pub fn expand_closure(
     Ok(result)
 }
 
-fn parse_address(address: &str) -> Result<(sindri_core::component::Backend, String), ResolverError> {
+fn parse_address(
+    address: &str,
+) -> Result<(sindri_core::component::Backend, String), ResolverError> {
     let id = ComponentId::parse(address).ok_or_else(|| {
         ResolverError::NotFound(format!("Invalid component address: {}", address))
     })?;

--- a/v4/crates/sindri-resolver/src/lockfile_writer.rs
+++ b/v4/crates/sindri-resolver/src/lockfile_writer.rs
@@ -1,14 +1,14 @@
+use crate::error::ResolverError;
+use sindri_core::component::{Backend, ComponentId};
+use sindri_core::lockfile::{Lockfile, ResolvedComponent};
+use sindri_core::registry::ComponentEntry;
+use sindri_core::version::Version;
 use std::fs;
 use std::path::Path;
-use sindri_core::lockfile::{Lockfile, ResolvedComponent};
-use sindri_core::component::{Backend, ComponentId};
-use sindri_core::version::Version;
-use sindri_core::registry::ComponentEntry;
-use crate::error::ResolverError;
 
 /// Compute bom_hash as sha256 of the sindri.yaml content
 pub fn compute_bom_hash(bom_content: &str) -> String {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bom_content.as_bytes());
     hex::encode(hasher.finalize())
@@ -30,8 +30,7 @@ pub fn read_lockfile(path: &Path) -> Result<Lockfile, ResolverError> {
         return Err(ResolverError::LockfileStale);
     }
     let content = fs::read_to_string(path)?;
-    serde_json::from_str(&content)
-        .map_err(|e| ResolverError::Serialization(e.to_string()))
+    serde_json::from_str(&content).map_err(|e| ResolverError::Serialization(e.to_string()))
 }
 
 /// Build ResolvedComponent from a closure node
@@ -43,6 +42,7 @@ pub fn resolved_from_entry(
     let id = ComponentId {
         backend: chosen_backend.clone(),
         name: entry.name.clone(),
+        qualifier: None,
     };
     ResolvedComponent {
         id,


### PR DESCRIPTION
## Summary

Closes the DDD divergence flagged in `v4/docs/review/2026-04-27-implementation-audit.md` §3: the `Component` aggregate per DDD-01 has 9 sub-fields; the code modeled only 5. As a result `sindri apply` could not run validation, write env vars/dotfiles, or run remove commands. This PR expands `sindri-core::component` to match DDD-01.

## Why

Without these fields, `apply` is "package install", not "component install". Adding them (additive only — no behaviour change yet) is the prerequisite for Wave 2D, which will wire validate/configure/remove into the execution pipeline.

Audit reference: `v4/docs/review/2026-04-27-implementation-audit.md` §3 (DDD-01).

## Schema additions

All new fields are additive and `#[serde(default)]`-protected — every existing `component.yaml` deserializes unchanged.

- **`ComponentId.qualifier: Option<String>`** (ADR-004) — alternative-flavour selector distinct from version, e.g. `npm:codex@openai`.
  - `parse()` accepts `backend:name[@qualifier]`. A secondary `@<version>` segment (rare) is dropped — versions live on `BomEntry`, not on the address.
  - `to_address()` round-trips correctly.
- **`ComponentManifest.options: Options`** — typed schema of user-facing options. `OptionSpec` variants: `Bool`, `String` (with optional `enum`), `Number` (with optional `min`/`max`), `Path`.
- **`ComponentManifest.validate: Option<ValidateConfig>`** (ADR-024) — post-install commands; each `ValidateCommand` may declare `expected-output` and/or `version-match`.
- **`ComponentManifest.configure: Option<ConfigureConfig>`** —
  - `environment: Vec<EnvSetting>` with `EnvScope`: `shell-rc` (default) | `login` | `session` | `user-env-var`.
  - `files: Vec<FileTemplate>` (Mustache `{{var}}` body, destination path, `overwrite` flag).
- **`ComponentManifest.remove: Option<RemoveConfig>`** — extra `commands[]` and `files[]` to clean up after the backend's own uninstall.
- **`ComponentManifest.overrides: HashMap<String, PlatformOverride>`** — per-platform overrides keyed by `{os}-{arch}` (e.g. `linux-x86_64`, `macos-aarch64`), each carrying optional `install` / `configure` / `validate` / `remove`. Helpers:
  - `effective_install(&Platform) -> &InstallConfig`
  - `effective_validate(&Platform) -> Option<&ValidateConfig>`
  - `effective_configure(&Platform) -> Option<&ConfigureConfig>`
  - `effective_remove(&Platform) -> Option<&RemoveConfig>`

## Backward compatibility

Hard test: `existing_registry_components_still_deserialize` loads 5 representative `v4/registry-core/components/*/component.yaml` files (`nodejs`, `gh`, `claude-code`, `clarity`, `guacamole`) and asserts each parses cleanly with empty `options` and empty `overrides`. All 97 existing manifests deserialize unchanged.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean for files touched in this PR (pre-existing drift outside touched files is out of scope)
- [x] `cargo test --workspace` all green
- [x] 15 new `sindri-core::component::tests` covering:
  - qualifier parse / no-qualifier / round-trip / unknown backend / secondary-`@version` stripping
  - validate round-trip; configure environment with mixed scopes; remove files
  - per-platform override `install` selection; fallback when no override
  - default EnvScope; platform_key format
  - typed `OptionSpec::String { enum }` round-trip
  - 5-fixture registry compat

## Out of scope

- Wiring validate/configure/remove into `apply` execution → Wave 2D.
- OCI manifest fetch → Wave 3.
- Workspace-wide `cargo fmt` sweep (the v4 base has pre-existing drift outside the files touched here) → separate PR.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)