### PR TITLE
feat(v4): apply-time wiring — hooks, configure, validate, project-init, collision (ADR-024)

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -1193,6 +1193,8 @@ dependencies = [
  "sindri-registry",
  "sindri-resolver",
  "sindri-targets",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -1062,6 +1062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1244,8 @@ name = "sindri-extensions"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dirs-next",
+ "semver",
  "serde",
  "serde_json",
  "sindri-core",

--- a/v4/Cargo.toml
+++ b/v4/Cargo.toml
@@ -28,3 +28,4 @@ sha2 = "0.11"
 hex = "0.4"
 dirs-next = "2"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+semver = "1"

--- a/v4/crates/sindri-backends/src/binary.rs
+++ b/v4/crates/sindri-backends/src/binary.rs
@@ -139,6 +139,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         };
         let ctx = InstallContext::new(&c, None, &mock);
         // Empty-checksum path: backend logs a warn and returns Ok without

--- a/v4/crates/sindri-backends/src/brew.rs
+++ b/v4/crates/sindri-backends/src/brew.rs
@@ -98,6 +98,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/cargo.rs
+++ b/v4/crates/sindri-backends/src/cargo.rs
@@ -121,6 +121,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/go_install.rs
+++ b/v4/crates/sindri-backends/src/go_install.rs
@@ -143,6 +143,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/mise.rs
+++ b/v4/crates/sindri-backends/src/mise.rs
@@ -62,6 +62,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/npm.rs
+++ b/v4/crates/sindri-backends/src/npm.rs
@@ -93,6 +93,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/pipx.rs
+++ b/v4/crates/sindri-backends/src/pipx.rs
@@ -108,6 +108,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/script.rs
+++ b/v4/crates/sindri-backends/src/script.rs
@@ -145,6 +145,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         };
         let ctx = InstallContext::new(&comp, None, &target);
         let err = ScriptBackend.install(&ctx).await.unwrap_err();

--- a/v4/crates/sindri-backends/src/sdkman.rs
+++ b/v4/crates/sindri-backends/src/sdkman.rs
@@ -102,6 +102,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/system_pm.rs
+++ b/v4/crates/sindri-backends/src/system_pm.rs
@@ -146,6 +146,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/winget.rs
+++ b/v4/crates/sindri-backends/src/winget.rs
@@ -121,6 +121,7 @@ mod tests {
             oci_digest: None,
             checksums: HashMap::new(),
             depends_on: vec![],
+            manifest: None,
         }
     }
 

--- a/v4/crates/sindri-core/src/lockfile.rs
+++ b/v4/crates/sindri-core/src/lockfile.rs
@@ -1,4 +1,4 @@
-use crate::component::{Backend, ComponentId};
+use crate::component::{Backend, ComponentId, ComponentManifest};
 use crate::version::Version;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -35,4 +35,15 @@ pub struct ResolvedComponent {
     pub oci_digest: Option<String>,
     pub checksums: HashMap<String, String>,
     pub depends_on: Vec<String>,
+    /// Full component manifest, when available.
+    ///
+    /// The resolver does not yet fetch OCI manifests (Wave 3A), so today this
+    /// is always `None` and the apply pipeline degrades gracefully — only the
+    /// install + lifecycle hook steps run for a `None` manifest, and the
+    /// configure / validate / remove capability executors are skipped with a
+    /// `tracing::debug!`. The field is in place so that when OCI fetch lands,
+    /// `sindri apply` will pick up validate / configure / per-platform overrides
+    /// without further changes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<ComponentManifest>,
 }

--- a/v4/crates/sindri-extensions/Cargo.toml
+++ b/v4/crates/sindri-extensions/Cargo.toml
@@ -16,6 +16,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+semver = { workspace = true }
+dirs-next = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/v4/crates/sindri-extensions/src/configure.rs
+++ b/v4/crates/sindri-extensions/src/configure.rs
@@ -250,13 +250,12 @@ fn apply_file_template(
         return Ok(());
     }
 
-    let rendered = render_mustache(&template.template, vars).map_err(|e| {
-        ExtensionError::ConfigureFailed {
+    let rendered =
+        render_mustache(&template.template, vars).map_err(|e| ExtensionError::ConfigureFailed {
             component: ctx.component.to_string(),
             step: format!("files[{}]", dest.display()),
             detail: e,
-        }
-    })?;
+        })?;
 
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent).map_err(|e| ExtensionError::ConfigureFailed {
@@ -458,6 +457,9 @@ mod tests {
 
     #[test]
     fn shell_escape_handles_quotes_and_dollars() {
-        assert_eq!(shell_escape_double_quoted(r#"a"b$c\d`e"#), r#"a\"b\$c\\d\`e"#);
+        assert_eq!(
+            shell_escape_double_quoted(r#"a"b$c\d`e"#),
+            r#"a\"b\$c\\d\`e"#
+        );
     }
 }

--- a/v4/crates/sindri-extensions/src/configure.rs
+++ b/v4/crates/sindri-extensions/src/configure.rs
@@ -1,0 +1,463 @@
+//! Configure executor (DDD-01 §Configure, ADR-024).
+//!
+//! [`ConfigureExecutor`] applies a component's
+//! [`sindri_core::component::ConfigureConfig`] after a successful install:
+//!
+//! 1. **Environment variables** — for each [`EnvSetting`] with
+//!    [`EnvScope::ShellRc`], a per-component fragment is written to
+//!    `<env-dir>/<component>.sh` with `export NAME="value"` lines. A guarded
+//!    block in the user's `~/.bashrc` and `~/.zshrc` source-globs the
+//!    fragment dir on next interactive shell. Other scopes (Login, Session,
+//!    UserEnvVar) emit a `tracing::warn!` and are skipped — implementation-plan
+//!    §5.5 will introduce the full PATH/scope abstraction in a follow-up.
+//!
+//! 2. **File templates** — for each [`FileTemplate`], the inline body is
+//!    Mustache-style `{{var}}`-substituted from a small context (component
+//!    name, version, target name, plus the configure-pass env settings) and
+//!    written to `path` (with leading `~` expanded). When `overwrite: false`
+//!    the executor preserves an existing file with a `tracing::warn!`.
+//!
+//! ### Idempotency
+//!
+//! Re-running the executor with the same inputs produces the same on-disk
+//! state with no error. The shell-rc guard block uses a `# sindri:auto`
+//! marker so it is appended at most once.
+//!
+//! ### Failure surface
+//!
+//! Real I/O or template parse errors return [`ExtensionError::ConfigureFailed`]
+//! with the offending sub-step (e.g. `environment[FOO]`, `files[/etc/x.conf]`).
+
+use crate::error::ExtensionError;
+use sindri_core::component::{ConfigureConfig, EnvScope, EnvSetting, FileTemplate};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Marker placed in `~/.bashrc` / `~/.zshrc` so the source-glob block is
+/// appended at most once even across re-runs.
+const SHELL_RC_MARKER: &str = "# sindri:auto";
+
+/// Context for a configure run.
+pub struct ConfigureContext<'a> {
+    /// Component metadata name (e.g. `"nodejs"`).
+    pub component: &'a str,
+    /// Component metadata version (e.g. `"22.0.0"`).
+    pub version: &'a str,
+    /// The execution target name (e.g. `"local"`).
+    pub target_name: &'a str,
+    /// Directory used for per-component shell-rc env fragments.
+    ///
+    /// Production callers typically pass `~/.sindri/env`; tests pass a
+    /// [`tempfile::TempDir`] path. Created (recursively) on demand.
+    pub env_dir: &'a Path,
+    /// Directory used as the base for `~`-expansion of [`FileTemplate::path`]
+    /// and the rc-file location for the source-glob guard. Production callers
+    /// pass `dirs_next::home_dir()`; tests pass a temp dir so the rc files
+    /// land inside the sandbox.
+    pub home_dir: &'a Path,
+}
+
+/// Capability executor for `configure` (ADR-024).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ConfigureExecutor;
+
+impl ConfigureExecutor {
+    /// Create a new executor.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Apply the full [`ConfigureConfig`] for a component.
+    ///
+    /// This is idempotent — running twice produces the same state with no
+    /// error.
+    pub async fn apply(
+        &self,
+        cfg: &ConfigureConfig,
+        ctx: &ConfigureContext<'_>,
+    ) -> Result<(), ExtensionError> {
+        // 1. Environment fragment.
+        self.apply_environment(cfg, ctx)?;
+
+        // 2. File templates.
+        self.apply_files(cfg, ctx)?;
+
+        Ok(())
+    }
+
+    /// Write a per-component shell-rc env fragment, source-globbed via a
+    /// guarded block in `~/.bashrc` and `~/.zshrc`.
+    fn apply_environment(
+        &self,
+        cfg: &ConfigureConfig,
+        ctx: &ConfigureContext<'_>,
+    ) -> Result<(), ExtensionError> {
+        // Partition by scope.
+        let mut shell_rc_settings: Vec<&EnvSetting> = Vec::new();
+        for setting in &cfg.environment {
+            match &setting.scope {
+                EnvScope::ShellRc => shell_rc_settings.push(setting),
+                other => {
+                    tracing::warn!(
+                        component = ctx.component,
+                        env_var = setting.name.as_str(),
+                        scope = ?other,
+                        "scope `{:?}` not yet supported on this platform; \
+                         skipping (see implementation-plan §5.5)",
+                        other
+                    );
+                }
+            }
+        }
+
+        if shell_rc_settings.is_empty() && cfg.environment.is_empty() {
+            return Ok(());
+        }
+
+        // Write the per-component fragment even if empty (idempotent).
+        let fragment_path = ctx.env_dir.join(format!("{}.sh", ctx.component));
+        std::fs::create_dir_all(ctx.env_dir).map_err(|e| ExtensionError::ConfigureFailed {
+            component: ctx.component.to_string(),
+            step: format!("env_dir({})", ctx.env_dir.display()),
+            detail: e.to_string(),
+        })?;
+
+        let mut body = String::new();
+        body.push_str(&format!(
+            "# sindri-managed env fragment for component `{}`\n\
+             # Re-run `sindri apply` to refresh.\n",
+            ctx.component
+        ));
+        for s in &shell_rc_settings {
+            body.push_str(&format!(
+                "export {}=\"{}\"\n",
+                s.name,
+                shell_escape_double_quoted(&s.value)
+            ));
+        }
+
+        std::fs::write(&fragment_path, body).map_err(|e| ExtensionError::ConfigureFailed {
+            component: ctx.component.to_string(),
+            step: format!("write fragment ({})", fragment_path.display()),
+            detail: e.to_string(),
+        })?;
+
+        // Append source-glob guard to bashrc/zshrc (at most once).
+        for rc_name in &[".bashrc", ".zshrc"] {
+            let rc_path = ctx.home_dir.join(rc_name);
+            ensure_shell_rc_block(&rc_path, ctx.env_dir, ctx.component)?;
+        }
+
+        Ok(())
+    }
+
+    /// Render and write all [`FileTemplate`]s.
+    fn apply_files(
+        &self,
+        cfg: &ConfigureConfig,
+        ctx: &ConfigureContext<'_>,
+    ) -> Result<(), ExtensionError> {
+        if cfg.files.is_empty() {
+            return Ok(());
+        }
+        let vars = build_template_vars(cfg, ctx);
+        for template in &cfg.files {
+            apply_file_template(template, ctx, &vars)?;
+        }
+        Ok(())
+    }
+}
+
+/// Idempotently append a guarded block to `rc_path` so interactive shells
+/// source the per-component env fragments. The block is wrapped between two
+/// `# sindri:auto` marker lines and is appended at most once per rc file.
+fn ensure_shell_rc_block(
+    rc_path: &Path,
+    env_dir: &Path,
+    component: &str,
+) -> Result<(), ExtensionError> {
+    let existing = std::fs::read_to_string(rc_path).unwrap_or_default();
+    if existing.contains(SHELL_RC_MARKER) {
+        return Ok(());
+    }
+
+    if let Some(parent) = rc_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ExtensionError::ConfigureFailed {
+            component: component.to_string(),
+            step: format!("rc parent({})", parent.display()),
+            detail: e.to_string(),
+        })?;
+    }
+
+    // Use ~/.sindri/env literally in the rendered rc text where possible —
+    // we render the resolved env_dir display path so tests get an absolute
+    // path and production gets `~/.sindri/env` (callers should pass that).
+    let block = format!(
+        "\n{marker}\n\
+         # Sindri-managed env fragments. Edit via `sindri apply`; do not modify by hand.\n\
+         if [ -d \"{env}\" ]; then\n\
+         \tfor _f in \"{env}\"/*.sh; do\n\
+         \t\t[ -r \"$_f\" ] && . \"$_f\"\n\
+         \tdone\n\
+         \tunset _f\n\
+         fi\n\
+         {marker}\n",
+        marker = SHELL_RC_MARKER,
+        env = env_dir.display(),
+    );
+
+    let mut body = existing;
+    body.push_str(&block);
+    std::fs::write(rc_path, body).map_err(|e| ExtensionError::ConfigureFailed {
+        component: component.to_string(),
+        step: format!("append rc({})", rc_path.display()),
+        detail: e.to_string(),
+    })?;
+    Ok(())
+}
+
+/// Build the variable map used for `{{var}}` substitution.
+fn build_template_vars(
+    cfg: &ConfigureConfig,
+    ctx: &ConfigureContext<'_>,
+) -> HashMap<String, String> {
+    let mut vars: HashMap<String, String> = HashMap::new();
+    vars.insert("component.name".into(), ctx.component.into());
+    vars.insert("component".into(), ctx.component.into());
+    vars.insert("version".into(), ctx.version.into());
+    vars.insert("target".into(), ctx.target_name.into());
+    vars.insert("target.name".into(), ctx.target_name.into());
+    for s in &cfg.environment {
+        vars.insert(format!("env.{}", s.name), s.value.clone());
+    }
+    vars
+}
+
+/// Render and write a single [`FileTemplate`].
+fn apply_file_template(
+    template: &FileTemplate,
+    ctx: &ConfigureContext<'_>,
+    vars: &HashMap<String, String>,
+) -> Result<(), ExtensionError> {
+    let dest = expand_tilde(&template.path, ctx.home_dir);
+
+    if dest.exists() && !template.overwrite {
+        tracing::warn!(
+            component = ctx.component,
+            path = %dest.display(),
+            "configure: file exists and overwrite=false; preserving"
+        );
+        return Ok(());
+    }
+
+    let rendered = render_mustache(&template.template, vars).map_err(|e| {
+        ExtensionError::ConfigureFailed {
+            component: ctx.component.to_string(),
+            step: format!("files[{}]", dest.display()),
+            detail: e,
+        }
+    })?;
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ExtensionError::ConfigureFailed {
+            component: ctx.component.to_string(),
+            step: format!("files[{}] parent", dest.display()),
+            detail: e.to_string(),
+        })?;
+    }
+    std::fs::write(&dest, rendered).map_err(|e| ExtensionError::ConfigureFailed {
+        component: ctx.component.to_string(),
+        step: format!("files[{}]", dest.display()),
+        detail: e.to_string(),
+    })?;
+    Ok(())
+}
+
+/// Expand a leading `~` or `~/` against `home_dir`.
+fn expand_tilde(path: &str, home_dir: &Path) -> PathBuf {
+    if let Some(stripped) = path.strip_prefix("~/") {
+        return home_dir.join(stripped);
+    }
+    if path == "~" {
+        return home_dir.to_path_buf();
+    }
+    PathBuf::from(path)
+}
+
+/// Tiny Mustache-style substitutor: replaces `{{key}}` (with optional
+/// surrounding whitespace) with `vars[key]`. An unknown key returns an error
+/// so misspelled placeholders surface during apply rather than silently
+/// rendering blank.
+fn render_mustache(input: &str, vars: &HashMap<String, String>) -> Result<String, String> {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("{{") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let end = after
+            .find("}}")
+            .ok_or_else(|| "unclosed `{{` in template".to_string())?;
+        let key = after[..end].trim();
+        let value = vars
+            .get(key)
+            .ok_or_else(|| format!("unknown template variable `{}`", key))?;
+        out.push_str(value);
+        rest = &after[end + 2..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Escape a value for inclusion inside a double-quoted shell string.
+/// Conservative: backslashes the four characters that have meaning inside
+/// `"..."` for POSIX shells.
+fn shell_escape_double_quoted(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' | '"' | '$' | '`' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::component::EnvSetting;
+    use tempfile::TempDir;
+
+    fn ctx<'a>(env: &'a Path, home: &'a Path) -> ConfigureContext<'a> {
+        ConfigureContext {
+            component: "nodejs",
+            version: "22.5.1",
+            target_name: "local",
+            env_dir: env,
+            home_dir: home,
+        }
+    }
+
+    #[tokio::test]
+    async fn env_setting_writes_per_component_fragment() {
+        let env_tmp = TempDir::new().unwrap();
+        let home_tmp = TempDir::new().unwrap();
+        let cfg = ConfigureConfig {
+            environment: vec![EnvSetting {
+                name: "NODE_PATH".into(),
+                value: "/opt/node/lib".into(),
+                scope: EnvScope::ShellRc,
+            }],
+            files: Vec::new(),
+        };
+        ConfigureExecutor::new()
+            .apply(&cfg, &ctx(env_tmp.path(), home_tmp.path()))
+            .await
+            .expect("apply ok");
+
+        let fragment = env_tmp.path().join("nodejs.sh");
+        let body = std::fs::read_to_string(&fragment).expect("fragment exists");
+        assert!(body.contains("export NODE_PATH=\"/opt/node/lib\""));
+
+        // Both rc files should contain the guard block.
+        let bashrc = std::fs::read_to_string(home_tmp.path().join(".bashrc")).unwrap();
+        assert!(bashrc.contains(SHELL_RC_MARKER));
+        let zshrc = std::fs::read_to_string(home_tmp.path().join(".zshrc")).unwrap();
+        assert!(zshrc.contains(SHELL_RC_MARKER));
+    }
+
+    #[tokio::test]
+    async fn rerun_does_not_double_append_rc_block() {
+        let env_tmp = TempDir::new().unwrap();
+        let home_tmp = TempDir::new().unwrap();
+        let cfg = ConfigureConfig {
+            environment: vec![EnvSetting {
+                name: "FOO".into(),
+                value: "bar".into(),
+                scope: EnvScope::ShellRc,
+            }],
+            files: Vec::new(),
+        };
+        let c = ctx(env_tmp.path(), home_tmp.path());
+        ConfigureExecutor::new().apply(&cfg, &c).await.unwrap();
+        ConfigureExecutor::new().apply(&cfg, &c).await.unwrap();
+        let bashrc = std::fs::read_to_string(home_tmp.path().join(".bashrc")).unwrap();
+        // Marker pair: opening + closing per block, exactly one block → 2 occurrences.
+        assert_eq!(bashrc.matches(SHELL_RC_MARKER).count(), 2);
+    }
+
+    #[tokio::test]
+    async fn file_template_substitutes_vars() {
+        let env_tmp = TempDir::new().unwrap();
+        let home_tmp = TempDir::new().unwrap();
+        let cfg = ConfigureConfig {
+            environment: Vec::new(),
+            files: vec![FileTemplate {
+                path: "~/.config/nodejs/info.txt".into(),
+                template: "name={{component.name}} v={{version}} target={{target}}".into(),
+                overwrite: true,
+            }],
+        };
+        ConfigureExecutor::new()
+            .apply(&cfg, &ctx(env_tmp.path(), home_tmp.path()))
+            .await
+            .expect("apply ok");
+        let dest = home_tmp.path().join(".config/nodejs/info.txt");
+        let body = std::fs::read_to_string(&dest).expect("file exists");
+        assert_eq!(body, "name=nodejs v=22.5.1 target=local");
+    }
+
+    #[tokio::test]
+    async fn overwrite_false_preserves_existing() {
+        let env_tmp = TempDir::new().unwrap();
+        let home_tmp = TempDir::new().unwrap();
+        let dest = home_tmp.path().join(".config/keep.txt");
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::fs::write(&dest, "ORIGINAL").unwrap();
+
+        let cfg = ConfigureConfig {
+            environment: Vec::new(),
+            files: vec![FileTemplate {
+                path: "~/.config/keep.txt".into(),
+                template: "REPLACED".into(),
+                overwrite: false,
+            }],
+        };
+        ConfigureExecutor::new()
+            .apply(&cfg, &ctx(env_tmp.path(), home_tmp.path()))
+            .await
+            .expect("apply ok");
+        let body = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(body, "ORIGINAL", "existing file must be preserved");
+    }
+
+    #[tokio::test]
+    async fn unknown_template_var_errors() {
+        let env_tmp = TempDir::new().unwrap();
+        let home_tmp = TempDir::new().unwrap();
+        let cfg = ConfigureConfig {
+            environment: Vec::new(),
+            files: vec![FileTemplate {
+                path: "~/oops.txt".into(),
+                template: "{{nope}}".into(),
+                overwrite: true,
+            }],
+        };
+        let err = ConfigureExecutor::new()
+            .apply(&cfg, &ctx(env_tmp.path(), home_tmp.path()))
+            .await
+            .expect_err("unknown var must fail");
+        match err {
+            ExtensionError::ConfigureFailed { component, .. } => assert_eq!(component, "nodejs"),
+            other => panic!("expected ConfigureFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shell_escape_handles_quotes_and_dollars() {
+        assert_eq!(shell_escape_double_quoted(r#"a"b$c\d`e"#), r#"a\"b\$c\\d\`e"#);
+    }
+}

--- a/v4/crates/sindri-extensions/src/error.rs
+++ b/v4/crates/sindri-extensions/src/error.rs
@@ -57,6 +57,48 @@ pub enum ExtensionError {
         fix: String,
     },
 
+    /// A `configure` step (env settings or file template) failed (ADR-024).
+    #[error(
+        "configure failed for component '{component}': {step} — {detail}"
+    )]
+    ConfigureFailed {
+        /// Component metadata name.
+        component: String,
+        /// Which configure sub-step failed (e.g. `environment[FOO]`, `files[/etc/x.conf]`).
+        step: String,
+        /// Human-readable reason.
+        detail: String,
+    },
+
+    /// A `validate` command failed an assertion (ADR-024).
+    #[error(
+        "validate failed for component '{component}': command `{command}` — \
+         expected {expected}, got `{got}`"
+    )]
+    ValidateFailed {
+        /// Component metadata name.
+        component: String,
+        /// Verbatim command string that failed.
+        command: String,
+        /// Human-readable description of the failed assertion.
+        expected: String,
+        /// The actual stdout (truncated) the command produced.
+        got: String,
+    },
+
+    /// A `remove` step (custom command or file deletion) failed.
+    #[error(
+        "remove failed for component '{component}': {step} — {detail}"
+    )]
+    RemoveFailed {
+        /// Component metadata name.
+        component: String,
+        /// Which remove sub-step failed (e.g. `commands[0]`, `files[/etc/x]`).
+        step: String,
+        /// Human-readable reason.
+        detail: String,
+    },
+
     /// Underlying target dispatch failed.
     #[error(transparent)]
     Target(#[from] sindri_targets::error::TargetError),

--- a/v4/crates/sindri-extensions/src/error.rs
+++ b/v4/crates/sindri-extensions/src/error.rs
@@ -58,9 +58,7 @@ pub enum ExtensionError {
     },
 
     /// A `configure` step (env settings or file template) failed (ADR-024).
-    #[error(
-        "configure failed for component '{component}': {step} — {detail}"
-    )]
+    #[error("configure failed for component '{component}': {step} — {detail}")]
     ConfigureFailed {
         /// Component metadata name.
         component: String,
@@ -87,9 +85,7 @@ pub enum ExtensionError {
     },
 
     /// A `remove` step (custom command or file deletion) failed.
-    #[error(
-        "remove failed for component '{component}': {step} — {detail}"
-    )]
+    #[error("remove failed for component '{component}': {step} — {detail}")]
     RemoveFailed {
         /// Component metadata name.
         component: String,

--- a/v4/crates/sindri-extensions/src/lib.rs
+++ b/v4/crates/sindri-extensions/src/lib.rs
@@ -13,11 +13,15 @@
 //! §4.3 for the wave plan and ADR-024 for the lifecycle contract.
 
 pub mod collision;
+pub mod configure;
 pub mod error;
 pub mod hooks;
 pub mod project_init;
+pub mod validate;
 
 pub use collision::{CollisionContext, CollisionPlan, CollisionResolver};
+pub use configure::{ConfigureContext, ConfigureExecutor};
 pub use error::ExtensionError;
 pub use hooks::{HookContext, HooksExecutor};
 pub use project_init::{ComponentRef, ProjectInitContext, ProjectInitExecutor};
+pub use validate::{ValidateContext, ValidateExecutor};

--- a/v4/crates/sindri-extensions/src/validate.rs
+++ b/v4/crates/sindri-extensions/src/validate.rs
@@ -63,15 +63,14 @@ impl ValidateExecutor {
             "running validate command"
         );
 
-        let (stdout, stderr) =
-            ctx.target
-                .exec(&cmd.command, ctx.env)
-                .map_err(|err| ExtensionError::ValidateFailed {
-                    component: ctx.component.to_string(),
-                    command: cmd.command.clone(),
-                    expected: "command to exit 0".to_string(),
-                    got: err.to_string(),
-                })?;
+        let (stdout, stderr) = ctx.target.exec(&cmd.command, ctx.env).map_err(|err| {
+            ExtensionError::ValidateFailed {
+                component: ctx.component.to_string(),
+                command: cmd.command.clone(),
+                expected: "command to exit 0".to_string(),
+                got: err.to_string(),
+            }
+        })?;
 
         if let Some(expected) = &cmd.expected_output {
             if !stdout.contains(expected.as_str()) {
@@ -85,34 +84,31 @@ impl ValidateExecutor {
         }
 
         if let Some(spec) = &cmd.version_match {
-            let req = semver::VersionReq::parse(spec).map_err(|e| {
-                ExtensionError::ValidateFailed {
+            let req =
+                semver::VersionReq::parse(spec).map_err(|e| ExtensionError::ValidateFailed {
                     component: ctx.component.to_string(),
                     command: cmd.command.clone(),
                     expected: format!("valid semver requirement (`{}`)", spec),
                     got: format!("parse error: {}", e),
-                }
-            })?;
-
-            let token =
-                extract_semver(&stdout).ok_or_else(|| ExtensionError::ValidateFailed {
-                    component: ctx.component.to_string(),
-                    command: cmd.command.clone(),
-                    expected: format!("a semver-looking token matching `{}`", spec),
-                    got: format!(
-                        "no MAJOR.MINOR.PATCH token in stdout: {}",
-                        truncate(&stdout, 256)
-                    ),
                 })?;
 
-            let actual = semver::Version::parse(&token).map_err(|e| {
-                ExtensionError::ValidateFailed {
+            let token = extract_semver(&stdout).ok_or_else(|| ExtensionError::ValidateFailed {
+                component: ctx.component.to_string(),
+                command: cmd.command.clone(),
+                expected: format!("a semver-looking token matching `{}`", spec),
+                got: format!(
+                    "no MAJOR.MINOR.PATCH token in stdout: {}",
+                    truncate(&stdout, 256)
+                ),
+            })?;
+
+            let actual =
+                semver::Version::parse(&token).map_err(|e| ExtensionError::ValidateFailed {
                     component: ctx.component.to_string(),
                     command: cmd.command.clone(),
                     expected: format!("a parseable semver in stdout matching `{}`", spec),
                     got: format!("`{}`: {}", token, e),
-                }
-            })?;
+                })?;
 
             if !req.matches(&actual) {
                 return Err(ExtensionError::ValidateFailed {
@@ -166,7 +162,9 @@ fn match_semver_at(bytes: &[u8], start: usize) -> Option<(String, usize)> {
         return None;
     }
     let (_, c_end) = scan_digits(bytes, b_end + 1)?;
-    let token = std::str::from_utf8(&bytes[a_start..c_end]).ok()?.to_string();
+    let token = std::str::from_utf8(&bytes[a_start..c_end])
+        .ok()?
+        .to_string();
     Some((token, c_end))
 }
 
@@ -332,7 +330,10 @@ mod tests {
     fn extract_semver_handles_v_prefix_and_trailing_text() {
         assert_eq!(extract_semver("v22.5.1\n").as_deref(), Some("22.5.1"));
         assert_eq!(extract_semver("v22.5.1").as_deref(), Some("22.5.1"));
-        assert_eq!(extract_semver("Python 3.12.4 (...)\n").as_deref(), Some("3.12.4"));
+        assert_eq!(
+            extract_semver("Python 3.12.4 (...)\n").as_deref(),
+            Some("3.12.4")
+        );
         assert_eq!(extract_semver("garbage").as_deref(), None);
     }
 }

--- a/v4/crates/sindri-extensions/src/validate.rs
+++ b/v4/crates/sindri-extensions/src/validate.rs
@@ -1,0 +1,338 @@
+//! Validate executor (DDD-01 §Validate, ADR-024).
+//!
+//! [`ValidateExecutor`] runs the post-install health checks declared by a
+//! component's [`sindri_core::component::ValidateConfig`].
+//!
+//! Each [`sindri_core::component::ValidateCommand`] is dispatched through the
+//! active [`Target`]; stdout is then matched against optional assertions:
+//!
+//! - `expected_output: Some(s)` — `s` must appear as a **substring** of stdout.
+//! - `version_match: Some(spec)` — a semver-looking token (`vMAJOR.MINOR.PATCH`
+//!   or bare `MAJOR.MINOR.PATCH`) is extracted from stdout and compared against
+//!   the [`semver::VersionReq`].
+//!
+//! All assertions must succeed for the validate phase to pass. The first
+//! failure surfaces as [`ExtensionError::ValidateFailed`] with the offending
+//! command and a human-readable expected/got pair.
+
+use crate::error::ExtensionError;
+use sindri_core::component::{ValidateCommand, ValidateConfig};
+use sindri_targets::Target;
+
+/// Context for a validate run.
+pub struct ValidateContext<'a> {
+    /// Component metadata name (e.g. `"nodejs"`).
+    pub component: &'a str,
+    /// Active target for command dispatch.
+    pub target: &'a dyn Target,
+    /// Environment variables to expose to each validate command.
+    pub env: &'a [(&'a str, &'a str)],
+}
+
+/// Capability executor for `validate` (ADR-024).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ValidateExecutor;
+
+impl ValidateExecutor {
+    /// Create a new executor.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Run every command in `cfg`, asserting each one's expected_output
+    /// and/or version_match.
+    pub async fn run(
+        &self,
+        cfg: &ValidateConfig,
+        ctx: &ValidateContext<'_>,
+    ) -> Result<(), ExtensionError> {
+        for cmd in &cfg.commands {
+            self.run_one(cmd, ctx)?;
+        }
+        Ok(())
+    }
+
+    fn run_one(
+        &self,
+        cmd: &ValidateCommand,
+        ctx: &ValidateContext<'_>,
+    ) -> Result<(), ExtensionError> {
+        tracing::info!(
+            component = ctx.component,
+            command = cmd.command.as_str(),
+            "running validate command"
+        );
+
+        let (stdout, stderr) =
+            ctx.target
+                .exec(&cmd.command, ctx.env)
+                .map_err(|err| ExtensionError::ValidateFailed {
+                    component: ctx.component.to_string(),
+                    command: cmd.command.clone(),
+                    expected: "command to exit 0".to_string(),
+                    got: err.to_string(),
+                })?;
+
+        if let Some(expected) = &cmd.expected_output {
+            if !stdout.contains(expected.as_str()) {
+                return Err(ExtensionError::ValidateFailed {
+                    component: ctx.component.to_string(),
+                    command: cmd.command.clone(),
+                    expected: format!("stdout to contain `{}`", expected),
+                    got: truncate(&stdout, 256),
+                });
+            }
+        }
+
+        if let Some(spec) = &cmd.version_match {
+            let req = semver::VersionReq::parse(spec).map_err(|e| {
+                ExtensionError::ValidateFailed {
+                    component: ctx.component.to_string(),
+                    command: cmd.command.clone(),
+                    expected: format!("valid semver requirement (`{}`)", spec),
+                    got: format!("parse error: {}", e),
+                }
+            })?;
+
+            let token =
+                extract_semver(&stdout).ok_or_else(|| ExtensionError::ValidateFailed {
+                    component: ctx.component.to_string(),
+                    command: cmd.command.clone(),
+                    expected: format!("a semver-looking token matching `{}`", spec),
+                    got: format!(
+                        "no MAJOR.MINOR.PATCH token in stdout: {}",
+                        truncate(&stdout, 256)
+                    ),
+                })?;
+
+            let actual = semver::Version::parse(&token).map_err(|e| {
+                ExtensionError::ValidateFailed {
+                    component: ctx.component.to_string(),
+                    command: cmd.command.clone(),
+                    expected: format!("a parseable semver in stdout matching `{}`", spec),
+                    got: format!("`{}`: {}", token, e),
+                }
+            })?;
+
+            if !req.matches(&actual) {
+                return Err(ExtensionError::ValidateFailed {
+                    component: ctx.component.to_string(),
+                    command: cmd.command.clone(),
+                    expected: format!("version matching `{}`", spec),
+                    got: format!("found `{}` (stderr: `{}`)", actual, truncate(&stderr, 128)),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Extract the first `MAJOR.MINOR.PATCH` token from `stdout`, ignoring an
+/// optional leading `v` (so `node --version` → `v22.5.1` → `22.5.1` works).
+fn extract_semver(stdout: &str) -> Option<String> {
+    let bytes = stdout.as_bytes();
+    let n = bytes.len();
+    let mut i = 0;
+    while i < n {
+        // Optional leading `v`/`V`.
+        let mut j = i;
+        if bytes[j] == b'v' || bytes[j] == b'V' {
+            j += 1;
+        }
+        if let Some((token, end)) = match_semver_at(bytes, j) {
+            // Make sure the token isn't preceded by an alphanumeric (so we
+            // don't grab `1.2.3` out of `node1.2.3pre`).
+            if i == 0 || !bytes[i - 1].is_ascii_alphanumeric() {
+                let _ = end;
+                return Some(token);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Try to match `<digits>.<digits>.<digits>` starting at `start`. Returns
+/// the matched token and the index just past it.
+fn match_semver_at(bytes: &[u8], start: usize) -> Option<(String, usize)> {
+    let n = bytes.len();
+    let (a_start, a_end) = scan_digits(bytes, start)?;
+    if a_end >= n || bytes[a_end] != b'.' {
+        return None;
+    }
+    let (_, b_end) = scan_digits(bytes, a_end + 1)?;
+    if b_end >= n || bytes[b_end] != b'.' {
+        return None;
+    }
+    let (_, c_end) = scan_digits(bytes, b_end + 1)?;
+    let token = std::str::from_utf8(&bytes[a_start..c_end]).ok()?.to_string();
+    Some((token, c_end))
+}
+
+fn scan_digits(bytes: &[u8], start: usize) -> Option<(usize, usize)> {
+    let n = bytes.len();
+    if start >= n || !bytes[start].is_ascii_digit() {
+        return None;
+    }
+    let mut end = start;
+    while end < n && bytes[end].is_ascii_digit() {
+        end += 1;
+    }
+    Some((start, end))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::platform::TargetProfile;
+    use sindri_targets::error::TargetError;
+    use sindri_targets::traits::PrereqCheck;
+    use std::sync::Mutex;
+
+    /// Mock target that returns scripted stdout for each command.
+    struct ScriptedTarget {
+        responses: Mutex<Vec<(String, String)>>, // (stdout, stderr) per call
+    }
+
+    impl ScriptedTarget {
+        fn with(stdouts: &[&str]) -> Self {
+            let v = stdouts
+                .iter()
+                .map(|s| ((*s).to_string(), String::new()))
+                .collect::<Vec<_>>();
+            Self {
+                responses: Mutex::new(v),
+            }
+        }
+    }
+
+    impl Target for ScriptedTarget {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+        fn kind(&self) -> &str {
+            "scripted"
+        }
+        fn profile(&self) -> Result<TargetProfile, TargetError> {
+            Err(TargetError::Unavailable {
+                name: "scripted".into(),
+                reason: "test".into(),
+            })
+        }
+        fn exec(&self, _cmd: &str, _env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
+            let mut g = self.responses.lock().unwrap();
+            if g.is_empty() {
+                return Ok((String::new(), String::new()));
+            }
+            Ok(g.remove(0))
+        }
+        fn upload(&self, _l: &std::path::Path, _r: &str) -> Result<(), TargetError> {
+            Ok(())
+        }
+        fn download(&self, _r: &str, _l: &std::path::Path) -> Result<(), TargetError> {
+            Ok(())
+        }
+        fn check_prerequisites(&self) -> Vec<PrereqCheck> {
+            Vec::new()
+        }
+    }
+
+    fn ctx<'a>(target: &'a dyn Target) -> ValidateContext<'a> {
+        ValidateContext {
+            component: "nodejs",
+            target,
+            env: &[],
+        }
+    }
+
+    #[tokio::test]
+    async fn version_match_passes_for_compatible_version() {
+        let t = ScriptedTarget::with(&["v22.5.1\n"]);
+        let cfg = ValidateConfig {
+            commands: vec![ValidateCommand {
+                command: "node --version".into(),
+                expected_output: None,
+                version_match: Some(">=22.0.0".into()),
+            }],
+        };
+        ValidateExecutor::new()
+            .run(&cfg, &ctx(&t))
+            .await
+            .expect("v22.5.1 satisfies >=22.0.0");
+    }
+
+    #[tokio::test]
+    async fn version_match_fails_for_incompatible_version() {
+        let t = ScriptedTarget::with(&["v18.20.0\n"]);
+        let cfg = ValidateConfig {
+            commands: vec![ValidateCommand {
+                command: "node --version".into(),
+                expected_output: None,
+                version_match: Some(">=22.0.0".into()),
+            }],
+        };
+        let err = ValidateExecutor::new()
+            .run(&cfg, &ctx(&t))
+            .await
+            .expect_err("v18.20.0 must not satisfy >=22.0.0");
+        match err {
+            ExtensionError::ValidateFailed {
+                component, command, ..
+            } => {
+                assert_eq!(component, "nodejs");
+                assert_eq!(command, "node --version");
+            }
+            other => panic!("expected ValidateFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn expected_output_substring_match() {
+        let t = ScriptedTarget::with(&["hello world from sindri\n"]);
+        let cfg = ValidateConfig {
+            commands: vec![ValidateCommand {
+                command: "echo hello".into(),
+                expected_output: Some("from sindri".into()),
+                version_match: None,
+            }],
+        };
+        ValidateExecutor::new()
+            .run(&cfg, &ctx(&t))
+            .await
+            .expect("substring should match");
+    }
+
+    #[tokio::test]
+    async fn expected_output_failure_yields_validate_failed() {
+        let t = ScriptedTarget::with(&["nope\n"]);
+        let cfg = ValidateConfig {
+            commands: vec![ValidateCommand {
+                command: "echo nope".into(),
+                expected_output: Some("yes".into()),
+                version_match: None,
+            }],
+        };
+        let err = ValidateExecutor::new()
+            .run(&cfg, &ctx(&t))
+            .await
+            .expect_err("substring miss must fail");
+        assert!(matches!(err, ExtensionError::ValidateFailed { .. }));
+    }
+
+    #[test]
+    fn extract_semver_handles_v_prefix_and_trailing_text() {
+        assert_eq!(extract_semver("v22.5.1\n").as_deref(), Some("22.5.1"));
+        assert_eq!(extract_semver("v22.5.1").as_deref(), Some("22.5.1"));
+        assert_eq!(extract_semver("Python 3.12.4 (...)\n").as_deref(), Some("3.12.4"));
+        assert_eq!(extract_semver("garbage").as_deref(), None);
+    }
+}

--- a/v4/crates/sindri-resolver/src/lockfile_writer.rs
+++ b/v4/crates/sindri-resolver/src/lockfile_writer.rs
@@ -51,5 +51,8 @@ pub fn resolved_from_entry(
         oci_digest: Some(entry.oci_ref.clone()),
         checksums: Default::default(),
         depends_on: entry.depends_on.clone(),
+        // Wave 3A will fetch manifests from OCI; until then, the apply
+        // pipeline degrades to install + hooks only when manifest is None.
+        manifest: None,
     }
 }

--- a/v4/crates/sindri/Cargo.toml
+++ b/v4/crates/sindri/Cargo.toml
@@ -26,3 +26,7 @@ dirs-next = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/v4/crates/sindri/src/commands/apply.rs
+++ b/v4/crates/sindri/src/commands/apply.rs
@@ -1,6 +1,35 @@
-use sindri_backends::install_component;
+//! `sindri apply` — execute the lockfile against a target (ADR-024, plan §4.4).
+//!
+//! Top-level orchestrator. Per ADR-024 the apply pipeline is:
+//!
+//! ```text
+//!   0. CollisionResolver.validate_and_resolve(&closure)  // once, up-front
+//!   for each component (in order):
+//!       1. pre-install hook
+//!       2. install backend
+//!       3. configure   (manifest-only)
+//!       4. validate    (manifest-only)
+//!       5. post-install hook
+//!   // After all installs:
+//!   6. pre-project-init hooks   (per component)
+//!   7. ProjectInitExecutor.run(steps_sorted_by_priority)
+//!   8. post-project-init hooks  (per component)
+//! ```
+//!
+//! Steps 1–5 are factored into [`super::apply_lifecycle::install_one`]; this
+//! function is the thin shell that loads the lockfile, runs collision
+//! validation, drives the loop, and runs the project-init pass.
+
+use crate::commands::apply_lifecycle::{install_one, ApplyError, ApplyOptions};
+use sindri_core::component::ComponentManifest;
 use sindri_core::exit_codes::{EXIT_RESOLUTION_CONFLICT, EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
-use sindri_targets::LocalTarget;
+use sindri_core::lockfile::ResolvedComponent;
+use sindri_core::platform::Platform;
+use sindri_extensions::{
+    CollisionContext, CollisionResolver, ComponentRef, HookContext, HooksExecutor,
+    ProjectInitContext, ProjectInitExecutor,
+};
+use sindri_targets::{LocalTarget, Target};
 use std::path::{Path, PathBuf};
 
 pub struct ApplyArgs {
@@ -44,7 +73,6 @@ async fn run_async(args: ApplyArgs) -> i32 {
         return EXIT_STALE_LOCKFILE;
     }
 
-    // Load lockfile
     let content = match std::fs::read_to_string(&lockfile_path) {
         Ok(c) => c,
         Err(e) => {
@@ -61,7 +89,6 @@ async fn run_async(args: ApplyArgs) -> i32 {
         }
     };
 
-    // Check staleness against sindri.yaml
     if Path::new("sindri.yaml").exists() {
         let bom_content = std::fs::read_to_string("sindri.yaml").unwrap_or_default();
         let current_hash = compute_hash(&bom_content);
@@ -89,7 +116,6 @@ async fn run_async(args: ApplyArgs) -> i32 {
         return EXIT_SUCCESS;
     }
 
-    // Show plan
     println!(
         "Plan: {} component(s) to apply on {}:",
         total, lockfile.target
@@ -108,7 +134,6 @@ async fn run_async(args: ApplyArgs) -> i32 {
         return EXIT_SUCCESS;
     }
 
-    // Prompt unless --yes
     if !args.yes {
         eprint!("\nProceed? [y/N] ");
         let mut input = String::new();
@@ -121,17 +146,79 @@ async fn run_async(args: ApplyArgs) -> i32 {
         }
     }
 
-    // Install in topological order (already sorted by resolver)
+    let platform = Platform::current();
+
+    // Step 0: CollisionResolver validates the entire closure once.
+    //
+    // Today the lockfile rarely carries manifests (resolver fetches OCI in
+    // Wave 3A), so in the common case this is a no-op. When manifests ARE
+    // present, the resolver enforces ADR-008 Gate 4 path-prefix rules and
+    // returns a (possibly reordered) `ordered` plus a `skipped` list.
+    let manifest_pairs: Vec<(ComponentManifest, &str)> = lockfile
+        .components
+        .iter()
+        .filter_map(|c| c.manifest.clone().map(|m| (m, "sindri/core")))
+        .collect();
+    let coll_ctx = CollisionContext { target: &target };
+    let plan = match CollisionResolver::new()
+        .validate_and_resolve(&manifest_pairs, &coll_ctx)
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Collision validation failed: {}", e);
+            return EXIT_RESOLUTION_CONFLICT;
+        }
+    };
+
+    // Build a name → manifest map for downstream lookup. (Lockfile entries
+    // remain authoritative for ordering — collision plan only filters.)
+    let skipped_names: std::collections::HashSet<String> = plan
+        .skipped
+        .iter()
+        .map(|(m, _)| m.metadata.name.clone())
+        .collect();
+    for (m, why) in &plan.skipped {
+        tracing::warn!(
+            component = m.metadata.name.as_str(),
+            "collision: skipping component — {}",
+            why
+        );
+    }
+
+    let apply_options = ApplyOptions::default();
     let mut failed = 0usize;
+    let mut applied: Vec<&ResolvedComponent> = Vec::new();
+
     for comp in &lockfile.components {
+        if skipped_names.contains(&comp.id.name) {
+            println!(
+                "  - {} {} (skipped by collision plan)",
+                comp.id.to_address(),
+                comp.version
+            );
+            continue;
+        }
+
         print!("  Installing {} {}...", comp.id.to_address(), comp.version);
-        // manifest = None: OCI ComponentManifest fetch is wired in Wave 3.
-        // Until then backends fall back to minimal name@version invocations
-        // and emit `tracing::debug!` so the gap is observable.
-        match install_component(comp, None, &target).await {
-            Ok(()) => println!(" done"),
+        match install_one(
+            comp,
+            comp.manifest.as_ref(),
+            &target,
+            &platform,
+            &apply_options,
+        )
+        .await
+        {
+            Ok(outcome) => {
+                println!(
+                    " done (hooks={}, configured={}, validated={})",
+                    outcome.hooks_ran, outcome.configured, outcome.validated
+                );
+                applied.push(comp);
+            }
             Err(e) => {
-                println!(" FAILED: {}", e);
+                println!(" FAILED: {}", render_apply_err(&e));
                 failed += 1;
             }
         }
@@ -139,11 +226,91 @@ async fn run_async(args: ApplyArgs) -> i32 {
 
     if failed > 0 {
         eprintln!("\n{}/{} component(s) failed", failed, total);
-        EXIT_RESOLUTION_CONFLICT
-    } else {
-        println!("\nApplied {} component(s) successfully.", total);
-        EXIT_SUCCESS
+        return EXIT_RESOLUTION_CONFLICT;
     }
+
+    // Project-init pass (steps 6–8). Runs across every component that was
+    // successfully installed AND has a manifest with project_init steps.
+    if let Err(e) = run_project_init_pass(&applied, &target).await {
+        eprintln!("project-init failed: {}", render_apply_err(&e));
+        return EXIT_RESOLUTION_CONFLICT;
+    }
+
+    println!("\nApplied {} component(s) successfully.", applied.len());
+    EXIT_SUCCESS
+}
+
+/// Run hooks.pre_project_init, then ProjectInitExecutor across the closure,
+/// then hooks.post_project_init. Components without a manifest contribute
+/// nothing to this pass.
+async fn run_project_init_pass(
+    applied: &[&ResolvedComponent],
+    target: &dyn Target,
+) -> Result<(), ApplyError> {
+    let hooks_executor = HooksExecutor::new();
+
+    // 6. pre-project-init hooks (per component, in apply order).
+    for comp in applied {
+        if let Some(m) = comp.manifest.as_ref() {
+            if let Some(h) = m.capabilities.hooks.as_ref() {
+                let ctx = HookContext {
+                    component: &comp.id.name,
+                    version: &comp.version.0,
+                    target,
+                    env: &[],
+                    workdir: ".",
+                };
+                hooks_executor.run_pre_project_init(h, &ctx).await?;
+            }
+        }
+    }
+
+    // 7. ProjectInitExecutor.
+    let mut steps: Vec<(ComponentRef, &sindri_core::component::ProjectInitStep)> = Vec::new();
+    for comp in applied {
+        if let Some(m) = comp.manifest.as_ref() {
+            if let Some(list) = m.capabilities.project_init.as_ref() {
+                let cref = ComponentRef {
+                    component_id: comp.id.clone(),
+                    name: comp.id.name.clone(),
+                };
+                for step in list {
+                    steps.push((cref.clone(), step));
+                }
+            }
+        }
+    }
+    if !steps.is_empty() {
+        let workdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let pi_ctx = ProjectInitContext {
+            target,
+            workdir: workdir.as_path(),
+            env: &[],
+        };
+        ProjectInitExecutor::new().run(&steps, &pi_ctx).await?;
+    }
+
+    // 8. post-project-init hooks (per component, in apply order).
+    for comp in applied {
+        if let Some(m) = comp.manifest.as_ref() {
+            if let Some(h) = m.capabilities.hooks.as_ref() {
+                let ctx = HookContext {
+                    component: &comp.id.name,
+                    version: &comp.version.0,
+                    target,
+                    env: &[],
+                    workdir: ".",
+                };
+                hooks_executor.run_post_project_init(h, &ctx).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn render_apply_err(e: &ApplyError) -> String {
+    e.to_string()
 }
 
 fn compute_hash(content: &str) -> String {

--- a/v4/crates/sindri/src/commands/apply_lifecycle.rs
+++ b/v4/crates/sindri/src/commands/apply_lifecycle.rs
@@ -1,0 +1,470 @@
+//! Per-component apply lifecycle (ADR-024).
+//!
+//! This module factors the per-component lifecycle out of
+//! [`crate::commands::apply`] so the top-level command stays a thin
+//! load-lockfile / collision-resolve / loop-and-call shell.
+//!
+//! Per ADR-024, a single component goes through this sequence:
+//!
+//! ```text
+//!   1. PRE-INSTALL  hook   (HooksExecutor::run_pre_install)
+//!   2. install             (sindri_backends::install_component)
+//!   3. CONFIGURE           (ConfigureExecutor::apply, manifest-only)
+//!   4. VALIDATE            (ValidateExecutor::run,    manifest-only)
+//!   5. POST-INSTALL hook   (HooksExecutor::run_post_install)
+//! ```
+//!
+//! When the lockfile entry has no embedded `manifest` (the resolver does
+//! not yet fetch OCI manifests — Wave 3A), only steps 1, 2, and 5 run.
+//! Steps 3 and 4 emit a single `tracing::debug!` and are skipped.
+//!
+//! Project-init runs **after** every component has been installed, in a
+//! second pass driven by [`crate::commands::apply::run`].
+
+use sindri_backends::{install_component, BackendError};
+use sindri_core::component::ComponentManifest;
+use sindri_core::lockfile::ResolvedComponent;
+use sindri_core::platform::Platform;
+use sindri_extensions::{
+    ConfigureContext, ConfigureExecutor, ExtensionError, HookContext, HooksExecutor,
+    ValidateContext, ValidateExecutor,
+};
+use sindri_targets::Target;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Options influencing the per-component lifecycle.
+#[derive(Debug, Clone, Default)]
+pub struct ApplyOptions {
+    /// Filesystem root for shell-rc env fragments. Defaults to
+    /// `$HOME/.sindri/env` when `None`.
+    pub env_dir: Option<PathBuf>,
+    /// Filesystem root for `~`-expansion in [`ConfigureExecutor`]. Defaults
+    /// to `$HOME` when `None`.
+    pub home_dir: Option<PathBuf>,
+}
+
+/// Outcome record for a single component's apply.
+///
+/// Useful for human-readable reporting at the end of the run.
+#[derive(Debug, Clone, Default)]
+pub struct ApplyOutcome {
+    /// `true` if the install backend completed (or reported "already
+    /// installed") without error.
+    pub installed: bool,
+    /// `true` if a [`sindri_core::component::ValidateConfig`] was present
+    /// and every assertion passed.
+    pub validated: bool,
+    /// `true` if a [`sindri_core::component::ConfigureConfig`] was applied.
+    pub configured: bool,
+    /// Number of lifecycle hooks that fired (0–2 for install-time;
+    /// project-init hooks are counted in a separate pass).
+    pub hooks_ran: u8,
+}
+
+/// Errors produced by the apply lifecycle.
+///
+/// Wraps the underlying domain errors so the CLI can render a single
+/// uniform diagnostic with the right exit code.
+#[derive(Debug, Error)]
+pub enum ApplyError {
+    /// Backend install (or pre-flight dispatch) failed.
+    #[error(transparent)]
+    Backend(#[from] BackendError),
+    /// A capability executor (hooks, configure, validate, project-init)
+    /// returned an error.
+    #[error(transparent)]
+    Extension(#[from] ExtensionError),
+}
+
+/// Run the install-time lifecycle for one component.
+///
+/// `manifest` is `Option<&ComponentManifest>` because OCI manifest fetch
+/// lands in Wave 3A; until then the resolver always emits `None` and the
+/// configure/validate steps are skipped with a `tracing::debug!`.
+///
+/// Returns a [`ApplyOutcome`] summarising what actually ran.
+pub async fn install_one(
+    comp: &ResolvedComponent,
+    manifest: Option<&ComponentManifest>,
+    target: &dyn Target,
+    platform: &Platform,
+    options: &ApplyOptions,
+) -> Result<ApplyOutcome, ApplyError> {
+    let mut outcome = ApplyOutcome::default();
+    let component_name = comp.id.name.as_str();
+    let version = comp.version.0.as_str();
+    let hooks = manifest.and_then(|m| m.capabilities.hooks.as_ref());
+
+    let hooks_executor = HooksExecutor::new();
+
+    // Step 1: pre-install hook.
+    if let Some(h) = hooks {
+        let ctx = hook_ctx(component_name, version, target);
+        hooks_executor.run_pre_install(h, &ctx).await?;
+        if h.pre_install.is_some() {
+            outcome.hooks_ran += 1;
+        }
+    }
+
+    // Step 2: install backend.
+    install_component(comp, manifest, target).await?;
+    outcome.installed = true;
+
+    // Steps 3 & 4: configure + validate, manifest-only.
+    if let Some(m) = manifest {
+        if let Some(cfg) = m.effective_configure(platform) {
+            let env_dir = options.env_dir.clone().unwrap_or_else(default_env_dir);
+            let home_dir = options.home_dir.clone().unwrap_or_else(default_home_dir);
+            let cfg_ctx = ConfigureContext {
+                component: component_name,
+                version,
+                target_name: target.name(),
+                env_dir: env_dir.as_path(),
+                home_dir: home_dir.as_path(),
+            };
+            ConfigureExecutor::new().apply(cfg, &cfg_ctx).await?;
+            outcome.configured = true;
+        }
+        if let Some(v) = m.effective_validate(platform) {
+            let v_ctx = ValidateContext {
+                component: component_name,
+                target,
+                env: &[],
+            };
+            ValidateExecutor::new().run(v, &v_ctx).await?;
+            outcome.validated = true;
+        }
+    } else {
+        tracing::debug!(
+            component = component_name,
+            "manifest not yet plumbed; skipping configure/validate \
+             (Wave 3A will fetch ComponentManifest from OCI)"
+        );
+    }
+
+    // Step 5: post-install hook.
+    if let Some(h) = hooks {
+        let ctx = hook_ctx(component_name, version, target);
+        hooks_executor.run_post_install(h, &ctx).await?;
+        if h.post_install.is_some() {
+            outcome.hooks_ran += 1;
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Build a [`HookContext`] for a target. Static lifetimes are easy here
+/// because the caller (apply.rs) holds component/version strings on the
+/// stack across each `install_one` invocation.
+fn hook_ctx<'a>(component: &'a str, version: &'a str, target: &'a dyn Target) -> HookContext<'a> {
+    HookContext {
+        component,
+        version,
+        target,
+        env: &[],
+        workdir: ".",
+    }
+}
+
+fn default_env_dir() -> PathBuf {
+    if let Some(home) = dirs_next::home_dir() {
+        home.join(".sindri").join("env")
+    } else {
+        PathBuf::from(".sindri/env")
+    }
+}
+
+fn default_home_dir() -> PathBuf {
+    dirs_next::home_dir().unwrap_or_else(|| PathBuf::from("."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::component::{
+        Backend, ComponentCapabilities, ComponentId, ComponentManifest, ComponentMetadata,
+        HooksConfig, InstallConfig, ValidateCommand, ValidateConfig,
+    };
+    use sindri_core::platform::TargetProfile;
+    use sindri_core::version::Version;
+    use sindri_targets::error::TargetError;
+    use sindri_targets::traits::PrereqCheck;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    /// Mock target that records every command and can return scripted stdout.
+    struct MockTarget {
+        commands: Mutex<Vec<String>>,
+        responses: Mutex<Vec<(String, String)>>, // popped per call after recording
+    }
+
+    impl MockTarget {
+        fn new() -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+                responses: Mutex::new(Vec::new()),
+            }
+        }
+        fn with_responses(responses: Vec<&str>) -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+                responses: Mutex::new(
+                    responses
+                        .into_iter()
+                        .map(|s| (s.to_string(), String::new()))
+                        .collect(),
+                ),
+            }
+        }
+        fn captured(&self) -> Vec<String> {
+            self.commands.lock().unwrap().clone()
+        }
+    }
+
+    impl Target for MockTarget {
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn kind(&self) -> &str {
+            // Pretend to be a local target so the Script backend proceeds
+            // (it rejects non-local targets with a Wave-3 stub error). The
+            // script backend then no-ops cleanly when no cached script is
+            // present, which is exactly what we want for these unit tests.
+            "local"
+        }
+        fn profile(&self) -> Result<TargetProfile, TargetError> {
+            Err(TargetError::Unavailable {
+                name: "mock".into(),
+                reason: "test fixture".into(),
+            })
+        }
+        fn exec(&self, cmd: &str, _env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
+            self.commands.lock().unwrap().push(cmd.to_string());
+            let mut g = self.responses.lock().unwrap();
+            if g.is_empty() {
+                Ok((String::new(), String::new()))
+            } else {
+                Ok(g.remove(0))
+            }
+        }
+        fn upload(&self, _l: &std::path::Path, _r: &str) -> Result<(), TargetError> {
+            Ok(())
+        }
+        fn download(&self, _r: &str, _l: &std::path::Path) -> Result<(), TargetError> {
+            Ok(())
+        }
+        fn check_prerequisites(&self) -> Vec<PrereqCheck> {
+            Vec::new()
+        }
+    }
+
+    /// Build a script-backend ResolvedComponent so `install_component`
+    /// dispatches a `sh:noop` install — which the script backend handles
+    /// without requiring real binaries on the host.
+    fn comp_script(name: &str) -> ResolvedComponent {
+        ResolvedComponent {
+            id: ComponentId {
+                backend: Backend::Script,
+                name: name.into(),
+                qualifier: None,
+            },
+            version: Version::new("1.0.0"),
+            backend: Backend::Script,
+            oci_digest: None,
+            checksums: Default::default(),
+            depends_on: vec![],
+            manifest: None,
+        }
+    }
+
+    fn manifest_for(
+        name: &str,
+        hooks: Option<HooksConfig>,
+        validate: Option<ValidateConfig>,
+    ) -> ComponentManifest {
+        ComponentManifest {
+            metadata: ComponentMetadata {
+                name: name.into(),
+                version: "1.0.0".into(),
+                description: "t".into(),
+                license: "MIT".into(),
+                tags: Vec::new(),
+                homepage: None,
+            },
+            platforms: Vec::new(),
+            install: InstallConfig {
+                script: Some(sindri_core::component::ScriptInstallConfig {
+                    sh: Some("true".into()),
+                    ps1: None,
+                }),
+                ..Default::default()
+            },
+            depends_on: Vec::new(),
+            capabilities: ComponentCapabilities {
+                collision_handling: None,
+                hooks,
+                project_init: None,
+            },
+            options: Default::default(),
+            validate,
+            configure: None,
+            remove: None,
+            overrides: Default::default(),
+        }
+    }
+
+    fn options_with_temp(env: &TempDir, home: &TempDir) -> ApplyOptions {
+        ApplyOptions {
+            env_dir: Some(env.path().to_path_buf()),
+            home_dir: Some(home.path().to_path_buf()),
+        }
+    }
+
+    #[tokio::test]
+    async fn install_one_runs_pre_install_then_install_then_post_install() {
+        let env = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        let target = MockTarget::new();
+        let platform = Platform::current();
+        let comp = comp_script("nodejs");
+        let manifest = manifest_for(
+            "nodejs",
+            Some(HooksConfig {
+                pre_install: Some("echo PRE".into()),
+                post_install: Some("echo POST".into()),
+                ..Default::default()
+            }),
+            None,
+        );
+
+        let outcome = install_one(
+            &comp,
+            Some(&manifest),
+            &target,
+            &platform,
+            &options_with_temp(&env, &home),
+        )
+        .await
+        .expect("lifecycle ok");
+
+        assert!(outcome.installed);
+        assert_eq!(outcome.hooks_ran, 2);
+        let captured = target.captured();
+        let pre = captured
+            .iter()
+            .position(|c| c == "echo PRE")
+            .expect("pre captured");
+        let post = captured
+            .iter()
+            .position(|c| c == "echo POST")
+            .expect("post captured");
+        assert!(pre < post, "pre-install must run before post-install");
+    }
+
+    #[tokio::test]
+    async fn install_one_skips_validate_when_manifest_absent() {
+        let env = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        let target = MockTarget::new();
+        let platform = Platform::current();
+        let comp = comp_script("nodejs");
+
+        let outcome = install_one(
+            &comp,
+            None, // manifest absent
+            &target,
+            &platform,
+            &options_with_temp(&env, &home),
+        )
+        .await
+        .expect("lifecycle ok without manifest");
+
+        assert!(outcome.installed);
+        assert!(!outcome.validated);
+        assert!(!outcome.configured);
+        assert_eq!(outcome.hooks_ran, 0);
+    }
+
+    #[tokio::test]
+    async fn install_one_runs_validate_when_manifest_present() {
+        let env = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        // The script backend is a no-op when there is no cached script,
+        // so validate is the FIRST exec call to the mock. Script the
+        // first response with the version string.
+        let target = MockTarget::with_responses(vec!["v22.5.1\n"]);
+        let platform = Platform::current();
+        let comp = comp_script("nodejs");
+        let manifest = manifest_for(
+            "nodejs",
+            None,
+            Some(ValidateConfig {
+                commands: vec![ValidateCommand {
+                    command: "node --version".into(),
+                    expected_output: None,
+                    version_match: Some(">=22.0.0".into()),
+                }],
+            }),
+        );
+
+        let outcome = install_one(
+            &comp,
+            Some(&manifest),
+            &target,
+            &platform,
+            &options_with_temp(&env, &home),
+        )
+        .await
+        .expect("validate should pass");
+        assert!(outcome.validated);
+    }
+
+    #[tokio::test]
+    async fn validate_failure_aborts_lifecycle() {
+        let env = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        // Script backend is a no-op (no cached script); validate is the
+        // first exec call → return an incompatible version.
+        let target = MockTarget::with_responses(vec!["v18.20.0\n"]);
+        let platform = Platform::current();
+        let comp = comp_script("nodejs");
+        let manifest = manifest_for(
+            "nodejs",
+            Some(HooksConfig {
+                post_install: Some("echo SHOULD_NOT_RUN".into()),
+                ..Default::default()
+            }),
+            Some(ValidateConfig {
+                commands: vec![ValidateCommand {
+                    command: "node --version".into(),
+                    expected_output: None,
+                    version_match: Some(">=22.0.0".into()),
+                }],
+            }),
+        );
+
+        let err = install_one(
+            &comp,
+            Some(&manifest),
+            &target,
+            &platform,
+            &options_with_temp(&env, &home),
+        )
+        .await
+        .expect_err("v18 must abort lifecycle");
+        match err {
+            ApplyError::Extension(ExtensionError::ValidateFailed { component, .. }) => {
+                assert_eq!(component, "nodejs");
+            }
+            other => panic!("expected ValidateFailed, got {other:?}"),
+        }
+
+        // Post-install must NOT have fired.
+        assert!(
+            !target.captured().iter().any(|c| c == "echo SHOULD_NOT_RUN"),
+            "post-install hook must not run after a validate failure"
+        );
+    }
+}

--- a/v4/crates/sindri/src/commands/mod.rs
+++ b/v4/crates/sindri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod apply;
+pub mod apply_lifecycle;
 pub mod bom;
 pub mod diff;
 pub mod doctor;

--- a/v4/crates/sindri/src/commands/remove.rs
+++ b/v4/crates/sindri/src/commands/remove.rs
@@ -1,3 +1,9 @@
+// SCOPE NOTE (feat/v4-apply-capability-wiring): the install-time wiring for
+// hooks / configure / validate / project-init lands in this PR. Wiring the
+// `RemoveExecutor` (running RemoveConfig.commands and deleting RemoveConfig
+// .files) is intentionally deferred to a follow-up so the diff stays
+// focused. Until then, `sindri remove` only edits sindri.yaml; backend
+// uninstall + custom remove commands are tracked as a follow-up to ADR-024.
 use crate::commands::manifest::{find_entry_index, load_manifest, save_manifest};
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 


### PR DESCRIPTION
## Summary

PR #209 added `sindri-extensions` capability executors (HooksExecutor,
ProjectInitExecutor, CollisionResolver) but did not wire them into apply.
PR #214 added DDD-01 fields to `ComponentManifest` (validate / configure /
remove / per-platform overrides) but those, too, were unwired. Today
`sindri apply` only runs the backend's install command.

This PR implements the full ADR-024 lifecycle in `sindri apply`.

## Why

- audit ref §3 — apply-time capabilities never executed
- audit ref §5.6 — DDD-01 manifest fields had no consumer

## Lifecycle order (ADR-024)

```
  0. CollisionResolver.validate_and_resolve(closure)   // once
  for each component (topological + collision-ordered):
    1. pre-install hook                (HooksExecutor::run_pre_install)
    2. backend.install                 (sindri_backends::install_component)
    3. configure   (manifest-only)     (ConfigureExecutor::apply)
    4. validate    (manifest-only)     (ValidateExecutor::run)
    5. post-install hook               (HooksExecutor::run_post_install)
  // after all installs:
  6. pre-project-init hooks            (HooksExecutor::run_pre_project_init)
  7. ProjectInitExecutor.run(...)      (priority-ordered)
  8. post-project-init hooks           (HooksExecutor::run_post_project_init)
```

Steps 1–5 are factored into a new `apply_lifecycle::install_one(...)`. The
top-level `apply::run` becomes a thin shell that loads the lockfile, runs
collision validation, drives the per-component loop, and runs the
project-init pass.

Components withheld by the collision plan log a `tracing::warn!` and are
excluded from steps 1–8.

## New executors

### `ConfigureExecutor` (DDD-01 §Configure)
- Per-component shell-rc env fragments at `<env-dir>/<name>.sh`
- Idempotent guard block (`# sindri:auto`) appended to `~/.bashrc` and
  `~/.zshrc` so fragments are sourced on next interactive shell.
- Mustache-style `{{var}}` substitution for `FileTemplate` bodies with
  `{{component.name}}`, `{{version}}`, `{{target}}`, `{{env.NAME}}`.
- `overwrite: false` preserves existing files (warn-only).
- Non-`ShellRc` scopes (`Login`, `Session`, `UserEnvVar`) emit a
  `tracing::warn!` and are skipped — implementation-plan §5.5 will
  introduce the full PATH/scope abstraction in a follow-up.

### `ValidateExecutor` (DDD-01 §Validate)
- Dispatches each `ValidateCommand` through `Target::exec`.
- `expected_output: Some(s)` — substring match against stdout.
- `version_match: Some(spec)` — extracts `MAJOR.MINOR.PATCH` (with
  optional leading `v`) from stdout and compares against
  `semver::VersionReq`.
- First failed assertion surfaces as
  `ExtensionError::ValidateFailed { component, command, expected, got }`.

`semver` added to workspace deps. `ExtensionError` extended with
`ConfigureFailed`, `ValidateFailed`, `RemoveFailed`.

## Schema impact

`Lockfile.components[].manifest` is now `Option<ComponentManifest>` with
`#[serde(default)]` + `skip_serializing_if = Option::is_none`. The
resolver always emits `manifest: None` today (Wave 3A will fetch from
OCI); existing lockfiles deserialize unchanged. When `manifest` is
`None`, the apply pipeline degrades gracefully — only steps 1, 2, 5 run
for that component.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings)
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (all green)

New tests:
- `apply_lifecycle::tests::install_one_runs_pre_install_then_install_then_post_install`
- `apply_lifecycle::tests::install_one_skips_validate_when_manifest_absent`
- `apply_lifecycle::tests::install_one_runs_validate_when_manifest_present`
- `apply_lifecycle::tests::validate_failure_aborts_lifecycle`
- `configure::tests::env_setting_writes_per_component_fragment`
- `configure::tests::rerun_does_not_double_append_rc_block`
- `configure::tests::file_template_substitutes_vars`
- `configure::tests::overwrite_false_preserves_existing`
- `configure::tests::unknown_template_var_errors`
- `configure::tests::shell_escape_handles_quotes_and_dollars`
- `validate::tests::version_match_passes_for_compatible_version`
- `validate::tests::version_match_fails_for_incompatible_version`
- `validate::tests::expected_output_substring_match`
- `validate::tests::expected_output_failure_yields_validate_failed`
- `validate::tests::extract_semver_handles_v_prefix_and_trailing_text`

## Out of scope (deferred to follow-ups)

- **OCI manifest fetch** — Wave 3A. Until then `manifest: None` and
  configure/validate are skipped with a `tracing::debug!`.
- **`sindri remove` wiring** — only edits `sindri.yaml` today; running
  `RemoveConfig.commands` and deleting `RemoveConfig.files` is tracked
  by a SCOPE NOTE in `remove.rs`. The decision was to keep this PR
  install-time only; remove-side wiring is a focused follow-up that
  needs a confirmation-prompt design (`--yes` semantics) of its own.
- **Remote-target migration** for DockerTarget/SshTarget/cloud — Wave 3.
- **Project-init across multiple targets** — single-target only.
- **Full PATH/shell-rc scope abstraction** (implementation-plan §5.5).
- **No new fields added to `ComponentManifest`.**

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)