### PR TITLE
feat(v4): registry foundation for OCI + cosign (ADR-003, ADR-014 — scaffold)

### DIFF
--- a/v4/.cargo/audit.toml
+++ b/v4/.cargo/audit.toml
@@ -1,0 +1,17 @@
+# cargo-audit configuration for the v4 workspace.
+#
+# Ignored advisories listed below are intentionally suppressed.  Each must
+# include a "reason" explaining why the vulnerable code path is unreachable
+# in this workspace.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071 — "Marvin attack" timing side-channel in `rsa` crate
+    # decryption.  Pulled in transitively by `sigstore` (X.509 / Fulcio /
+    # Rekor support).  Sindri only loads ECDSA P-256 cosign keys (see
+    # crates/sindri-registry/src/signing.rs); the RSA decryption path is
+    # never exercised.  Upstream `rsa` has no fix as of 2026-04 — track for
+    # removal once the `rsa` crate releases a constant-time fix or
+    # `sigstore` ships a feature gate to drop the rsa dependency.
+    "RUSTSEC-2023-0071",
+]

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -3,6 +3,45 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +98,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,10 +126,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "regex",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-fips-sys",
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -89,11 +228,39 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -109,13 +276,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -129,6 +316,42 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -171,10 +394,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -183,12 +431,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -201,14 +517,202 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -244,10 +748,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -272,10 +848,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -287,12 +903,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -300,6 +938,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -313,10 +985,26 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -347,6 +1035,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +1110,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +1135,15 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -454,7 +1226,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -469,6 +1241,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -554,6 +1350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,12 +1378,35 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -607,10 +1432,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -625,10 +1536,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+]
+
+[[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common 0.1.7",
+ "digest 0.10.7",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -679,6 +1659,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +1689,191 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec 0.8.4",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jsonwebtoken",
+ "lazy_static",
+ "oci-spec 0.9.0",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -700,6 +1887,82 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -725,16 +1988,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -746,6 +2129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,12 +2144,139 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "base64 0.22.1",
+ "prost",
+ "prost-reflect-derive",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8214ae2c30bbac390db0134d08300e770ef89b6d4e5abf855e8d300eded87e28"
+dependencies = [
+ "prost-build",
+ "prost-reflect",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -789,10 +2305,11 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -835,12 +2352,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -850,7 +2388,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -903,14 +2450,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -924,20 +2544,32 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
- "webpki-roots",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -950,8 +2582,28 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -959,6 +2611,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -979,12 +2640,26 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -998,14 +2673,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1021,13 +2724,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schema-gen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "schemars",
+ "schemars 1.2.1",
  "serde_json",
  "sindri-core",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1062,6 +2804,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +2866,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -1122,6 +2923,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,16 +2955,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1153,8 +3027,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1174,6 +3048,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "sigstore"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "cfg-if",
+ "chrono",
+ "const-oid 0.9.6",
+ "crypto_secretbox",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "futures",
+ "futures-util",
+ "hex",
+ "oci-client 0.15.0",
+ "olpc-cjson",
+ "openidconnect",
+ "p256",
+ "p384",
+ "pem",
+ "pkcs1",
+ "pkcs8",
+ "rand 0.8.6",
+ "regex",
+ "reqwest 0.12.28",
+ "rsa",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "sigstore_protobuf_specs",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "tokio",
+ "tokio-util",
+ "tough",
+ "tracing",
+ "url",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "sigstore-protobuf-specs-derive"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sigstore_protobuf_specs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2"
+dependencies = [
+ "anyhow",
+ "glob",
+ "prost",
+ "prost-build",
+ "prost-reflect",
+ "prost-reflect-build",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "sigstore-protobuf-specs-derive",
+ "which",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "sindri"
 version = "0.1.0"
 dependencies = [
@@ -1184,7 +3165,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "sindri-backends",
  "sindri-core",
  "sindri-discovery",
@@ -1207,10 +3188,10 @@ dependencies = [
  "async-trait",
  "dirs-next",
  "hex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "sindri-core",
  "sindri-targets",
  "thiserror 2.0.18",
@@ -1222,7 +3203,7 @@ dependencies = [
 name = "sindri-core"
 version = "0.1.0"
 dependencies = [
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1276,13 +3257,19 @@ version = "4.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "dirs-next",
+ "ecdsa",
  "hex",
- "reqwest",
+ "oci-client 0.16.1",
+ "p256",
+ "rand_core 0.6.4",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
+ "sigstore",
  "sindri-core",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1297,7 +3284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "sindri-core",
  "sindri-policy",
  "sindri-registry",
@@ -1332,6 +3319,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +3349,22 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1352,6 +3378,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1444,6 +3488,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +3542,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -1504,6 +3600,54 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tough"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88d0ee9525696569cc2af5d46f8a739028c0268895071e0386957195b0c9161"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "aws-lc-rs",
+ "bytes",
+ "chrono",
+ "dyn-clone",
+ "futures",
+ "futures-core",
+ "globset",
+ "hex",
+ "log",
+ "olpc-cjson",
+ "pem",
+ "percent-encoding",
+ "reqwest 0.12.28",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "typed-path",
+ "untrusted 0.7.1",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -1557,6 +3701,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1589,10 +3734,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1601,10 +3758,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -1622,6 +3810,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1635,6 +3824,22 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1716,6 +3921,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,12 +3967,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1761,16 +4010,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1941,6 +4252,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +4334,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/v4/Cargo.toml
+++ b/v4/Cargo.toml
@@ -29,3 +29,14 @@ hex = "0.4"
 dirs-next = "2"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 semver = "1"
+# OCI client (successor to oci-distribution; ADR-003). Wired into sindri-registry
+# scaffold in Wave 3A.1; live OCI fetch lands in Wave 3A.2.
+oci-client = { version = "0.16", default-features = false, features = ["rustls-tls"] }
+# cosign / sigstore verification (ADR-014). Trust-key loading lands in Wave 3A.1;
+# signature-manifest verification lands in Wave 3A.2. We intentionally keep the
+# feature surface small to minimise compile time.
+sigstore = { version = "0.13", default-features = false, features = ["cosign", "sigstore-trust-root", "rustls-tls"] }
+# ECDSA P-256 verifying key parsing for the `CosignVerifier` trust-key loader.
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "pem", "pkcs8", "std"] }
+ecdsa = { version = "0.16", default-features = false, features = ["pem", "pkcs8"] }
+tempfile = "3"

--- a/v4/crates/sindri-backends/src/binary.rs
+++ b/v4/crates/sindri-backends/src/binary.rs
@@ -140,6 +140,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         };
         let ctx = InstallContext::new(&c, None, &mock);
         // Empty-checksum path: backend logs a warn and returns Ok without

--- a/v4/crates/sindri-backends/src/brew.rs
+++ b/v4/crates/sindri-backends/src/brew.rs
@@ -99,6 +99,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/cargo.rs
+++ b/v4/crates/sindri-backends/src/cargo.rs
@@ -122,6 +122,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/go_install.rs
+++ b/v4/crates/sindri-backends/src/go_install.rs
@@ -144,6 +144,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/mise.rs
+++ b/v4/crates/sindri-backends/src/mise.rs
@@ -63,6 +63,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/npm.rs
+++ b/v4/crates/sindri-backends/src/npm.rs
@@ -94,6 +94,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/pipx.rs
+++ b/v4/crates/sindri-backends/src/pipx.rs
@@ -109,6 +109,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/script.rs
+++ b/v4/crates/sindri-backends/src/script.rs
@@ -146,6 +146,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         };
         let ctx = InstallContext::new(&comp, None, &target);
         let err = ScriptBackend.install(&ctx).await.unwrap_err();

--- a/v4/crates/sindri-backends/src/sdkman.rs
+++ b/v4/crates/sindri-backends/src/sdkman.rs
@@ -103,6 +103,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/system_pm.rs
+++ b/v4/crates/sindri-backends/src/system_pm.rs
@@ -147,6 +147,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-backends/src/winget.rs
+++ b/v4/crates/sindri-backends/src/winget.rs
@@ -122,6 +122,7 @@ mod tests {
             checksums: HashMap::new(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri-core/src/lockfile.rs
+++ b/v4/crates/sindri-core/src/lockfile.rs
@@ -46,4 +46,69 @@ pub struct ResolvedComponent {
     /// without further changes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest: Option<ComponentManifest>,
+    /// OCI manifest digest of the component's `component.yaml` blob (ADR-003,
+    /// ADR-014). Wave 3A.1 carries this field through the lockfile schema with
+    /// `#[serde(default)]` so older lockfiles still deserialize; the resolver
+    /// continues to write `None` until Wave 3A.2 hooks up the live OCI fetch
+    /// path that populates the digest from the registry response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_digest: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::Backend;
+
+    fn sample(manifest_digest: Option<String>) -> ResolvedComponent {
+        ResolvedComponent {
+            id: ComponentId {
+                backend: Backend::Brew,
+                name: "git".into(),
+                qualifier: None,
+            },
+            version: Version::new("2.45.0"),
+            backend: Backend::Brew,
+            oci_digest: None,
+            checksums: HashMap::new(),
+            depends_on: vec![],
+            manifest: None,
+            manifest_digest,
+        }
+    }
+
+    #[test]
+    fn lockfile_without_manifest_digest_still_deserializes() {
+        // Pre-3A.1 schema: no `manifest_digest` field at all.
+        let yaml = r#"
+id:
+  backend: brew
+  name: git
+version: "2.45.0"
+backend: brew
+oci_digest: null
+checksums: {}
+depends_on: []
+"#;
+        let parsed: ResolvedComponent = serde_yaml::from_str(yaml).unwrap();
+        assert!(parsed.manifest_digest.is_none());
+    }
+
+    #[test]
+    fn manifest_digest_round_trips() {
+        let original = sample(Some("sha256:deadbeef".into()));
+        let yaml = serde_yaml::to_string(&original).unwrap();
+        let parsed: ResolvedComponent = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.manifest_digest.as_deref(), Some("sha256:deadbeef"));
+        assert_eq!(parsed.id.name, original.id.name);
+    }
+
+    #[test]
+    fn manifest_digest_none_is_omitted_in_serialization() {
+        // skip_serializing_if = "Option::is_none" keeps existing lockfiles
+        // textually identical when the field isn't populated.
+        let comp = sample(None);
+        let yaml = serde_yaml::to_string(&comp).unwrap();
+        assert!(!yaml.contains("manifest_digest"), "yaml: {}", yaml);
+    }
 }

--- a/v4/crates/sindri-registry/Cargo.toml
+++ b/v4/crates/sindri-registry/Cargo.toml
@@ -20,3 +20,14 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 dirs-next = { workspace = true }
 reqwest = { workspace = true }
+# OCI + cosign foundation (Wave 3A.1 — scaffold; Wave 3A.2 wires real fetch/verify).
+# See ADR-003 (OCI-only registry distribution) and ADR-014 (signed registries).
+oci-client = { workspace = true }
+sigstore = { workspace = true }
+p256 = { workspace = true }
+ecdsa = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true }
+rand_core = { version = "0.6", features = ["std"] }

--- a/v4/crates/sindri-registry/src/cache.rs
+++ b/v4/crates/sindri-registry/src/cache.rs
@@ -231,8 +231,27 @@ mod tests {
             .unwrap();
         assert!(path.ends_with("manifest.json"));
         // Sharded under by-digest/sha256/ab/<rest>/manifest.json.
-        let path_str = path.to_string_lossy();
-        assert!(path_str.contains("by-digest/sha256/ab/"));
+        // Verify via Path::components so the assertion is correct on Windows
+        // (which uses '\\' as the path separator) as well as POSIX.
+        let segments: Vec<String> = path
+            .components()
+            .filter_map(|c| match c {
+                std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                _ => None,
+            })
+            .collect();
+        let by_digest_idx = segments
+            .iter()
+            .position(|s| s == "by-digest")
+            .expect("path should contain a 'by-digest' segment");
+        assert_eq!(
+            segments.get(by_digest_idx + 1).map(String::as_str),
+            Some("sha256")
+        );
+        assert_eq!(
+            segments.get(by_digest_idx + 2).map(String::as_str),
+            Some("ab")
+        );
         let read = cache.get_by_digest(&digest, BlobKind::Manifest).unwrap();
         assert_eq!(read, content);
     }

--- a/v4/crates/sindri-registry/src/cache.rs
+++ b/v4/crates/sindri-registry/src/cache.rs
@@ -1,14 +1,62 @@
+//! Content-addressed registry cache (ADR-003 §"Registry artifact structure").
+//!
+//! Layout under `~/.sindri/cache/registries/`:
+//!
+//! ```text
+//! by-digest/sha256/<aa>/<bbcc…>/manifest.json
+//!                              index.yaml
+//!                              signature.bundle
+//! refs/<registry-name>/<encoded-oci-ref>   (file containing the digest)
+//! ```
+//!
+//! - The first 2 hex chars of the digest are sharded as a subdirectory so
+//!   directories don't blow up on registries with thousands of components.
+//! - `<encoded-oci-ref>` replaces `:` and `/` with `_` to keep the filename
+//!   filesystem-safe on Windows.
+//!
+//! In Wave 3A.1 only the digest+ref API is exercised by tests; the legacy
+//! `get_index`/`put_index` API remains as a thin wrapper so existing callers
+//! (`RegistryClient::fetch_index`) keep working until Wave 3A.2 swaps them
+//! over to the digest path.
+
 use crate::error::RegistryError;
+use crate::oci_ref::OciRef;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-/// Content-addressed blob cache at ~/.sindri/cache/registries/ (ADR-003)
+/// Kind of blob stored under a digest.
+///
+/// Each kind maps to a fixed filename inside the digest directory so that
+/// manifests, indices, and signatures are isolated from each other even when
+/// they happen to share a content digest (e.g. an empty manifest).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlobKind {
+    /// OCI image / artifact manifest JSON.
+    Manifest,
+    /// `index.yaml` payload (registry catalog).
+    Index,
+    /// cosign signature bundle.
+    Signature,
+}
+
+impl BlobKind {
+    fn filename(self) -> &'static str {
+        match self {
+            BlobKind::Manifest => "manifest.json",
+            BlobKind::Index => "index.yaml",
+            BlobKind::Signature => "signature.bundle",
+        }
+    }
+}
+
+/// Content-addressed blob cache at `~/.sindri/cache/registries/` (ADR-003).
 pub struct RegistryCache {
     root: PathBuf,
 }
 
 impl RegistryCache {
+    /// Open the default user cache (`~/.sindri/cache/registries/`).
     pub fn new() -> Result<Self, RegistryError> {
         let home = dirs_next::home_dir()
             .ok_or_else(|| RegistryError::CacheError("Cannot determine home directory".into()))?;
@@ -17,14 +65,75 @@ impl RegistryCache {
         Ok(RegistryCache { root })
     }
 
+    /// Open a cache rooted at an explicit path (test harnesses, alt-roots).
     pub fn with_path(root: PathBuf) -> Result<Self, RegistryError> {
         fs::create_dir_all(&root)?;
         Ok(RegistryCache { root })
     }
 
-    /// Returns the cached index.yaml content if not stale
+    /// Store `content` under its digest. Returns the absolute path written.
+    ///
+    /// Writes are atomic: a `.tmp` sibling is renamed into place. The same
+    /// digest can be written multiple times — the second write is a no-op
+    /// from the caller's perspective.
+    pub fn put_by_digest(
+        &self,
+        digest: &str,
+        kind: BlobKind,
+        content: &[u8],
+    ) -> Result<PathBuf, RegistryError> {
+        let dir = self.digest_dir(digest)?;
+        fs::create_dir_all(&dir)?;
+        let target = dir.join(kind.filename());
+        let tmp = target.with_extension("tmp");
+        fs::write(&tmp, content)?;
+        fs::rename(&tmp, &target)?;
+        Ok(target)
+    }
+
+    /// Fetch a previously-stored blob by digest. `None` if absent.
+    pub fn get_by_digest(&self, digest: &str, kind: BlobKind) -> Option<Vec<u8>> {
+        let dir = self.digest_dir(digest).ok()?;
+        let path = dir.join(kind.filename());
+        fs::read(&path).ok()
+    }
+
+    /// Link an OCI reference to a digest under the given registry name.
+    ///
+    /// The link is a small file containing the digest string; we deliberately
+    /// avoid filesystem symlinks for Windows portability.
+    pub fn link_ref(
+        &self,
+        registry_name: &str,
+        oci_ref: &OciRef,
+        digest: &str,
+    ) -> Result<(), RegistryError> {
+        let path = self.ref_path(registry_name, oci_ref);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("tmp");
+        fs::write(&tmp, digest.as_bytes())?;
+        fs::rename(&tmp, &path)?;
+        Ok(())
+    }
+
+    /// Resolve an OCI reference for the given registry to its previously
+    /// linked digest, if any.
+    pub fn lookup_ref(&self, registry_name: &str, oci_ref: &OciRef) -> Option<String> {
+        let path = self.ref_path(registry_name, oci_ref);
+        fs::read_to_string(&path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+
+    /// Returns the cached `index.yaml` content for `registry_name` if present
+    /// and within `ttl`. Legacy API retained so the existing
+    /// [`crate::client::RegistryClient::fetch_index`] HTTP shim keeps working
+    /// until Wave 3A.2 routes it through the digest cache.
     pub fn get_index(&self, registry_name: &str, ttl: Duration) -> Option<String> {
-        let path = self.index_path(registry_name);
+        let path = self.legacy_index_path(registry_name);
         if !path.exists() {
             return None;
         }
@@ -36,23 +145,170 @@ impl RegistryCache {
         fs::read_to_string(&path).ok()
     }
 
+    /// Legacy companion to [`Self::get_index`]; same Wave-3A.2 deprecation
+    /// notes apply.
     pub fn put_index(&self, registry_name: &str, content: &str) -> Result<(), RegistryError> {
-        let path = self.index_path(registry_name);
+        let path = self.legacy_index_path(registry_name);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        // Write atomically: temp file + rename
         let tmp = path.with_extension("tmp");
         fs::write(&tmp, content)?;
         fs::rename(&tmp, &path)?;
         Ok(())
     }
 
-    pub fn index_path(&self, registry_name: &str) -> PathBuf {
-        self.root.join(registry_name).join("index.yaml")
-    }
-
+    /// Root of the cache (mostly useful in tests).
     pub fn cache_root(&self) -> &Path {
         &self.root
+    }
+
+    // -- internals -----------------------------------------------------------
+
+    fn digest_dir(&self, digest: &str) -> Result<PathBuf, RegistryError> {
+        let (alg, hex) = digest.split_once(':').ok_or_else(|| {
+            RegistryError::CacheError(format!(
+                "digest '{}' missing ':' separator (expected '<alg>:<hex>')",
+                digest
+            ))
+        })?;
+        if alg.is_empty() || hex.len() < 4 {
+            return Err(RegistryError::CacheError(format!(
+                "digest '{}' is too short to shard",
+                digest
+            )));
+        }
+        let shard = &hex[..2];
+        let rest = &hex[2..];
+        Ok(self.root.join("by-digest").join(alg).join(shard).join(rest))
+    }
+
+    fn ref_path(&self, registry_name: &str, oci_ref: &OciRef) -> PathBuf {
+        let encoded = encode_ref(&oci_ref.to_canonical());
+        self.root.join("refs").join(registry_name).join(encoded)
+    }
+
+    fn legacy_index_path(&self, registry_name: &str) -> PathBuf {
+        self.root.join(registry_name).join("index.yaml")
+    }
+}
+
+/// Encode an OCI reference into a filename-safe form (`:` and `/` → `_`).
+fn encode_ref(canonical: &str) -> String {
+    canonical
+        .chars()
+        .map(|c| match c {
+            '/' | ':' | '@' => '_',
+            other => other,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oci_ref::OciRef;
+    use tempfile::TempDir;
+
+    fn fixture_digest(b: u8) -> String {
+        format!(
+            "sha256:{}",
+            std::iter::repeat_n(b, 32).fold(String::new(), |mut a, n| {
+                a.push_str(&format!("{:02x}", n));
+                a
+            })
+        )
+    }
+
+    #[test]
+    fn put_and_get_by_digest_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let cache = RegistryCache::with_path(tmp.path().to_path_buf()).unwrap();
+        let digest = fixture_digest(0xab);
+        let content = b"manifest body";
+        let path = cache
+            .put_by_digest(&digest, BlobKind::Manifest, content)
+            .unwrap();
+        assert!(path.ends_with("manifest.json"));
+        // Sharded under by-digest/sha256/ab/<rest>/manifest.json.
+        let path_str = path.to_string_lossy();
+        assert!(path_str.contains("by-digest/sha256/ab/"));
+        let read = cache.get_by_digest(&digest, BlobKind::Manifest).unwrap();
+        assert_eq!(read, content);
+    }
+
+    #[test]
+    fn link_ref_and_lookup_ref() {
+        let tmp = TempDir::new().unwrap();
+        let cache = RegistryCache::with_path(tmp.path().to_path_buf()).unwrap();
+        let oci = OciRef::parse("ghcr.io/sindri-dev/registry-core:2026.04").unwrap();
+        let digest = fixture_digest(0x12);
+        cache.link_ref("sindri/core", &oci, &digest).unwrap();
+        assert_eq!(cache.lookup_ref("sindri/core", &oci), Some(digest));
+        // Different registry name → distinct namespace, no leak.
+        assert_eq!(cache.lookup_ref("other", &oci), None);
+    }
+
+    #[test]
+    fn blob_kinds_are_isolated() {
+        let tmp = TempDir::new().unwrap();
+        let cache = RegistryCache::with_path(tmp.path().to_path_buf()).unwrap();
+        let digest = fixture_digest(0x77);
+        cache
+            .put_by_digest(&digest, BlobKind::Manifest, b"manifest")
+            .unwrap();
+        cache
+            .put_by_digest(&digest, BlobKind::Signature, b"signature")
+            .unwrap();
+        assert_eq!(
+            cache.get_by_digest(&digest, BlobKind::Manifest).unwrap(),
+            b"manifest"
+        );
+        assert_eq!(
+            cache.get_by_digest(&digest, BlobKind::Signature).unwrap(),
+            b"signature"
+        );
+        assert!(cache.get_by_digest(&digest, BlobKind::Index).is_none());
+    }
+
+    #[test]
+    fn missing_entry_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let cache = RegistryCache::with_path(tmp.path().to_path_buf()).unwrap();
+        let digest = fixture_digest(0x01);
+        assert!(cache.get_by_digest(&digest, BlobKind::Manifest).is_none());
+        let oci = OciRef::parse("ghcr.io/foo/bar:1.0").unwrap();
+        assert!(cache.lookup_ref("nope", &oci).is_none());
+    }
+
+    #[test]
+    fn persists_across_cache_reopen() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let digest = fixture_digest(0x42);
+        let oci = OciRef::parse("ghcr.io/foo/bar:1.0").unwrap();
+        {
+            let cache = RegistryCache::with_path(path.clone()).unwrap();
+            cache
+                .put_by_digest(&digest, BlobKind::Index, b"yaml: content")
+                .unwrap();
+            cache.link_ref("acme", &oci, &digest).unwrap();
+        }
+        let cache = RegistryCache::with_path(path).unwrap();
+        assert_eq!(
+            cache.get_by_digest(&digest, BlobKind::Index).unwrap(),
+            b"yaml: content"
+        );
+        assert_eq!(cache.lookup_ref("acme", &oci), Some(digest));
+    }
+
+    #[test]
+    fn rejects_malformed_digest() {
+        let tmp = TempDir::new().unwrap();
+        let cache = RegistryCache::with_path(tmp.path().to_path_buf()).unwrap();
+        let err = cache
+            .put_by_digest("not-a-digest", BlobKind::Manifest, b"x")
+            .unwrap_err();
+        assert!(matches!(err, RegistryError::CacheError(_)));
     }
 }

--- a/v4/crates/sindri-registry/src/client.rs
+++ b/v4/crates/sindri-registry/src/client.rs
@@ -1,32 +1,77 @@
 use crate::cache::RegistryCache;
 use crate::error::RegistryError;
 use crate::index::RegistryIndex;
+use sindri_core::policy::InstallPolicy;
 use std::path::Path;
 use std::time::Duration;
 
-/// OCI registry client. Fetches index.yaml blobs from OCI registries (ADR-003).
+/// OCI registry client. Fetches `index.yaml` blobs from OCI registries
+/// (ADR-003).
 ///
-/// Sprint 2 uses HTTP fetch for index.yaml; full OCI Distribution Spec blob pipeline
-/// (manifest → blob layer → extract) is Sprint 6 hardening.
+/// **Wave 3A.1** still uses an HTTP shim for `index.yaml` — the
+/// `oci-client` crate is on the dependency tree (so 3A.2 can swap to the
+/// real OCI Distribution Spec pipeline) but is not yet called here.
+///
+/// **Wave 3A.2** will:
+///   1. Replace [`Self::fetch_from_source`] with `oci-client` manifest +
+///      blob fetches.
+///   2. Implement [`Self::verify`] using the loaded [`crate::CosignVerifier`].
+///   3. Honour the [`InstallPolicy`] threaded through [`Self::with_policy`].
 pub struct RegistryClient {
     cache: RegistryCache,
     ttl: Duration,
+    /// Active install policy. Wave 3A.1 only stores this; the policy is not
+    /// yet consulted in [`Self::fetch_index`].
+    policy: Option<InstallPolicy>,
 }
 
 impl RegistryClient {
+    /// Construct a client backed by the default user cache.
     pub fn new() -> Result<Self, RegistryError> {
         Ok(RegistryClient {
             cache: RegistryCache::new()?,
             ttl: Duration::from_secs(3600),
+            policy: None,
         })
     }
 
+    /// Override the cache TTL (default: 1h).
     pub fn with_ttl(mut self, ttl: Duration) -> Self {
         self.ttl = ttl;
         self
     }
 
+    /// Attach an install policy. Stored only — policy enforcement is
+    /// deferred to Wave 3A.2 (signed-registry gate, offline gate).
+    pub fn with_policy(mut self, policy: InstallPolicy) -> Self {
+        self.policy = Some(policy);
+        self
+    }
+
+    /// Read the policy currently attached to this client (mostly for tests
+    /// + diagnostics; Wave 3A.2 will actually consult it).
+    pub fn policy(&self) -> Option<&InstallPolicy> {
+        self.policy.as_ref()
+    }
+
+    /// Verify the cosign signature of the given registry against trusted
+    /// keys.
+    ///
+    /// **Wave 3A.1 stub.** Always returns
+    /// [`RegistryError::SignatureRequired`] with a message explicitly naming
+    /// Wave 3A.2 as the place that wires up real verification — we never
+    /// silently succeed.
+    pub async fn verify(&self, registry_name: &str) -> Result<(), RegistryError> {
+        Err(RegistryError::SignatureRequired {
+            registry: registry_name.to_string(),
+            reason: "verify not yet implemented (deferred to Wave 3A.2)".to_string(),
+        })
+    }
+
     /// Fetch the registry index, using cache if within TTL.
+    ///
+    /// TODO(wave-3a.2): real OCI fetch via `oci-client`; until then,
+    /// `fetch_from_source` still uses the HTTP shim below.
     pub async fn fetch_index(
         &self,
         registry_name: &str,
@@ -59,8 +104,8 @@ impl RegistryClient {
             return std::fs::read_to_string(&index_path).map_err(RegistryError::Io);
         }
 
-        // HTTP(S) — fetch index.yaml directly
-        // Full OCI Distribution Spec (manifest + blob) is Sprint 6
+        // HTTP(S) — fetch index.yaml directly.
+        // TODO(wave-3a.2): replace with oci-client (manifest + blob).
         let index_url = format!("{}/index.yaml", registry_url.trim_end_matches('/'));
         tracing::info!("Fetching registry index from {}", index_url);
 

--- a/v4/crates/sindri-registry/src/error.rs
+++ b/v4/crates/sindri-registry/src/error.rs
@@ -1,17 +1,47 @@
 use thiserror::Error;
 
+/// Errors raised by the registry layer (ADR-003 / ADR-014).
 #[derive(Debug, Error)]
 pub enum RegistryError {
+    /// A registry endpoint could not be reached.
     #[error("Registry not reachable: {0}")]
     Unreachable(String),
+    /// The requested component / blob was not found in the registry.
     #[error("Component not found: {0}")]
     NotFound(String),
+    /// The fetched payload failed schema validation.
     #[error("Schema validation failed: {0}")]
     SchemaError(String),
+    /// A signature verification step failed.
     #[error("Signature verification failed: {0}")]
     SignatureError(String),
+    /// A cache I/O or layout error occurred.
     #[error("Cache error: {0}")]
     CacheError(String),
+
+    /// The given OCI reference could not be parsed (ADR-003).
+    #[error("Invalid OCI reference '{input}': {reason}")]
+    InvalidOciRef { input: String, reason: String },
+
+    /// A registry that requires a signature was added or refreshed without
+    /// one (ADR-014, "fail closed" trust model).
+    #[error("Signature required for registry '{registry}': {reason}")]
+    SignatureRequired { registry: String, reason: String },
+
+    /// A signature was present but did not match any trusted key.
+    #[error(
+        "Signature mismatch for registry '{registry}': expected one of {expected_keys:?} ({detail})"
+    )]
+    SignatureMismatch {
+        registry: String,
+        expected_keys: Vec<String>,
+        detail: String,
+    },
+
+    /// A trust key on disk could not be parsed as an ECDSA P-256 PEM.
+    #[error("Failed to parse cosign trust key '{path}': {detail}")]
+    TrustKeyParseFailed { path: String, detail: String },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]

--- a/v4/crates/sindri-registry/src/lib.rs
+++ b/v4/crates/sindri-registry/src/lib.rs
@@ -1,13 +1,29 @@
 #![allow(dead_code)]
 
+//! Sindri v4 registry crate.
+//!
+//! Wave 3A.1 introduces the OCI + cosign foundation (ADR-003, ADR-014):
+//!
+//! - [`oci_ref`]: pure value parser for OCI references.
+//! - [`cache`]: content-addressed blob cache.
+//! - [`signing`]: cosign trust-key loader (verification deferred to 3A.2).
+//!
+//! Live OCI fetch (`oci-client` API calls) and cosign signature verification
+//! land in Wave 3A.2; see `v4/docs/review/2026-04-27-implementation-audit-delta.md`.
+
 pub mod cache;
 pub mod client;
 pub mod error;
 pub mod index;
 pub mod lint;
 pub mod local;
+pub mod oci_ref;
+pub mod signing;
 
+pub use cache::{BlobKind, RegistryCache};
 pub use client::RegistryClient;
 pub use error::RegistryError;
 pub use index::RegistryIndex;
 pub use local::LocalRegistry;
+pub use oci_ref::{OciRef, OciReference};
+pub use signing::{CosignVerifier, TrustedKey};

--- a/v4/crates/sindri-registry/src/oci_ref.rs
+++ b/v4/crates/sindri-registry/src/oci_ref.rs
@@ -1,0 +1,282 @@
+//! OCI reference parser (ADR-003 §"Registry artifact structure").
+//!
+//! Parses OCI references of the forms accepted by `sindri registry add`,
+//! `sindri add`, and the resolver's outbound fetch path. Pure value type —
+//! no I/O, no allocations beyond the resulting [`OciRef`].
+//!
+//! ## Accepted forms
+//!
+//! - `oci://ghcr.io/sindri-dev/registry-core:2026.04` — explicit `oci://`
+//!   prefix, with tag.
+//! - `ghcr.io/sindri-dev/registry-core:2026.04` — bare form, with tag.
+//! - `ghcr.io/sindri-dev/registry-core@sha256:abc…` — digest-pinned form.
+//! - `library/alpine:3.20` — defaulted to `docker.io` registry (see
+//!   "Default registry" below).
+//!
+//! ## Default registry
+//!
+//! If the input has no `oci://` prefix and the first path segment contains
+//! neither a `.` nor a `:`, it is treated as a Docker Hub repository and the
+//! registry defaults to `docker.io`. This matches the behaviour of `docker
+//! pull` and `oras` and is documented for future readers in
+//! [`OciRef::parse`].
+//!
+//! Wave 3A.1 only consumes [`OciRef`] from the parser tests and the
+//! [`crate::cache::RegistryCache`] reference index. Live OCI fetches that
+//! actually hit a registry land in Wave 3A.2.
+
+use crate::error::RegistryError;
+
+/// Parsed OCI reference. Construct via [`OciRef::parse`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OciRef {
+    /// Registry hostname (e.g. `ghcr.io`, `docker.io`, `registry.example.com:5000`).
+    pub registry: String,
+    /// Repository path within the registry (e.g. `sindri-dev/registry-core`).
+    pub repository: String,
+    /// Tag or digest reference.
+    pub reference: OciReference,
+}
+
+/// Either a tag (`:1.0.0`) or a digest (`@sha256:…`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum OciReference {
+    /// Mutable tag (e.g. `2026.04`, `latest`).
+    Tag(String),
+    /// Immutable content digest in the canonical `sha256:<64-hex>` form.
+    Digest(String),
+}
+
+const DEFAULT_REGISTRY: &str = "docker.io";
+
+impl OciRef {
+    /// Parse an OCI reference.
+    ///
+    /// See the module-level docs for the accepted grammar. Returns
+    /// [`RegistryError::InvalidOciRef`] on malformed input — never panics.
+    pub fn parse(input: &str) -> Result<Self, RegistryError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(invalid(input, "empty input"));
+        }
+
+        let stripped = trimmed.strip_prefix("oci://").unwrap_or(trimmed);
+        let had_scheme = trimmed.starts_with("oci://");
+
+        // Split off the digest if present (digest takes precedence over tag).
+        if let Some((head, digest)) = stripped.split_once('@') {
+            let (registry, repository) = split_registry_and_repo(head, had_scheme)?;
+            let digest = parse_digest(digest, input)?;
+            return Ok(OciRef {
+                registry,
+                repository,
+                reference: OciReference::Digest(digest),
+            });
+        }
+
+        // Otherwise the last `:` after the final `/` is the tag separator.
+        let last_slash = stripped.rfind('/');
+        let last_colon = stripped.rfind(':');
+        let tag_colon = match (last_slash, last_colon) {
+            (Some(s), Some(c)) if c > s => Some(c),
+            (None, Some(c)) => Some(c),
+            _ => None,
+        };
+
+        let (head, tag) = match tag_colon {
+            Some(idx) => {
+                let tag = &stripped[idx + 1..];
+                if tag.is_empty() {
+                    return Err(invalid(input, "tag is empty after ':'"));
+                }
+                (&stripped[..idx], tag.to_string())
+            }
+            None => {
+                return Err(invalid(
+                    input,
+                    "missing tag (expected ':<tag>' or '@sha256:…')",
+                ))
+            }
+        };
+
+        let (registry, repository) = split_registry_and_repo(head, had_scheme)?;
+        Ok(OciRef {
+            registry,
+            repository,
+            reference: OciReference::Tag(tag),
+        })
+    }
+
+    /// Render the reference back to the canonical bare form
+    /// `<registry>/<repository>:<tag>` or `<registry>/<repository>@sha256:<digest>`.
+    pub fn to_canonical(&self) -> String {
+        match &self.reference {
+            OciReference::Tag(t) => format!("{}/{}:{}", self.registry, self.repository, t),
+            OciReference::Digest(d) => format!("{}/{}@{}", self.registry, self.repository, d),
+        }
+    }
+}
+
+fn split_registry_and_repo(
+    head: &str,
+    had_scheme: bool,
+) -> Result<(String, String), RegistryError> {
+    let head = head.trim_matches('/');
+    if head.is_empty() {
+        return Err(invalid(head, "empty registry+repository"));
+    }
+    let (first, rest) = head.split_once('/').unwrap_or((head, ""));
+    // The first segment is treated as a registry hostname when:
+    //   - the input had an explicit `oci://` scheme, or
+    //   - it contains a `.` (FQDN) or `:` (host:port), or
+    //   - it is exactly `localhost`.
+    let looks_like_registry =
+        had_scheme || first.contains('.') || first.contains(':') || first == "localhost";
+    if looks_like_registry {
+        if rest.is_empty() {
+            return Err(invalid(head, "missing repository path after registry"));
+        }
+        Ok((first.to_string(), rest.to_string()))
+    } else {
+        Ok((DEFAULT_REGISTRY.to_string(), head.to_string()))
+    }
+}
+
+fn parse_digest(digest: &str, original: &str) -> Result<String, RegistryError> {
+    // Canonical OCI digest is `<algorithm>:<hex>`. We accept any registered
+    // algorithm but validate the hex portion is non-empty and lowercase hex.
+    let (alg, hex) = digest
+        .split_once(':')
+        .ok_or_else(|| invalid(original, "digest missing ':' separator"))?;
+    if alg.is_empty() {
+        return Err(invalid(original, "digest algorithm is empty"));
+    }
+    if hex.is_empty() {
+        return Err(invalid(original, "digest hex is empty"));
+    }
+    if alg == "sha256" && hex.len() != 64 {
+        return Err(invalid(
+            original,
+            "sha256 digest must be exactly 64 hex chars",
+        ));
+    }
+    if !hex
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    {
+        return Err(invalid(original, "digest hex must be lowercase ASCII hex"));
+    }
+    Ok(digest.to_string())
+}
+
+fn invalid(input: &str, reason: &str) -> RegistryError {
+    RegistryError::InvalidOciRef {
+        input: input.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_tag_form() {
+        let r = OciRef::parse("ghcr.io/sindri-dev/registry-core:2026.04").unwrap();
+        assert_eq!(r.registry, "ghcr.io");
+        assert_eq!(r.repository, "sindri-dev/registry-core");
+        assert_eq!(r.reference, OciReference::Tag("2026.04".into()));
+    }
+
+    #[test]
+    fn parses_digest_form() {
+        let digest = format!("sha256:{}", "a".repeat(64));
+        let input = format!("ghcr.io/foo/bar@{}", digest);
+        let r = OciRef::parse(&input).unwrap();
+        assert_eq!(r.registry, "ghcr.io");
+        assert_eq!(r.repository, "foo/bar");
+        assert_eq!(r.reference, OciReference::Digest(digest));
+    }
+
+    #[test]
+    fn parses_oci_scheme_prefix() {
+        let r = OciRef::parse("oci://ghcr.io/sindri-dev/registry-core:1.0.0").unwrap();
+        assert_eq!(r.registry, "ghcr.io");
+        assert_eq!(r.repository, "sindri-dev/registry-core");
+        assert_eq!(r.reference, OciReference::Tag("1.0.0".into()));
+    }
+
+    #[test]
+    fn parses_subdomain_registry() {
+        let r = OciRef::parse("registry.example.co.uk/team/app:v7").unwrap();
+        assert_eq!(r.registry, "registry.example.co.uk");
+        assert_eq!(r.repository, "team/app");
+        assert_eq!(r.reference, OciReference::Tag("v7".into()));
+    }
+
+    #[test]
+    fn parses_nested_repository_path() {
+        let r = OciRef::parse("ghcr.io/org/team/sub/component:0.1.0").unwrap();
+        assert_eq!(r.repository, "org/team/sub/component");
+    }
+
+    #[test]
+    fn parses_registry_with_port() {
+        let r = OciRef::parse("localhost:5000/foo/bar:dev").unwrap();
+        assert_eq!(r.registry, "localhost:5000");
+        assert_eq!(r.repository, "foo/bar");
+        assert_eq!(r.reference, OciReference::Tag("dev".into()));
+    }
+
+    #[test]
+    fn defaults_registry_to_docker_io() {
+        let r = OciRef::parse("library/alpine:3.20").unwrap();
+        assert_eq!(r.registry, "docker.io");
+        assert_eq!(r.repository, "library/alpine");
+        assert_eq!(r.reference, OciReference::Tag("3.20".into()));
+    }
+
+    #[test]
+    fn rejects_missing_tag() {
+        let err = OciRef::parse("ghcr.io/foo/bar").unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidOciRef { .. }));
+    }
+
+    #[test]
+    fn rejects_malformed_digest() {
+        let err = OciRef::parse("ghcr.io/foo/bar@sha256:not-hex").unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidOciRef { .. }));
+        let err = OciRef::parse("ghcr.io/foo/bar@sha256:tooShort").unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidOciRef { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(matches!(
+            OciRef::parse("").unwrap_err(),
+            RegistryError::InvalidOciRef { .. }
+        ));
+        assert!(matches!(
+            OciRef::parse("   ").unwrap_err(),
+            RegistryError::InvalidOciRef { .. }
+        ));
+    }
+
+    #[test]
+    fn round_trip_via_canonical_tag() {
+        let original = "ghcr.io/sindri-dev/registry-core:2026.04";
+        let r = OciRef::parse(original).unwrap();
+        assert_eq!(r.to_canonical(), original);
+        // Re-parsing the canonical form gives an equal value.
+        assert_eq!(OciRef::parse(&r.to_canonical()).unwrap(), r);
+    }
+
+    #[test]
+    fn round_trip_via_canonical_digest() {
+        let digest = format!("sha256:{}", "f".repeat(64));
+        let input = format!("ghcr.io/foo/bar@{}", digest);
+        let r = OciRef::parse(&input).unwrap();
+        assert_eq!(r.to_canonical(), input);
+        assert_eq!(OciRef::parse(&r.to_canonical()).unwrap(), r);
+    }
+}

--- a/v4/crates/sindri-registry/src/signing.rs
+++ b/v4/crates/sindri-registry/src/signing.rs
@@ -1,0 +1,229 @@
+//! Cosign trust-key loading (ADR-014 §"Trust model").
+//!
+//! Wave 3A.1 owns trust-key **loading** only. Verification — fetching the
+//! signature manifest, decoding the simple-signing payload, and verifying
+//! signature bytes — is deferred to Wave 3A.2 so we don't ship a verifier
+//! that quietly accepts everything.
+//!
+//! ## On-disk layout
+//!
+//! ```text
+//! ~/.sindri/trust/
+//!   <registry-name>/
+//!     cosign-<short-key-id>.pub
+//! ```
+//!
+//! Each `.pub` file is an ECDSA P-256 public key in PEM (PKCS#8 SPKI) form,
+//! the default cosign key format.
+
+use crate::error::RegistryError;
+use ecdsa::elliptic_curve::pkcs8::DecodePublicKey;
+use p256::ecdsa::VerifyingKey;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// A single trusted cosign key, parsed from PEM.
+#[derive(Debug, Clone)]
+pub struct TrustedKey {
+    /// First 8 hex chars of the SHA-256 of the DER-encoded SPKI bytes.
+    /// Stable, human-friendly identifier suitable for filenames + log lines.
+    pub key_id: String,
+    /// Original PEM (re-export / debug).
+    pub spki_pem: String,
+    /// The parsed verifying key.
+    pub key: VerifyingKey,
+}
+
+impl TrustedKey {
+    /// Parse a PEM public key, computing its short key id.
+    pub fn from_pem(pem: &str) -> Result<Self, RegistryError> {
+        let key = VerifyingKey::from_public_key_pem(pem).map_err(|e| {
+            RegistryError::TrustKeyParseFailed {
+                path: "<pem>".to_string(),
+                detail: e.to_string(),
+            }
+        })?;
+        let spki_der = key.to_encoded_point(false);
+        let mut hasher = Sha256::new();
+        hasher.update(spki_der.as_bytes());
+        let digest = hasher.finalize();
+        let key_id = hex::encode(&digest[..4]);
+        Ok(TrustedKey {
+            key_id,
+            spki_pem: pem.to_string(),
+            key,
+        })
+    }
+}
+
+/// Set of trusted cosign keys, indexed by registry name.
+///
+/// Built by [`CosignVerifier::load_from_trust_dir`] from
+/// `~/.sindri/trust/<registry>/cosign-*.pub`.
+#[derive(Debug)]
+pub struct CosignVerifier {
+    trusted_keys: HashMap<String, Vec<TrustedKey>>,
+}
+
+impl CosignVerifier {
+    /// Load all trust keys under `root` (typically `~/.sindri/trust/`).
+    ///
+    /// - Each immediate subdirectory is treated as a registry name.
+    /// - Inside each subdirectory, every file matching `cosign-*.pub` is
+    ///   parsed as a P-256 public key.
+    /// - A malformed key file aborts the whole load with
+    ///   [`RegistryError::TrustKeyParseFailed`] — we fail closed rather than
+    ///   silently dropping bad keys.
+    /// - A non-existent `root` is treated as an empty trust set.
+    pub fn load_from_trust_dir(root: &Path) -> Result<Self, RegistryError> {
+        let mut trusted_keys: HashMap<String, Vec<TrustedKey>> = HashMap::new();
+        if !root.exists() {
+            return Ok(CosignVerifier { trusted_keys });
+        }
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let registry_name = match path.file_name().and_then(|s| s.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let mut keys: Vec<TrustedKey> = Vec::new();
+            for key_entry in fs::read_dir(&path)? {
+                let key_entry = key_entry?;
+                let key_path = key_entry.path();
+                if !key_path.is_file() {
+                    continue;
+                }
+                let name = key_path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                if !name.starts_with("cosign-") || !name.ends_with(".pub") {
+                    continue;
+                }
+                let pem = fs::read_to_string(&key_path)?;
+                let key = TrustedKey::from_pem(&pem).map_err(|e| match e {
+                    RegistryError::TrustKeyParseFailed { detail, .. } => {
+                        RegistryError::TrustKeyParseFailed {
+                            path: key_path.display().to_string(),
+                            detail,
+                        }
+                    }
+                    other => other,
+                })?;
+                keys.push(key);
+            }
+            if !keys.is_empty() {
+                trusted_keys.insert(registry_name, keys);
+            }
+        }
+        Ok(CosignVerifier { trusted_keys })
+    }
+
+    /// Iterator over registry names with at least one trusted key.
+    pub fn trusted_registries(&self) -> impl Iterator<Item = &str> {
+        self.trusted_keys.keys().map(|s| s.as_str())
+    }
+
+    /// Trusted keys for `registry`, or an empty slice.
+    pub fn keys_for(&self, registry: &str) -> &[TrustedKey] {
+        self.trusted_keys
+            .get(registry)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::ecdsa::SigningKey;
+    use p256::pkcs8::EncodePublicKey;
+    use rand_core::OsRng;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_test_key(dir: &Path, registry: &str, key_idx: usize) -> String {
+        let registry_dir = dir.join(registry);
+        fs::create_dir_all(&registry_dir).unwrap();
+        let signing = SigningKey::random(&mut OsRng);
+        let verifying = VerifyingKey::from(&signing);
+        let pem = verifying
+            .to_public_key_pem(p256::pkcs8::LineEnding::LF)
+            .unwrap();
+        let path = registry_dir.join(format!("cosign-test-{}.pub", key_idx));
+        fs::write(&path, &pem).unwrap();
+        pem
+    }
+
+    #[test]
+    fn loads_fixture_key() {
+        let tmp = TempDir::new().unwrap();
+        write_test_key(tmp.path(), "ghcr.io_sindri", 0);
+        let verifier = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap();
+        let registries: Vec<&str> = verifier.trusted_registries().collect();
+        assert_eq!(registries, vec!["ghcr.io_sindri"]);
+        let keys = verifier.keys_for("ghcr.io_sindri");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key_id.len(), 8);
+        assert!(keys[0].spki_pem.contains("BEGIN PUBLIC KEY"));
+    }
+
+    #[test]
+    fn rejects_malformed_pem() {
+        let tmp = TempDir::new().unwrap();
+        let registry_dir = tmp.path().join("acme");
+        fs::create_dir_all(&registry_dir).unwrap();
+        fs::write(
+            registry_dir.join("cosign-bad.pub"),
+            "-----BEGIN PUBLIC KEY-----\nnot-pem\n-----END PUBLIC KEY-----\n",
+        )
+        .unwrap();
+        let err = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, RegistryError::TrustKeyParseFailed { ref path, .. } if path.contains("cosign-bad.pub"))
+        );
+    }
+
+    #[test]
+    fn supports_multiple_keys_per_registry() {
+        let tmp = TempDir::new().unwrap();
+        write_test_key(tmp.path(), "acme", 0);
+        write_test_key(tmp.path(), "acme", 1);
+        let verifier = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap();
+        let keys = verifier.keys_for("acme");
+        assert_eq!(keys.len(), 2);
+        assert_ne!(keys[0].key_id, keys[1].key_id);
+    }
+
+    #[test]
+    fn empty_trust_dir_yields_empty_verifier() {
+        let tmp = TempDir::new().unwrap();
+        let verifier = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap();
+        assert_eq!(verifier.trusted_registries().count(), 0);
+    }
+
+    #[test]
+    fn nonexistent_root_yields_empty_verifier() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let verifier = CosignVerifier::load_from_trust_dir(&missing).unwrap();
+        assert_eq!(verifier.trusted_registries().count(), 0);
+    }
+
+    #[test]
+    fn ignores_non_cosign_files() {
+        let tmp = TempDir::new().unwrap();
+        write_test_key(tmp.path(), "acme", 0);
+        let registry_dir = tmp.path().join("acme");
+        fs::write(registry_dir.join("README.md"), "not a key").unwrap();
+        fs::write(registry_dir.join("other.pub"), "not loaded").unwrap();
+        let verifier = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap();
+        assert_eq!(verifier.keys_for("acme").len(), 1);
+    }
+}

--- a/v4/crates/sindri-resolver/src/lockfile_writer.rs
+++ b/v4/crates/sindri-resolver/src/lockfile_writer.rs
@@ -54,5 +54,8 @@ pub fn resolved_from_entry(
         // Wave 3A will fetch manifests from OCI; until then, the apply
         // pipeline degrades to install + hooks only when manifest is None.
         manifest: None,
+        // Wave 3A.1: resolver still writes None. Wave 3A.2 will populate
+        // this from the live OCI manifest digest returned by oci-client.
+        manifest_digest: None,
     }
 }

--- a/v4/crates/sindri/src/commands/apply_lifecycle.rs
+++ b/v4/crates/sindri/src/commands/apply_lifecycle.rs
@@ -276,6 +276,7 @@ mod tests {
             checksums: Default::default(),
             depends_on: vec![],
             manifest: None,
+            manifest_digest: None,
         }
     }
 

--- a/v4/crates/sindri/src/commands/registry.rs
+++ b/v4/crates/sindri/src/commands/registry.rs
@@ -1,10 +1,12 @@
 use sindri_core::component::ComponentManifest;
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use sindri_registry::signing::TrustedKey;
 
 pub enum RegistryCmd {
     Refresh { name: String, url: String },
     Lint { path: String, json: bool },
     Trust { name: String, signer: String },
+    Verify { name: String },
     FetchChecksums { path: String },
 }
 
@@ -13,6 +15,7 @@ pub fn run(cmd: RegistryCmd) -> i32 {
         RegistryCmd::Refresh { name, url } => refresh(&name, &url),
         RegistryCmd::Lint { path, json } => lint(&path, json),
         RegistryCmd::Trust { name, signer } => trust(&name, &signer),
+        RegistryCmd::Verify { name } => verify(&name),
         RegistryCmd::FetchChecksums { path } => fetch_checksums(&path),
     }
 }
@@ -223,34 +226,87 @@ fn lint_dir(dir: &std::path::Path, json: bool) -> i32 {
     }
 }
 
+/// Trust a cosign public key for a registry (ADR-014).
+///
+/// `signer` accepts the form `cosign:key=<path>` (the canonical syntax in
+/// ADR-014) or a bare path. The key is read, parsed as a P-256 SPKI PEM, and
+/// copied to `~/.sindri/trust/<name>/cosign-<short-key-id>.pub`.
+///
+/// Wave 3A.1 lands the actual copy + parse step (the audit flagged the
+/// previous behaviour — writing a JSON sidecar with the raw path — as
+/// security theatre). Wave 3A.2 wires the loaded keys into
+/// `RegistryClient::verify`.
 fn trust(name: &str, signer: &str) -> i32 {
-    let trust_dir = dirs_next::home_dir()
-        .unwrap_or_default()
-        .join(".sindri")
-        .join("trust");
-
-    if let Err(e) = std::fs::create_dir_all(&trust_dir) {
-        eprintln!("Cannot create trust dir: {}", e);
+    // Accept either `cosign:key=<path>` or a bare path.
+    let path_str = signer.strip_prefix("cosign:key=").unwrap_or(signer).trim();
+    if path_str.is_empty() {
+        eprintln!("Empty signer; expected `cosign:key=<path>` or a path to a P-256 PEM public key");
         return EXIT_SCHEMA_OR_RESOLVE_ERROR;
     }
 
-    let entry = format!(
-        r#"{{"registry":"{}","signer":"{}","stored_at":"{}"}}"#,
-        name,
-        signer,
-        chrono_now()
-    );
-
-    match std::fs::write(trust_dir.join(format!("{}.json", name)), entry) {
-        Ok(_) => {
-            println!("Stored trust config for '{}' (signer: {})", name, signer);
-            EXIT_SUCCESS
-        }
+    let src = std::path::Path::new(path_str);
+    let pem = match std::fs::read_to_string(src) {
+        Ok(s) => s,
         Err(e) => {
-            eprintln!("Cannot store trust config: {}", e);
-            EXIT_SCHEMA_OR_RESOLVE_ERROR
+            eprintln!("Cannot read signer key '{}': {}", path_str, e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
         }
+    };
+
+    let key = match TrustedKey::from_pem(&pem) {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("Invalid cosign public key at '{}': {}", path_str, e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    let trust_dir = dirs_next::home_dir()
+        .unwrap_or_default()
+        .join(".sindri")
+        .join("trust")
+        .join(name);
+
+    if let Err(e) = std::fs::create_dir_all(&trust_dir) {
+        eprintln!("Cannot create trust dir '{}': {}", trust_dir.display(), e);
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
     }
+
+    let target = trust_dir.join(format!("cosign-{}.pub", key.key_id));
+    let tmp = target.with_extension("tmp");
+    if let Err(e) = std::fs::write(&tmp, &pem) {
+        eprintln!("Cannot write trust key '{}': {}", target.display(), e);
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+    }
+    if let Err(e) = std::fs::rename(&tmp, &target) {
+        eprintln!("Cannot finalize trust key '{}': {}", target.display(), e);
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+    }
+
+    println!(
+        "Trusted cosign key {} for registry '{}' (stored at {})",
+        key.key_id,
+        name,
+        target.display()
+    );
+    EXIT_SUCCESS
+}
+
+/// Verify the cosign signature on a registry's manifest (ADR-014).
+///
+/// **Wave 3A.1 placeholder.** Verification — fetching the cosign signature
+/// manifest, decoding the simple-signing payload, and verifying the
+/// signature bytes against trusted keys — lands in Wave 3A.2. Today this
+/// command exits non-zero with a clear message so callers can wire it into
+/// CI without it silently passing.
+fn verify(name: &str) -> i32 {
+    eprintln!(
+        "registry verify '{}': not yet implemented (deferred to Wave 3A.2). \
+         Trust-key loading is in place; signature verification will be wired \
+         once the live oci-client fetch path lands.",
+        name
+    );
+    EXIT_SCHEMA_OR_RESOLVE_ERROR
 }
 
 fn fetch_checksums(path: &str) -> i32 {
@@ -261,14 +317,4 @@ fn fetch_checksums(path: &str) -> i32 {
         path
     );
     EXIT_SUCCESS
-}
-
-fn chrono_now() -> String {
-    // Simple timestamp without chrono dep
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    format!("{}", secs)
 }

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -226,6 +226,14 @@ enum RegistrySubcmds {
         #[arg(long)]
         signer: String,
     },
+    /// Verify a registry's cosign signature against trusted keys (ADR-014).
+    ///
+    /// Wave 3A.1 placeholder: trust-key loading is in place, but live
+    /// signature verification (cosign signature manifest fetch +
+    /// simple-signing payload verify) is deferred to Wave 3A.2. This
+    /// subcommand currently exits non-zero with an explanatory message so
+    /// it cannot silently pass in CI.
+    Verify { name: String },
     /// Download assets and write sha256 checksums
     FetchChecksums { path: String },
 }
@@ -286,6 +294,7 @@ fn main() {
                 RegistrySubcmds::Refresh { name, url } => RegistryCmd::Refresh { name, url },
                 RegistrySubcmds::Lint { path, json } => RegistryCmd::Lint { path, json },
                 RegistrySubcmds::Trust { name, signer } => RegistryCmd::Trust { name, signer },
+                RegistrySubcmds::Verify { name } => RegistryCmd::Verify { name },
                 RegistrySubcmds::FetchChecksums { path } => RegistryCmd::FetchChecksums { path },
             };
             commands::registry::run(registry_cmd)

--- a/v4/docs/review/2026-04-27-implementation-audit-delta.md
+++ b/v4/docs/review/2026-04-27-implementation-audit-delta.md
@@ -1,0 +1,55 @@
+# 2026-04-27 audit delta
+
+Companion to `2026-04-27-implementation-audit.md`. This file tracks status
+movement of audit findings as remediation lands. The original audit document
+is **never modified**; new wave entries are appended here.
+
+## Wave 3A.1 — Foundation PR (`feat/v4-registry-oci-cosign-foundation`)
+
+### ADR-003 (OCI-only registry distribution)
+
+- **Status:** 🔴 → 🟡 (partial — foundation in PR; live fetch in Wave 3A.2)
+- **What landed:**
+  - `oci-client` 0.16 added as a workspace dependency (successor to
+    `oci-distribution`).
+  - `OciRef` parser in `crates/sindri-registry/src/oci_ref.rs` — handles
+    bare, `oci://`-prefixed, digest-pinned, and default-registry forms.
+  - Content-addressed cache in `crates/sindri-registry/src/cache.rs` —
+    `by-digest/<alg>/<aa>/<bbcc…>/{manifest,index,signature}` layout with
+    a `refs/<registry>/<encoded-ref>` index.
+  - `ResolvedComponent.manifest_digest: Option<String>` lockfile field
+    (additive, `#[serde(default)]`, `skip_serializing_if`).
+- **What's next (3A.2):**
+  - Replace `RegistryClient::fetch_from_source` with `oci-client` manifest
+    + blob fetches.
+  - Resolver populates `manifest_digest` from the live OCI response.
+  - Wiremock-backed integration tests for the OCI fetch path.
+
+### ADR-014 (signed registries via cosign)
+
+- **Status:** 🔴 → 🟡 (partial — trust-key loading; verification deferred)
+- **What landed:**
+  - `sigstore` 0.13 added with `cosign` + `sigstore-trust-root` features.
+  - `CosignVerifier::load_from_trust_dir` in
+    `crates/sindri-registry/src/signing.rs` — parses ECDSA P-256 PEM keys
+    under `~/.sindri/trust/<registry>/cosign-*.pub` with a stable 8-char
+    key id derived from SHA-256 of the SPKI bytes.
+  - **Bug fix.** `sindri registry trust` now actually reads the source
+    PEM, validates it parses as a P-256 public key, and copies it to
+    `~/.sindri/trust/<name>/cosign-<short-key-id>.pub`. The audit flagged
+    the previous behaviour (writing a JSON sidecar with the raw signer
+    path, never validated) as security theatre.
+  - `sindri registry verify <name>` CLI subcommand stub. Exits non-zero
+    with an explanatory "deferred to Wave 3A.2" message so callers cannot
+    accidentally rely on it.
+  - New `RegistryError` variants: `InvalidOciRef`, `SignatureRequired`,
+    `SignatureMismatch`, `TrustKeyParseFailed`.
+- **What's next (3A.2):**
+  - Cosign signature manifest fetch via `oci-client`.
+  - Simple-signing payload decode + signature byte verification using the
+    loaded `TrustedKey` set.
+  - `--insecure` flag on `sindri registry add` (deliberately deferred so
+    we don't ship a flag that bypasses verification that doesn't yet
+    exist).
+  - Strict-policy enforcement: `InstallPolicy::require_signed_registries`
+    consulted in `RegistryClient::fetch_index`.


### PR DESCRIPTION
## Summary

Part 1 of a 2-PR Wave 3A. This PR lands the **scaffold + pure components**
of the OCI + cosign work flagged by the 2026-04-27 implementation audit
(ADR-003 and ADR-014, both 🔴). No live network calls in this slice — the
crates are wired, the value types and on-disk layout exist, the
`sindri registry trust` security-theatre bug is fixed, and the
verification surface (`sindri registry verify`, `RegistryClient::verify`)
exists as honest non-zero stubs. Wave **3A.2** wires the `oci-client` fetch
+ cosign verification path on top of these primitives.

Audit score moves 🔴 → 🟡 for both ADRs. See `audit-delta.md` link below.

## Why

The 2026-04-27 audit (`v4/docs/review/2026-04-27-implementation-audit.md`)
flagged ADR-003 and ADR-014 as non-compliant: no real OCI fetch path,
no signature verification, and `sindri registry trust` writing a JSON
sidecar with the raw signer path — never validating, never copying the
key. This PR is the deliberate first slice that lands clean.

## Crate choices

Versions confirmed via crates.io on 2026-04-27 — latest non-prerelease.

- **`oci-client = "0.16"`** (default-features = false, `rustls-tls`).
  Successor to the now-archived `oci-distribution`. Pure-Rust, no native
  TLS dependency. Wired as a workspace dep but **not yet called at
  runtime** — Wave 3A.2 swaps `RegistryClient::fetch_from_source` over to
  it.
- **`sigstore = "0.13"`** (default-features = false; features =
  `cosign`, `sigstore-trust-root`, `rustls-tls`). Feature names confirmed
  against the 0.13 manifest. We deliberately keep the surface narrow —
  no `fulcio`, no `rekor`, no OAuth — to minimise compile time. 3A.2 may
  add `verify` if the cosign signature manifest path requires it.
- **`p256 = "0.13"` + `ecdsa = "0.16"`**. Used by `CosignVerifier::load_*`
  to parse PEM ECDSA P-256 verifying keys (the cosign default). Pulls
  `pkcs8` and `pem` features only.
- **`tempfile = "3"`**, **`rand_core = "0.6"`** (dev-only) for
  generating ephemeral keys in tests — no pre-baked crypto fixtures.

## What this PR adds

1. **Workspace dependencies** — `oci-client`, `sigstore`, `p256`,
   `ecdsa`, `tempfile` (dev) in `v4/Cargo.toml [workspace.dependencies]`,
   pulled in by `sindri-registry/Cargo.toml`.
2. **`OciRef` parser** (`crates/sindri-registry/src/oci_ref.rs`).
   Accepts `oci://`-prefixed, bare, and `@sha256:...` digest forms;
   defaults to `docker.io` when the first path segment isn't a hostname.
   12 unit tests cover every accepted/rejected form + canonical
   round-trip.
3. **Content-addressed cache** (`crates/sindri-registry/src/cache.rs`,
   rewritten). Layout:
   `by-digest/<alg>/<aa>/<bbcc…>/{manifest.json,index.yaml,signature.bundle}`
   plus `refs/<registry>/<encoded-ref>` index. Legacy
   `get_index`/`put_index` API kept so existing `RegistryClient` callers
   don't break until 3A.2 routes them through the digest path. 6 unit
   tests.
4. **`ResolvedComponent.manifest_digest: Option<String>`** on
   `sindri-core/src/lockfile.rs` with `#[serde(default)]` +
   `skip_serializing_if`. The resolver still writes `None` — 3A.2
   populates from real digests. 3 unit tests.
5. **New `RegistryError` variants**: `InvalidOciRef`,
   `SignatureRequired`, `SignatureMismatch`, `TrustKeyParseFailed`.
6. **`signing.rs` skeleton — KEY LOADING ONLY**. `CosignVerifier::load_from_trust_dir`
   parses every `cosign-*.pub` under `~/.sindri/trust/<registry>/` as a
   P-256 PKCS#8 SPKI PEM. 6 unit tests; keys are generated in-test.
7. **Bug fix: `sindri registry trust`** now reads the source PEM,
   validates it parses as P-256, copies it to
   `~/.sindri/trust/<name>/cosign-<short-id>.pub`, and emits a clear
   "Trusted cosign key …" line. Replaces the JSON-sidecar
   security-theatre flagged by the audit.
8. **3A.2 stubs that don't panic**:
   - `RegistryClient::with_policy(InstallPolicy)` — stored only.
   - `RegistryClient::verify(&str) -> Result<(), RegistryError>` —
     returns `SignatureRequired { reason: "deferred to Wave 3A.2" }`.
   - `sindri registry verify <name>` CLI subcommand — exits non-zero
     with the same explanatory message so CI cannot silently pass.

## What this PR explicitly does NOT do (deferred to Wave 3A.2)

- Real OCI fetch via `oci-client` (manifest + blob pipeline).
- Cosign verification logic (signature manifest fetch, simple-signing
  payload decode, signature byte verification).
- Crypto test fixtures of signed manifests / wiremock OCI integration
  tests.
- `--insecure` flag on `sindri registry add` — deliberately deferred so
  we don't ship a flag that bypasses verification that doesn't yet
  exist.
- Lockfile populate from real digests.
- SBOM digest population.
- `InstallPolicy::require_signed_registries` enforcement.

A `TODO(wave-3a.2)` marker in `client.rs` points at the swap site.

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean,
      zero `#[allow(...)]` added.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo test --workspace` — all existing tests pass + **27 new
      tests** across the four new/rewritten modules:
  - `oci_ref`: 12 tests
  - `cache`: 6 tests
  - `signing`: 6 tests
  - `lockfile` (manifest_digest): 3 tests
- [ ] Manual: `sindri registry trust acme --signer cosign:key=./key.pub`
      copies + parses + logs key-id.
- [ ] Manual: `sindri registry verify acme` exits non-zero with the
      "deferred to Wave 3A.2" message.

## Schema impact

`ResolvedComponent` gains an optional `manifest_digest: Option<String>`
field. The change is fully back-compatible — `#[serde(default)]` lets
older lockfiles deserialize, and `skip_serializing_if = "Option::is_none"`
keeps freshly-written lockfiles textually identical when the field is
unpopulated. Wave 2D adds a sibling `manifest: Option<ComponentManifest>`
field; both are additive `Option<...>` so the rebase is a clean merge.

## Audit-delta

`v4/docs/review/2026-04-27-implementation-audit-delta.md` — new file.
Records ADR-003 and ADR-014 moving 🔴 → 🟡 with explicit "what's next"
for Wave 3A.2. The original audit document is **not modified**.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)