### PR TITLE
feat(v4): live OCI fetch + cosign verification (ADR-003, ADR-014 — operational)

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -3256,6 +3256,7 @@ name = "sindri-registry"
 version = "4.0.0-alpha.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "dirs-next",
  "ecdsa",
  "hex",

--- a/v4/Cargo.toml
+++ b/v4/Cargo.toml
@@ -39,4 +39,6 @@ sigstore = { version = "0.13", default-features = false, features = ["cosign", "
 # ECDSA P-256 verifying key parsing for the `CosignVerifier` trust-key loader.
 p256 = { version = "0.13", default-features = false, features = ["ecdsa", "pem", "pkcs8", "std"] }
 ecdsa = { version = "0.16", default-features = false, features = ["pem", "pkcs8"] }
+# base64 decoding for cosign signature annotation payloads (ADR-014).
+base64 = "0.22"
 tempfile = "3"

--- a/v4/crates/sindri-registry/Cargo.toml
+++ b/v4/crates/sindri-registry/Cargo.toml
@@ -26,8 +26,17 @@ oci-client = { workspace = true }
 sigstore = { workspace = true }
 p256 = { workspace = true }
 ecdsa = { workspace = true }
+base64 = { workspace = true }
+
+[features]
+default = []
+# Enables tests that hit live public OCI registries (e.g. ghcr.io). Skipped by
+# default in CI; run locally with:
+#     cargo test -p sindri-registry --features live-oci-tests -- --ignored
+live-oci-tests = []
 
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true }
 rand_core = { version = "0.6", features = ["std"] }
+serde_json = { workspace = true }

--- a/v4/crates/sindri-registry/src/cache.rs
+++ b/v4/crates/sindri-registry/src/cache.rs
@@ -118,6 +118,27 @@ impl RegistryCache {
         Ok(())
     }
 
+    /// Find any digest currently linked under `registry_name`.
+    ///
+    /// Useful when the caller knows the registry name but not the specific
+    /// OCI ref that produced the cache entry — for example, the resolver
+    /// reading a previously refreshed `index.yaml` and needing the
+    /// registry-level manifest digest to record on lockfile entries.
+    /// Returns `None` if no refs are linked.
+    pub fn any_digest_for_registry(&self, registry_name: &str) -> Option<String> {
+        let dir = self.root.join("refs").join(registry_name);
+        let entries = fs::read_dir(&dir).ok()?;
+        for entry in entries.flatten() {
+            if let Ok(s) = fs::read_to_string(entry.path()) {
+                let trimmed = s.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+        None
+    }
+
     /// Resolve an OCI reference for the given registry to its previously
     /// linked digest, if any.
     pub fn lookup_ref(&self, registry_name: &str, oci_ref: &OciRef) -> Option<String> {

--- a/v4/crates/sindri-registry/src/client.rs
+++ b/v4/crates/sindri-registry/src/client.rs
@@ -1,28 +1,90 @@
-use crate::cache::RegistryCache;
+//! Live OCI registry client (ADR-003) with cosign verification (ADR-014).
+//!
+//! Wave 3A.2 promotes the Wave 3A.1 scaffold into an operational client:
+//!
+//! 1. [`RegistryClient::fetch_index`] now pulls the registry's `index.yaml`
+//!    via the OCI Distribution Spec using [`oci_client::Client`].
+//! 2. Before the index is returned to the caller, the cosign signature on
+//!    the registry artifact is verified against the trusted-key set loaded
+//!    by [`crate::CosignVerifier`].
+//! 3. The content-addressed [`crate::cache::RegistryCache`] is the source of
+//!    truth for cache hits; the legacy `<registry>/index.yaml` cache entry is
+//!    written alongside for backwards compatibility with the resolver's
+//!    `load_registry_from_cache` path until that, too, migrates to the
+//!    digest layout.
+//!
+//! ## Authentication
+//!
+//! - Anonymous public-registry pulls are the default (`RegistryAuth::Anonymous`).
+//! - When `~/.docker/config.json` exists and contains an `auths` entry whose
+//!   key matches the registry hostname, the basic-auth credentials are
+//!   extracted and used (`RegistryAuth::Basic`). `oci-client` then handles
+//!   the standard `Www-Authenticate: Bearer realm=…` token exchange
+//!   transparently.
+//!
+//! ## Insecure mode
+//!
+//! Callers may pass `insecure = true` to bypass cosign verification, but only
+//! when the active [`InstallPolicy`] does **not** require signed registries.
+//! In strict mode an `--insecure` flag is rejected with
+//! [`RegistryError::InsecureForbiddenByPolicy`] — the strict-mode contract
+//! (ADR-014) is non-negotiable.
+
+use crate::cache::{BlobKind, RegistryCache};
 use crate::error::RegistryError;
 use crate::index::RegistryIndex;
+use crate::oci_ref::{OciRef, OciReference};
+use crate::signing::CosignVerifier;
+use base64::Engine as _;
+use oci_client::client::ClientConfig;
+use oci_client::manifest::OciManifest;
+use oci_client::secrets::RegistryAuth;
+use oci_client::Client as OciClient;
+use oci_client::Reference as OciClientReference;
 use sindri_core::policy::InstallPolicy;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
-/// OCI registry client. Fetches `index.yaml` blobs from OCI registries
-/// (ADR-003).
+/// Media type used when the registry artifact is a single raw `index.yaml`
+/// blob (one layer, no tar wrapping). This is the simplest "registry-as-OCI
+/// artifact" form; documented here so registry publishers have a stable
+/// target to reach for.
+pub const SINDRI_INDEX_MEDIA_TYPE: &str = "application/vnd.sindri.registry.index.v1+yaml";
+
+/// Standard OCI tarball-gzip media type. Accepted as a fallback when a
+/// registry publisher chose to bundle their `index.yaml` inside a tarball
+/// (e.g. for hosting the index alongside other assets).
+pub const OCI_TAR_GZIP_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+
+/// Cosign simple-signing payload media type (cosign spec). The signature
+/// manifest layer carrying this media type contains the canonical
+/// simple-signing JSON document we verify against.
+pub const COSIGN_SIMPLESIGNING_MEDIA_TYPE: &str =
+    "application/vnd.dev.cosign.simplesigning.v1+json";
+
+/// Annotation key on the cosign signature manifest holding the base64-encoded
+/// signature bytes (cosign spec).
+pub const COSIGN_SIGNATURE_ANNOTATION: &str = "dev.cosignproject.cosign/signature";
+
+/// OCI registry client — fetches `index.yaml` artifacts (ADR-003) and
+/// verifies their cosign signatures (ADR-014) before handing them back.
 ///
-/// **Wave 3A.1** still uses an HTTP shim for `index.yaml` — the
-/// `oci-client` crate is on the dependency tree (so 3A.2 can swap to the
-/// real OCI Distribution Spec pipeline) but is not yet called here.
-///
-/// **Wave 3A.2** will:
-///   1. Replace [`Self::fetch_from_source`] with `oci-client` manifest +
-///      blob fetches.
-///   2. Implement [`Self::verify`] using the loaded [`crate::CosignVerifier`].
-///   3. Honour the [`InstallPolicy`] threaded through [`Self::with_policy`].
+/// See the module-level docs for the full protocol contract.
 pub struct RegistryClient {
     cache: RegistryCache,
     ttl: Duration,
-    /// Active install policy. Wave 3A.1 only stores this; the policy is not
-    /// yet consulted in [`Self::fetch_index`].
+    /// Active install policy. Consulted by [`Self::fetch_index`] to decide
+    /// whether unsigned registries are tolerated.
     policy: Option<InstallPolicy>,
+    /// Trust-key set used to verify cosign signatures. `None` means "no
+    /// keys loaded" — equivalent to an empty trust set.
+    verifier: Option<Arc<CosignVerifier>>,
+    /// When `true`, cosign verification is skipped (with a `tracing::warn!`).
+    /// Cannot be combined with a strict signing policy.
+    insecure: bool,
+    /// Underlying OCI Distribution Spec client.
+    oci: OciClient,
 }
 
 impl RegistryClient {
@@ -32,7 +94,22 @@ impl RegistryClient {
             cache: RegistryCache::new()?,
             ttl: Duration::from_secs(3600),
             policy: None,
+            verifier: None,
+            insecure: false,
+            oci: OciClient::new(ClientConfig::default()),
         })
+    }
+
+    /// Construct a client with an explicit cache root (test harnesses).
+    pub fn with_cache(cache: RegistryCache) -> Self {
+        RegistryClient {
+            cache,
+            ttl: Duration::from_secs(3600),
+            policy: None,
+            verifier: None,
+            insecure: false,
+            oci: OciClient::new(ClientConfig::default()),
+        }
     }
 
     /// Override the cache TTL (default: 1h).
@@ -41,49 +118,132 @@ impl RegistryClient {
         self
     }
 
-    /// Attach an install policy. Stored only — policy enforcement is
-    /// deferred to Wave 3A.2 (signed-registry gate, offline gate).
+    /// Attach an install policy. Consulted in [`Self::fetch_index`].
     pub fn with_policy(mut self, policy: InstallPolicy) -> Self {
         self.policy = Some(policy);
         self
     }
 
-    /// Read the policy currently attached to this client (mostly for tests
-    /// + diagnostics; Wave 3A.2 will actually consult it).
+    /// Attach a cosign trust-key set. When unset, [`Self::fetch_index`] will
+    /// only succeed if the policy does *not* require signing.
+    pub fn with_verifier(mut self, verifier: CosignVerifier) -> Self {
+        self.verifier = Some(Arc::new(verifier));
+        self
+    }
+
+    /// Bypass cosign verification with a loud warning (ADR-014 §"Escape
+    /// hatches"). Forbidden in strict mode — see
+    /// [`RegistryError::InsecureForbiddenByPolicy`].
+    pub fn with_insecure(mut self, insecure: bool) -> Self {
+        self.insecure = insecure;
+        self
+    }
+
+    /// Read the policy currently attached to this client.
     pub fn policy(&self) -> Option<&InstallPolicy> {
         self.policy.as_ref()
     }
 
-    /// Verify the cosign signature of the given registry against trusted
-    /// keys.
+    /// Whether `--insecure` is active on this client.
+    pub fn is_insecure(&self) -> bool {
+        self.insecure
+    }
+
+    /// Verify the cosign signature on the most recently fetched (or cached)
+    /// artifact for `registry_name`.
     ///
-    /// **Wave 3A.1 stub.** Always returns
-    /// [`RegistryError::SignatureRequired`] with a message explicitly naming
-    /// Wave 3A.2 as the place that wires up real verification — we never
-    /// silently succeed.
-    pub async fn verify(&self, registry_name: &str) -> Result<(), RegistryError> {
-        Err(RegistryError::SignatureRequired {
-            registry: registry_name.to_string(),
-            reason: "verify not yet implemented (deferred to Wave 3A.2)".to_string(),
-        })
+    /// Resolves the OCI reference + digest from the cache index built by
+    /// [`Self::fetch_index`], then calls
+    /// [`CosignVerifier::verify_registry_signature`].
+    pub async fn verify(
+        &self,
+        registry_name: &str,
+        oci_ref: &OciRef,
+    ) -> Result<String, RegistryError> {
+        let digest = self
+            .cache
+            .lookup_ref(registry_name, oci_ref)
+            .ok_or_else(|| RegistryError::SignatureRequired {
+                registry: registry_name.to_string(),
+                reason: format!(
+                    "no cached digest for {} — run `sindri registry refresh` first",
+                    oci_ref.to_canonical()
+                ),
+            })?;
+        let verifier = self.verifier.as_ref();
+        let policy_requires = self
+            .policy
+            .as_ref()
+            .and_then(|p| p.require_signed_registries)
+            .unwrap_or(false);
+
+        match verifier {
+            Some(v) => {
+                let key_id = v
+                    .verify_registry_signature(
+                        &self.oci,
+                        registry_name,
+                        oci_ref,
+                        &digest,
+                        policy_requires,
+                    )
+                    .await?;
+                Ok(key_id)
+            }
+            None => {
+                if policy_requires {
+                    Err(RegistryError::SignatureRequired {
+                        registry: registry_name.to_string(),
+                        reason: "no trusted keys loaded".into(),
+                    })
+                } else {
+                    tracing::warn!(
+                        "no trusted keys for registry '{}'; skipping signature verification",
+                        registry_name
+                    );
+                    Ok("<unsigned>".to_string())
+                }
+            }
+        }
     }
 
     /// Fetch the registry index, using cache if within TTL.
     ///
-    /// TODO(wave-3a.2): real OCI fetch via `oci-client`; until then,
-    /// `fetch_from_source` still uses the HTTP shim below.
+    /// On a cache miss, performs a real OCI Distribution Spec pull, verifies
+    /// the cosign signature, and writes both the digest-keyed cache and the
+    /// legacy `<registry>/index.yaml` path before returning.
     pub async fn fetch_index(
         &self,
         registry_name: &str,
         registry_url: &str,
-    ) -> Result<RegistryIndex, RegistryError> {
+    ) -> Result<(RegistryIndex, Option<String>), RegistryError> {
+        // Local-filesystem protocol: bypasses OCI + cosign entirely. Used
+        // for development; fixtures keep working.
+        if let Some(path) = registry_url.strip_prefix("registry:local:") {
+            let index_path = Path::new(path).join("index.yaml");
+            let content = std::fs::read_to_string(&index_path).map_err(RegistryError::Io)?;
+            self.cache.put_index(registry_name, &content)?;
+            let index = RegistryIndex::from_yaml(&content).map_err(RegistryError::Yaml)?;
+            return Ok((index, None));
+        }
+
         if let Some(cached) = self.cache.get_index(registry_name, self.ttl) {
             tracing::debug!("Using cached index for {}", registry_name);
-            return RegistryIndex::from_yaml(&cached).map_err(RegistryError::Yaml);
+            let index = RegistryIndex::from_yaml(&cached).map_err(RegistryError::Yaml)?;
+            return Ok((index, None));
         }
-        let content = self.fetch_from_source(registry_url).await?;
+
+        let (content, digest, oci_ref) = self.pull_index_blob(registry_url).await?;
+        self.maybe_verify(registry_name, &oci_ref, &digest).await?;
+
+        // Persist into both cache layouts (digest-addressed + legacy).
+        self.cache
+            .put_by_digest(&digest, BlobKind::Index, content.as_bytes())?;
+        self.cache.link_ref(registry_name, &oci_ref, &digest)?;
         self.cache.put_index(registry_name, &content)?;
-        RegistryIndex::from_yaml(&content).map_err(RegistryError::Yaml)
+
+        let index = RegistryIndex::from_yaml(&content).map_err(RegistryError::Yaml)?;
+        Ok((index, Some(digest)))
     }
 
     /// Force-refresh the registry index, bypassing cache.
@@ -91,45 +251,310 @@ impl RegistryClient {
         &self,
         registry_name: &str,
         registry_url: &str,
-    ) -> Result<RegistryIndex, RegistryError> {
-        let content = self.fetch_from_source(registry_url).await?;
-        self.cache.put_index(registry_name, &content)?;
-        RegistryIndex::from_yaml(&content).map_err(RegistryError::Yaml)
-    }
-
-    async fn fetch_from_source(&self, registry_url: &str) -> Result<String, RegistryError> {
-        // registry:local: protocol — read directly from filesystem
+    ) -> Result<(RegistryIndex, Option<String>), RegistryError> {
         if let Some(path) = registry_url.strip_prefix("registry:local:") {
             let index_path = Path::new(path).join("index.yaml");
-            return std::fs::read_to_string(&index_path).map_err(RegistryError::Io);
+            let content = std::fs::read_to_string(&index_path).map_err(RegistryError::Io)?;
+            self.cache.put_index(registry_name, &content)?;
+            let index = RegistryIndex::from_yaml(&content).map_err(RegistryError::Yaml)?;
+            return Ok((index, None));
+        }
+        let (content, digest, oci_ref) = self.pull_index_blob(registry_url).await?;
+        self.maybe_verify(registry_name, &oci_ref, &digest).await?;
+        self.cache
+            .put_by_digest(&digest, BlobKind::Index, content.as_bytes())?;
+        self.cache.link_ref(registry_name, &oci_ref, &digest)?;
+        self.cache.put_index(registry_name, &content)?;
+        let index = RegistryIndex::from_yaml(&content).map_err(RegistryError::Yaml)?;
+        Ok((index, Some(digest)))
+    }
+
+    // ------------------------------------------------------------------
+    // internals
+    // ------------------------------------------------------------------
+
+    /// Pull `index.yaml` content from an OCI registry using the OCI
+    /// Distribution Spec. Returns `(content, manifest_digest, parsed_ref)`.
+    async fn pull_index_blob(
+        &self,
+        registry_url: &str,
+    ) -> Result<(String, String, OciRef), RegistryError> {
+        let oci_ref = OciRef::parse(registry_url)?;
+        let reference = oci_reference_for(&oci_ref);
+        let auth = docker_config_auth(&oci_ref.registry).unwrap_or(RegistryAuth::Anonymous);
+
+        tracing::info!(
+            "Pulling registry artifact {} via OCI Distribution Spec",
+            oci_ref.to_canonical()
+        );
+
+        let (manifest, digest) = self
+            .oci
+            .pull_manifest(&reference, &auth)
+            .await
+            .map_err(|e| RegistryError::OciFetch {
+                reference: oci_ref.to_canonical(),
+                detail: e.to_string(),
+            })?;
+
+        let image_manifest = match manifest {
+            OciManifest::Image(m) => m,
+            OciManifest::ImageIndex(_) => {
+                return Err(RegistryError::OciFetch {
+                    reference: oci_ref.to_canonical(),
+                    detail: "expected image manifest, got image index".into(),
+                });
+            }
+        };
+
+        let layer = image_manifest
+            .layers
+            .first()
+            .ok_or_else(|| RegistryError::OciFetch {
+                reference: oci_ref.to_canonical(),
+                detail: "manifest has no layers".into(),
+            })?;
+
+        let mut buf: Vec<u8> = Vec::new();
+        self.oci
+            .pull_blob(&reference, layer, &mut buf)
+            .await
+            .map_err(|e| RegistryError::OciFetch {
+                reference: oci_ref.to_canonical(),
+                detail: format!("blob pull failed: {}", e),
+            })?;
+
+        let content = match layer.media_type.as_str() {
+            SINDRI_INDEX_MEDIA_TYPE => {
+                String::from_utf8(buf).map_err(|e| RegistryError::OciFetch {
+                    reference: oci_ref.to_canonical(),
+                    detail: format!("layer was not valid UTF-8: {}", e),
+                })?
+            }
+            OCI_TAR_GZIP_MEDIA_TYPE => {
+                return Err(RegistryError::UnsupportedMediaType {
+                    reference: oci_ref.to_canonical(),
+                    media_type: layer.media_type.clone(),
+                    expected: format!(
+                        "{} (tar+gzip layer extraction will land in a follow-up PR)",
+                        SINDRI_INDEX_MEDIA_TYPE
+                    ),
+                });
+            }
+            other => {
+                return Err(RegistryError::UnsupportedMediaType {
+                    reference: oci_ref.to_canonical(),
+                    media_type: other.to_string(),
+                    expected: format!("{} or {}", SINDRI_INDEX_MEDIA_TYPE, OCI_TAR_GZIP_MEDIA_TYPE),
+                });
+            }
+        };
+
+        Ok((content, digest, oci_ref))
+    }
+
+    async fn maybe_verify(
+        &self,
+        registry_name: &str,
+        oci_ref: &OciRef,
+        digest: &str,
+    ) -> Result<(), RegistryError> {
+        let policy_requires = self
+            .policy
+            .as_ref()
+            .and_then(|p| p.require_signed_registries)
+            .unwrap_or(false);
+
+        if self.insecure {
+            if policy_requires {
+                return Err(RegistryError::InsecureForbiddenByPolicy {
+                    registry: registry_name.to_string(),
+                });
+            }
+            tracing::warn!(
+                "INSECURE: skipping cosign verification for registry '{}' ({})",
+                registry_name,
+                oci_ref.to_canonical()
+            );
+            return Ok(());
         }
 
-        // HTTP(S) — fetch index.yaml directly.
-        // TODO(wave-3a.2): replace with oci-client (manifest + blob).
-        let index_url = format!("{}/index.yaml", registry_url.trim_end_matches('/'));
-        tracing::info!("Fetching registry index from {}", index_url);
-
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .map_err(|e| RegistryError::Unreachable(e.to_string()))?;
-
-        let resp = client
-            .get(&index_url)
-            .send()
-            .await
-            .map_err(|e| RegistryError::Unreachable(e.to_string()))?;
-
-        if !resp.status().is_success() {
-            return Err(RegistryError::Unreachable(format!(
-                "HTTP {} fetching {}",
-                resp.status(),
-                index_url
-            )));
+        match self.verifier.as_ref() {
+            Some(v) => {
+                let key_id = v
+                    .verify_registry_signature(
+                        &self.oci,
+                        registry_name,
+                        oci_ref,
+                        digest,
+                        policy_requires,
+                    )
+                    .await?;
+                if key_id != "<unsigned>" {
+                    tracing::info!(
+                        "Verified registry '{}' signature against trusted key {}",
+                        registry_name,
+                        key_id
+                    );
+                }
+                Ok(())
+            }
+            None => {
+                if policy_requires {
+                    Err(RegistryError::SignatureRequired {
+                        registry: registry_name.to_string(),
+                        reason: "no trusted keys loaded for registry".into(),
+                    })
+                } else {
+                    tracing::warn!(
+                        "no trusted keys for registry '{}'; skipping cosign verification \
+                         (policy.require_signed_registries=false)",
+                        registry_name
+                    );
+                    Ok(())
+                }
+            }
         }
+    }
+}
 
-        resp.text()
-            .await
-            .map_err(|e| RegistryError::Unreachable(e.to_string()))
+/// Convert an [`OciRef`] into the [`oci_client::Reference`] type expected by
+/// the underlying client.
+fn oci_reference_for(oci: &OciRef) -> OciClientReference {
+    match &oci.reference {
+        OciReference::Tag(tag) => {
+            OciClientReference::with_tag(oci.registry.clone(), oci.repository.clone(), tag.clone())
+        }
+        OciReference::Digest(d) => {
+            OciClientReference::with_digest(oci.registry.clone(), oci.repository.clone(), d.clone())
+        }
+    }
+}
+
+/// Decode `~/.docker/config.json` and return basic-auth credentials for the
+/// requested registry hostname, if present. Failures are silently treated as
+/// "no credentials" — anonymous pull is the safe default.
+pub(crate) fn docker_config_auth(registry: &str) -> Option<RegistryAuth> {
+    let path = dirs_next::home_dir()?.join(".docker").join("config.json");
+    let raw = std::fs::read_to_string(&path).ok()?;
+    parse_docker_config_auth(&raw, registry)
+}
+
+/// Pure-function helper for [`docker_config_auth`] — exposed for unit tests
+/// so we don't depend on the user's actual `~/.docker/config.json`.
+pub(crate) fn parse_docker_config_auth(raw: &str, registry: &str) -> Option<RegistryAuth> {
+    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let auths = v.get("auths")?.as_object()?;
+    // Match the registry hostname against the auths map. Docker's keys can
+    // include a scheme prefix (https://) and a trailing path; normalise both
+    // sides before comparing.
+    let normalised_target = normalise_registry_host(registry);
+    let entry = auths.iter().find_map(|(k, v)| {
+        if normalise_registry_host(k) == normalised_target {
+            Some(v)
+        } else {
+            None
+        }
+    })?;
+    let auth_b64 = entry.get("auth")?.as_str()?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(auth_b64.as_bytes())
+        .ok()?;
+    let s = std::str::from_utf8(&decoded).ok()?;
+    let (user, password) = s.split_once(':')?;
+    Some(RegistryAuth::Basic(user.to_string(), password.to_string()))
+}
+
+fn normalise_registry_host(s: &str) -> String {
+    let s = s.trim();
+    let s = s.strip_prefix("https://").unwrap_or(s);
+    let s = s.strip_prefix("http://").unwrap_or(s);
+    let s = s.split('/').next().unwrap_or(s);
+    s.trim_end_matches('/').to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn temp_client() -> (TempDir, RegistryClient) {
+        let tmp = TempDir::new().unwrap();
+        let cache = RegistryCache::with_path(tmp.path().to_path_buf()).unwrap();
+        (tmp, RegistryClient::with_cache(cache))
+    }
+
+    #[tokio::test]
+    async fn registry_local_protocol_unaffected() {
+        // The `registry:local:` protocol must bypass OCI/cosign entirely so
+        // local development workflows never hit the network and never touch
+        // the verifier.
+        let tmp = TempDir::new().unwrap();
+        let registry_dir = tmp.path().join("local-reg");
+        std::fs::create_dir_all(&registry_dir).unwrap();
+        let index = "version: 1\nregistry: local\ncomponents: []\n";
+        std::fs::write(registry_dir.join("index.yaml"), index).unwrap();
+
+        let (_cache_tmp, client) = temp_client();
+        let url = format!("registry:local:{}", registry_dir.display());
+        let (parsed, digest) = client.fetch_index("dev-local", &url).await.unwrap();
+        assert!(digest.is_none(), "local protocol must not produce a digest");
+        assert_eq!(parsed.components.len(), 0);
+    }
+
+    #[test]
+    fn parse_docker_config_extracts_basic_auth() {
+        let cfg = r#"{
+            "auths": {
+                "ghcr.io": { "auth": "dXNlcjpwYXNz" }
+            }
+        }"#;
+        let auth = parse_docker_config_auth(cfg, "ghcr.io").unwrap();
+        match auth {
+            RegistryAuth::Basic(u, p) => {
+                assert_eq!(u, "user");
+                assert_eq!(p, "pass");
+            }
+            other => panic!("expected Basic auth, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_docker_config_normalises_https_prefix() {
+        let cfg = r#"{
+            "auths": {
+                "https://index.docker.io/v1/": { "auth": "Zm9vOmJhcg==" }
+            }
+        }"#;
+        let auth = parse_docker_config_auth(cfg, "index.docker.io").unwrap();
+        assert!(matches!(auth, RegistryAuth::Basic(_, _)));
+    }
+
+    #[test]
+    fn parse_docker_config_returns_none_when_registry_missing() {
+        let cfg = r#"{ "auths": { "ghcr.io": { "auth": "Zm9vOmJhcg==" } } }"#;
+        assert!(parse_docker_config_auth(cfg, "registry.example.com").is_none());
+    }
+
+    #[test]
+    fn parse_docker_config_returns_none_for_garbage() {
+        assert!(parse_docker_config_auth("not-json", "ghcr.io").is_none());
+        assert!(parse_docker_config_auth("{}", "ghcr.io").is_none());
+        // Missing `auth` field.
+        assert!(parse_docker_config_auth(r#"{"auths":{"ghcr.io":{}}}"#, "ghcr.io").is_none());
+    }
+
+    #[test]
+    fn oci_reference_for_tag_and_digest() {
+        let r = OciRef::parse("ghcr.io/sindri-dev/registry-core:1.0.0").unwrap();
+        let conv = oci_reference_for(&r);
+        assert_eq!(conv.registry(), "ghcr.io");
+        assert_eq!(conv.repository(), "sindri-dev/registry-core");
+        assert_eq!(conv.tag(), Some("1.0.0"));
+
+        let digest = format!("sha256:{}", "a".repeat(64));
+        let r2 = OciRef::parse(&format!("ghcr.io/foo/bar@{}", digest)).unwrap();
+        let conv2 = oci_reference_for(&r2);
+        assert_eq!(conv2.digest(), Some(digest.as_str()));
     }
 }

--- a/v4/crates/sindri-registry/src/error.rs
+++ b/v4/crates/sindri-registry/src/error.rs
@@ -42,6 +42,28 @@ pub enum RegistryError {
     #[error("Failed to parse cosign trust key '{path}': {detail}")]
     TrustKeyParseFailed { path: String, detail: String },
 
+    /// An OCI Distribution Spec call (manifest pull, blob pull) failed.
+    #[error("OCI fetch failed for '{reference}': {detail}")]
+    OciFetch { reference: String, detail: String },
+
+    /// The pulled OCI artifact had a layer media type the registry layer
+    /// does not know how to interpret.
+    #[error(
+        "Unsupported OCI layer media type '{media_type}' for reference '{reference}'; expected one of: {expected}"
+    )]
+    UnsupportedMediaType {
+        reference: String,
+        media_type: String,
+        expected: String,
+    },
+
+    /// The user passed `--insecure` while running under a policy that
+    /// requires signed registries (ADR-014, strict preset).
+    #[error(
+        "policy requires signing for registry '{registry}'; --insecure is not allowed in strict mode"
+    )]
+    InsecureForbiddenByPolicy { registry: String },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]

--- a/v4/crates/sindri-registry/src/signing.rs
+++ b/v4/crates/sindri-registry/src/signing.rs
@@ -1,9 +1,4 @@
-//! Cosign trust-key loading (ADR-014 §"Trust model").
-//!
-//! Wave 3A.1 owns trust-key **loading** only. Verification — fetching the
-//! signature manifest, decoding the simple-signing payload, and verifying
-//! signature bytes — is deferred to Wave 3A.2 so we don't ship a verifier
-//! that quietly accepts everything.
+//! Cosign trust-key loading + signature verification (ADR-014).
 //!
 //! ## On-disk layout
 //!
@@ -15,10 +10,34 @@
 //!
 //! Each `.pub` file is an ECDSA P-256 public key in PEM (PKCS#8 SPKI) form,
 //! the default cosign key format.
+//!
+//! ## Verification flow (Wave 3A.2 — operational)
+//!
+//! Per the [cosign signature spec][cosign-spec], a signed OCI artifact at
+//! `<repo>:<tag>` (digest `sha256:<hex>`) has a companion signature manifest
+//! at the *tag* `sha256-<hex>.sig`. The signature manifest's first layer is
+//! a JSON document of media type
+//! `application/vnd.dev.cosign.simplesigning.v1+json` whose
+//! `critical.image.docker-manifest-digest` field MUST match the original
+//! artifact digest. The signature itself is base64-encoded in the manifest's
+//! `dev.cosignproject.cosign/signature` annotation.
+//!
+//! [`CosignVerifier::verify_payload`] is the pure, allocation-free verifier
+//! over already-fetched bytes; [`CosignVerifier::verify_registry_signature`]
+//! adds the OCI fetch wrapping needed at runtime.
+//!
+//! [cosign-spec]: https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md
 
 use crate::error::RegistryError;
+use crate::oci_ref::OciRef;
+use base64::Engine as _;
 use ecdsa::elliptic_curve::pkcs8::DecodePublicKey;
-use p256::ecdsa::VerifyingKey;
+use ecdsa::signature::Verifier;
+use oci_client::manifest::OciManifest;
+use oci_client::secrets::RegistryAuth;
+use oci_client::Client as OciClient;
+use oci_client::Reference as OciClientReference;
+use p256::ecdsa::{Signature, VerifyingKey};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
@@ -137,11 +156,254 @@ impl CosignVerifier {
             .map(|v| v.as_slice())
             .unwrap_or(&[])
     }
+
+    /// Verify an already-fetched cosign signature payload against the trust
+    /// keys registered for `registry_name`.
+    ///
+    /// This is the pure-function core of the verification flow — given the
+    /// raw simple-signing JSON bytes, the base64-decoded signature bytes,
+    /// and the expected manifest digest of the artifact under attestation,
+    /// returns the `key_id` of the first trusted key that verifies the
+    /// signature, or a [`RegistryError::SignatureMismatch`].
+    ///
+    /// Caller responsibilities:
+    ///
+    /// - `payload_bytes` MUST be the canonical bytes read off the wire from
+    ///   the cosign signature layer — do not pretty-print, re-serialize, or
+    ///   otherwise normalise. Cosign signatures are computed over the bytes
+    ///   the registry hosts, byte-for-byte.
+    /// - `signature_bytes` MUST be the *raw* signature bytes after
+    ///   base64-decoding the `dev.cosignproject.cosign/signature` annotation.
+    /// - `expected_manifest_digest` is the `sha256:<hex>` digest of the
+    ///   *original* artifact (not the signature manifest).
+    pub fn verify_payload(
+        &self,
+        registry_name: &str,
+        payload_bytes: &[u8],
+        signature_bytes: &[u8],
+        expected_manifest_digest: &str,
+        policy_requires_signing: bool,
+    ) -> Result<String, RegistryError> {
+        // 1. Parse the simple-signing payload.
+        let payload: serde_json::Value = serde_json::from_slice(payload_bytes).map_err(|e| {
+            RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!("simple-signing payload was not valid JSON: {}", e),
+            }
+        })?;
+        let actual_digest = payload
+            .get("critical")
+            .and_then(|c| c.get("image"))
+            .and_then(|i| i.get("docker-manifest-digest"))
+            .and_then(|d| d.as_str())
+            .ok_or_else(|| RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: "simple-signing payload missing critical.image.docker-manifest-digest"
+                    .into(),
+            })?;
+        if actual_digest != expected_manifest_digest {
+            return Err(RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!(
+                    "payload digest {} != expected {}",
+                    actual_digest, expected_manifest_digest
+                ),
+            });
+        }
+
+        // 2. Empty trust set short-circuit. We resolve this before even
+        //    attempting to parse the signature bytes so callers running
+        //    with no trust keys get the precise SignatureRequired /
+        //    `<unsigned>` outcome rather than a parse-error red herring.
+        let keys = self.keys_for(registry_name);
+        if keys.is_empty() {
+            if policy_requires_signing {
+                return Err(RegistryError::SignatureRequired {
+                    registry: registry_name.to_string(),
+                    reason: "no trusted keys configured for this registry".into(),
+                });
+            }
+            tracing::warn!(
+                "no trusted keys for registry '{}'; cosign signature not verified",
+                registry_name
+            );
+            return Ok("<unsigned>".to_string());
+        }
+
+        // 3. Decode the signature bytes into a P-256 ECDSA Signature.
+        let signature = Signature::from_der(signature_bytes)
+            .or_else(|_| Signature::from_slice(signature_bytes))
+            .map_err(|e| RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!(
+                    "signature bytes are not a valid P-256 ECDSA signature: {}",
+                    e
+                ),
+            })?;
+
+        // 4. Try every trusted key for this registry.
+        for key in keys {
+            if key.key.verify(payload_bytes, &signature).is_ok() {
+                return Ok(key.key_id.clone());
+            }
+        }
+        Err(RegistryError::SignatureMismatch {
+            registry: registry_name.to_string(),
+            expected_keys: self.key_ids_for(registry_name),
+            detail: "no trusted key matched the signature".into(),
+        })
+    }
+
+    /// Fetch + verify a cosign signature for a registry artifact.
+    ///
+    /// Wraps [`Self::verify_payload`] with the OCI fetch protocol described
+    /// in the module docs. Returns the `key_id` of the trusted key that
+    /// verified, or `<unsigned>` when no keys are loaded and the policy
+    /// permits unsigned registries.
+    pub async fn verify_registry_signature(
+        &self,
+        oci: &OciClient,
+        registry_name: &str,
+        oci_ref: &OciRef,
+        manifest_digest: &str,
+        policy_requires_signing: bool,
+    ) -> Result<String, RegistryError> {
+        // Fast path: empty trust set + permissive policy → warn + skip.
+        if self.keys_for(registry_name).is_empty() && !policy_requires_signing {
+            tracing::warn!(
+                "no trusted keys for registry '{}'; skipping cosign verification",
+                registry_name
+            );
+            return Ok("<unsigned>".to_string());
+        }
+        if self.keys_for(registry_name).is_empty() && policy_requires_signing {
+            return Err(RegistryError::SignatureRequired {
+                registry: registry_name.to_string(),
+                reason: "no trusted keys configured for this registry".into(),
+            });
+        }
+
+        // 1. Compute the cosign signature tag: sha256:<hex> → sha256-<hex>.sig
+        let sig_tag = cosign_signature_tag(manifest_digest).ok_or_else(|| {
+            RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!(
+                    "cannot derive cosign signature tag from '{}'",
+                    manifest_digest
+                ),
+            }
+        })?;
+        let sig_ref = OciClientReference::with_tag(
+            oci_ref.registry.clone(),
+            oci_ref.repository.clone(),
+            sig_tag,
+        );
+        let auth =
+            crate::client::docker_config_auth(&oci_ref.registry).unwrap_or(RegistryAuth::Anonymous);
+
+        // 2. Pull the signature manifest.
+        let (manifest, _sig_manifest_digest) =
+            oci.pull_manifest(&sig_ref, &auth).await.map_err(|e| {
+                RegistryError::SignatureRequired {
+                    registry: registry_name.to_string(),
+                    reason: format!("could not pull signature manifest: {}", e),
+                }
+            })?;
+        let image = match manifest {
+            OciManifest::Image(m) => m,
+            OciManifest::ImageIndex(_) => {
+                return Err(RegistryError::SignatureMismatch {
+                    registry: registry_name.to_string(),
+                    expected_keys: self.key_ids_for(registry_name),
+                    detail: "signature manifest unexpectedly was an image index".into(),
+                });
+            }
+        };
+
+        // 3. Find the simple-signing layer.
+        let layer = image
+            .layers
+            .iter()
+            .find(|l| l.media_type == crate::client::COSIGN_SIMPLESIGNING_MEDIA_TYPE)
+            .ok_or_else(|| RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!(
+                    "signature manifest missing layer with media type {}",
+                    crate::client::COSIGN_SIMPLESIGNING_MEDIA_TYPE
+                ),
+            })?;
+
+        // 4. Pull the layer (the simple-signing JSON payload).
+        let mut payload_bytes: Vec<u8> = Vec::new();
+        oci.pull_blob(&sig_ref, layer, &mut payload_bytes)
+            .await
+            .map_err(|e| RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!("could not pull simple-signing layer: {}", e),
+            })?;
+
+        // 5. Extract + base64-decode the signature annotation.
+        let sig_b64 = image
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get(crate::client::COSIGN_SIGNATURE_ANNOTATION))
+            .ok_or_else(|| RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!(
+                    "signature manifest missing '{}' annotation",
+                    crate::client::COSIGN_SIGNATURE_ANNOTATION
+                ),
+            })?;
+        let signature_bytes = base64::engine::general_purpose::STANDARD
+            .decode(sig_b64.as_bytes())
+            .map_err(|e| RegistryError::SignatureMismatch {
+                registry: registry_name.to_string(),
+                expected_keys: self.key_ids_for(registry_name),
+                detail: format!("signature annotation was not valid base64: {}", e),
+            })?;
+
+        // 6. Verify.
+        self.verify_payload(
+            registry_name,
+            &payload_bytes,
+            &signature_bytes,
+            manifest_digest,
+            policy_requires_signing,
+        )
+    }
+
+    fn key_ids_for(&self, registry_name: &str) -> Vec<String> {
+        self.keys_for(registry_name)
+            .iter()
+            .map(|k| k.key_id.clone())
+            .collect()
+    }
+}
+
+/// Compute the cosign signature tag for a given manifest digest.
+///
+/// `sha256:<hex>` becomes `sha256-<hex>.sig` per the cosign signature spec.
+/// Returns `None` if the input is not a valid `<alg>:<hex>` digest string.
+pub(crate) fn cosign_signature_tag(manifest_digest: &str) -> Option<String> {
+    let (alg, hex) = manifest_digest.split_once(':')?;
+    if alg.is_empty() || hex.is_empty() {
+        return None;
+    }
+    Some(format!("{}-{}.sig", alg, hex))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ecdsa::signature::Signer;
     use p256::ecdsa::SigningKey;
     use p256::pkcs8::EncodePublicKey;
     use rand_core::OsRng;
@@ -159,6 +421,41 @@ mod tests {
         let path = registry_dir.join(format!("cosign-test-{}.pub", key_idx));
         fs::write(&path, &pem).unwrap();
         pem
+    }
+
+    /// Build a `(signing_key, verifier_with_one_key)` pair under registry name
+    /// `registry`. The verifier mirrors the on-disk shape produced by
+    /// `sindri registry trust`.
+    fn fixture_verifier(registry: &str) -> (SigningKey, CosignVerifier) {
+        let tmp = TempDir::new().unwrap();
+        // Persist `tmp` for the lifetime of the verifier by leaking a Box —
+        // tests are short-lived processes so this is fine and avoids a
+        // lifetime parameter on `fixture_verifier`.
+        let dir = Box::leak(Box::new(tmp));
+        let registry_dir = dir.path().join(registry);
+        fs::create_dir_all(&registry_dir).unwrap();
+        let signing = SigningKey::random(&mut OsRng);
+        let verifying = VerifyingKey::from(&signing);
+        let pem = verifying
+            .to_public_key_pem(p256::pkcs8::LineEnding::LF)
+            .unwrap();
+        fs::write(registry_dir.join("cosign-test-0.pub"), &pem).unwrap();
+        let verifier = CosignVerifier::load_from_trust_dir(dir.path()).unwrap();
+        (signing, verifier)
+    }
+
+    fn simple_signing_payload(manifest_digest: &str) -> Vec<u8> {
+        // Cosign payload body — only `critical.image.docker-manifest-digest`
+        // is consulted by the verifier; the rest is structural ballast.
+        let payload = serde_json::json!({
+            "critical": {
+                "identity": { "docker-reference": "ghcr.io/example/repo" },
+                "image": { "docker-manifest-digest": manifest_digest },
+                "type": "cosign container image signature"
+            },
+            "optional": null
+        });
+        serde_json::to_vec(&payload).unwrap()
     }
 
     #[test]
@@ -225,5 +522,118 @@ mod tests {
         fs::write(registry_dir.join("other.pub"), "not loaded").unwrap();
         let verifier = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap();
         assert_eq!(verifier.keys_for("acme").len(), 1);
+    }
+
+    // -- Wave 3A.2: verify_payload pure-function tests -----------------------
+
+    #[test]
+    fn verify_succeeds_with_test_signature_against_trusted_key() {
+        let (signing, verifier) = fixture_verifier("ghcr.io_sindri-dev");
+        let manifest_digest = format!("sha256:{}", "a".repeat(64));
+        let payload = simple_signing_payload(&manifest_digest);
+        // Sign the canonical payload bytes with the test key.
+        let sig: Signature = signing.sign(&payload);
+        let sig_bytes = sig.to_der().as_bytes().to_vec();
+        let key_id = verifier
+            .verify_payload(
+                "ghcr.io_sindri-dev",
+                &payload,
+                &sig_bytes,
+                &manifest_digest,
+                true,
+            )
+            .expect("verification should succeed against the trusted key");
+        // The matched key id should be the only one in the trust set.
+        assert_eq!(key_id, verifier.keys_for("ghcr.io_sindri-dev")[0].key_id);
+    }
+
+    #[test]
+    fn verify_fails_with_wrong_payload_digest() {
+        let (signing, verifier) = fixture_verifier("ghcr.io_sindri-dev");
+        let real_digest = format!("sha256:{}", "a".repeat(64));
+        let tampered_digest = format!("sha256:{}", "b".repeat(64));
+        // Build a payload where the docker-manifest-digest claims a
+        // different artifact than the one we say we expect. The signature
+        // itself is over the tampered payload (so the crypto is valid) but
+        // the payload→expected mismatch must be caught.
+        let payload = simple_signing_payload(&real_digest);
+        let sig: Signature = signing.sign(&payload);
+        let sig_bytes = sig.to_der().as_bytes().to_vec();
+        let err = verifier
+            .verify_payload(
+                "ghcr.io_sindri-dev",
+                &payload,
+                &sig_bytes,
+                &tampered_digest,
+                true,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, RegistryError::SignatureMismatch { ref detail, .. } if detail.contains("payload digest")),
+            "expected SignatureMismatch with payload-digest detail, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn verify_fails_with_wrong_key() {
+        // Trust set contains key A; we sign with key B.
+        let (_signing_a, verifier) = fixture_verifier("acme");
+        let signing_b = SigningKey::random(&mut OsRng);
+        let manifest_digest = format!("sha256:{}", "c".repeat(64));
+        let payload = simple_signing_payload(&manifest_digest);
+        let sig: Signature = signing_b.sign(&payload);
+        let sig_bytes = sig.to_der().as_bytes().to_vec();
+        let err = verifier
+            .verify_payload("acme", &payload, &sig_bytes, &manifest_digest, true)
+            .unwrap_err();
+        assert!(
+            matches!(err, RegistryError::SignatureMismatch { ref detail, .. } if detail.contains("no trusted key matched")),
+            "expected SignatureMismatch with 'no trusted key matched', got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn strict_policy_no_keys_fails() {
+        let tmp = TempDir::new().unwrap();
+        let verifier = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap();
+        let digest = format!("sha256:{}", "0".repeat(64));
+        let payload = simple_signing_payload(&digest);
+        let err = verifier
+            .verify_payload("nope", &payload, &[0u8; 64], &digest, true)
+            .unwrap_err();
+        assert!(
+            matches!(err, RegistryError::SignatureRequired { .. }),
+            "expected SignatureRequired in strict mode with no keys, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn permissive_policy_no_keys_warns_only() {
+        let tmp = TempDir::new().unwrap();
+        let verifier = CosignVerifier::load_from_trust_dir(tmp.path()).unwrap();
+        let digest = format!("sha256:{}", "0".repeat(64));
+        let payload = simple_signing_payload(&digest);
+        // Garbage signature bytes — but with no keys + permissive policy we
+        // never get to the crypto check, so this should succeed with the
+        // sentinel `<unsigned>` key id.
+        let key_id = verifier
+            .verify_payload("nope", &payload, &[0u8; 64], &digest, false)
+            .unwrap();
+        assert_eq!(key_id, "<unsigned>");
+    }
+
+    #[test]
+    fn cosign_signature_tag_round_trip() {
+        let digest = "sha256:abcdef0123456789";
+        assert_eq!(
+            cosign_signature_tag(digest),
+            Some("sha256-abcdef0123456789.sig".to_string())
+        );
+        assert_eq!(cosign_signature_tag("not-a-digest"), None);
+        assert_eq!(cosign_signature_tag(":empty-alg"), None);
+        assert_eq!(cosign_signature_tag("sha256:"), None);
     }
 }

--- a/v4/crates/sindri-registry/tests/oci_integration.rs
+++ b/v4/crates/sindri-registry/tests/oci_integration.rs
@@ -1,0 +1,54 @@
+//! Live OCI integration tests (ADR-003 / ADR-014).
+//!
+//! These tests actually hit a public OCI registry, so they are gated behind
+//! the `live-oci-tests` feature **and** the `#[ignore]` attribute. CI does
+//! not run them by default.
+//!
+//! Run locally with:
+//!
+//! ```bash
+//! cargo test -p sindri-registry --features live-oci-tests \
+//!     --test oci_integration -- --ignored
+//! ```
+//!
+//! TODO(wave-3a.3): replace these with `wiremock`-backed mock-server tests
+//! that don't require network access. The bearer-token negotiation handshake
+//! made the wiremock setup non-trivial enough that it was scoped out of
+//! Wave 3A.2 — see PR description for the trade-off.
+
+#![cfg(feature = "live-oci-tests")]
+
+use oci_client::secrets::RegistryAuth;
+use oci_client::Client as OciClient;
+use sindri_registry::OciRef;
+
+/// Smoke test: pull a manifest from a small public OCI image and assert we
+/// got a non-empty digest back. Validates the end-to-end oci-client wiring
+/// against a real registry without depending on a sindri-published artifact
+/// (which doesn't exist yet).
+#[tokio::test]
+#[ignore = "requires network access; run with --features live-oci-tests --ignored"]
+async fn pulls_manifest_from_public_registry() {
+    // `cgr.dev/chainguard/static` is a tiny public image; manifests for its
+    // tags should always be reachable.
+    let oci_ref = OciRef::parse("cgr.dev/chainguard/static:latest").unwrap();
+    let reference = oci_client::Reference::with_tag(
+        oci_ref.registry.clone(),
+        oci_ref.repository.clone(),
+        match &oci_ref.reference {
+            sindri_registry::OciReference::Tag(t) => t.clone(),
+            sindri_registry::OciReference::Digest(d) => d.clone(),
+        },
+    );
+    let client = OciClient::default();
+    let (_manifest, digest) = client
+        .pull_manifest(&reference, &RegistryAuth::Anonymous)
+        .await
+        .expect("manifest pull should succeed");
+    assert!(!digest.is_empty());
+    assert!(
+        digest.starts_with("sha256:"),
+        "expected sha256-prefixed digest, got {}",
+        digest
+    );
+}

--- a/v4/crates/sindri-resolver/src/lib.rs
+++ b/v4/crates/sindri-resolver/src/lib.rs
@@ -25,6 +25,12 @@ pub struct ResolveOptions {
     pub offline: bool,
     pub strict: bool,
     pub explain: Option<String>,
+    /// Live OCI manifest digest of the registry artifact this resolution
+    /// was performed against. Populated by callers that fetched the index
+    /// via `RegistryClient::fetch_index` (Wave 3A.2). When `None`, lockfile
+    /// entries omit `manifest_digest`. ADR-003 audit-delta tracks moving
+    /// this from registry-scoped to per-component when SBOM (Wave 5) lands.
+    pub registry_manifest_digest: Option<String>,
 }
 
 /// Main resolution pipeline: manifest → registry → closure → gates → backend → lockfile
@@ -76,8 +82,12 @@ pub fn resolve(
         }
 
         let chosen = backend_choice::choose_backend(&node.entry, platform, None);
-        let resolved =
-            lockfile_writer::resolved_from_entry(&node.entry, chosen, &node.id.to_address());
+        let resolved = lockfile_writer::resolved_from_entry(
+            &node.entry,
+            chosen,
+            &node.id.to_address(),
+            opts.registry_manifest_digest.as_deref(),
+        );
         lockfile.components.push(resolved);
     }
 

--- a/v4/crates/sindri-resolver/src/lockfile_writer.rs
+++ b/v4/crates/sindri-resolver/src/lockfile_writer.rs
@@ -33,11 +33,23 @@ pub fn read_lockfile(path: &Path) -> Result<Lockfile, ResolverError> {
     serde_json::from_str(&content).map_err(|e| ResolverError::Serialization(e.to_string()))
 }
 
-/// Build ResolvedComponent from a closure node
+/// Build ResolvedComponent from a closure node.
+///
+/// `registry_manifest_digest` is the live OCI manifest digest returned by
+/// `oci-client` when the resolver fetched the registry's `index.yaml` (Wave
+/// 3A.2). When `None` (e.g. local-protocol fixtures, offline mode), the
+/// lockfile entry omits `manifest_digest` for backwards compatibility.
+///
+/// Per ADR-003 audit-delta (Wave 3A.2): per-component manifest digests
+/// (each component carrying its own OCI digest) are deferred to the SBOM
+/// work in Wave 5. This field carries the *registry-level* artifact digest
+/// — an integrity tie-in for "this lockfile was resolved against this
+/// exact `index.yaml` snapshot."
 pub fn resolved_from_entry(
     entry: &ComponentEntry,
     chosen_backend: Backend,
     _bom_address: &str,
+    registry_manifest_digest: Option<&str>,
 ) -> ResolvedComponent {
     let id = ComponentId {
         backend: chosen_backend.clone(),
@@ -54,8 +66,6 @@ pub fn resolved_from_entry(
         // Wave 3A will fetch manifests from OCI; until then, the apply
         // pipeline degrades to install + hooks only when manifest is None.
         manifest: None,
-        // Wave 3A.1: resolver still writes None. Wave 3A.2 will populate
-        // this from the live OCI manifest digest returned by oci-client.
-        manifest_digest: None,
+        manifest_digest: registry_manifest_digest.map(|s| s.to_string()),
     }
 }

--- a/v4/crates/sindri/src/commands/registry.rs
+++ b/v4/crates/sindri/src/commands/registry.rs
@@ -1,96 +1,122 @@
 use sindri_core::component::ComponentManifest;
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_registry::signing::TrustedKey;
+use sindri_registry::{CosignVerifier, OciRef, RegistryClient};
 
 pub enum RegistryCmd {
-    Refresh { name: String, url: String },
-    Lint { path: String, json: bool },
-    Trust { name: String, signer: String },
-    Verify { name: String },
-    FetchChecksums { path: String },
+    Refresh {
+        name: String,
+        url: String,
+        insecure: bool,
+    },
+    Lint {
+        path: String,
+        json: bool,
+    },
+    Trust {
+        name: String,
+        signer: String,
+    },
+    Verify {
+        name: String,
+        url: String,
+    },
+    FetchChecksums {
+        path: String,
+    },
 }
 
 pub fn run(cmd: RegistryCmd) -> i32 {
     match cmd {
-        RegistryCmd::Refresh { name, url } => refresh(&name, &url),
+        RegistryCmd::Refresh {
+            name,
+            url,
+            insecure,
+        } => refresh(&name, &url, insecure),
         RegistryCmd::Lint { path, json } => lint(&path, json),
         RegistryCmd::Trust { name, signer } => trust(&name, &signer),
-        RegistryCmd::Verify { name } => verify(&name),
+        RegistryCmd::Verify { name, url } => verify(&name, &url),
         RegistryCmd::FetchChecksums { path } => fetch_checksums(&path),
     }
 }
 
-fn refresh(name: &str, url: &str) -> i32 {
-    // local registry protocol
-    if let Some(path) = url.strip_prefix("registry:local:") {
-        let index_path = std::path::Path::new(path).join("index.yaml");
-        if !index_path.exists() {
-            eprintln!("Local registry index not found: {}", index_path.display());
+/// Refresh a registry index via the live OCI Distribution Spec pipeline
+/// (ADR-003) and verify its cosign signature (ADR-014) before caching.
+///
+/// `--insecure` bypasses cosign verification with a loud warning. It is
+/// rejected when the active install policy sets `require_signed_registries`.
+fn refresh(name: &str, url: &str, insecure: bool) -> i32 {
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Cannot start async runtime: {}", e);
             return EXIT_SCHEMA_OR_RESOLVE_ERROR;
         }
-        let content = match std::fs::read_to_string(&index_path) {
+    };
+
+    runtime.block_on(async move {
+        let mut client = match RegistryClient::new() {
             Ok(c) => c,
             Err(e) => {
-                eprintln!("Cannot read local registry: {}", e);
+                eprintln!("Cannot construct registry client: {}", e);
                 return EXIT_SCHEMA_OR_RESOLVE_ERROR;
             }
         };
-        return write_to_cache(name, &content);
-    }
 
-    // HTTP fetch via curl (matches Sprint 2 risk mitigation strategy)
-    let index_url = format!("{}/index.yaml", url.trim_end_matches('/'));
-    eprintln!("Fetching registry index from {}...", index_url);
+        // Load policy + trust keys. Policy may not exist yet for a fresh
+        // install; default to permissive in that case so `--insecure`
+        // semantics are usable out of the box.
+        let policy = sindri_policy::loader::load_effective_policy().policy;
+        client = client.with_policy(policy);
 
-    match std::process::Command::new("curl")
-        .args(["-sSfL", &index_url, "--max-time", "30"])
-        .output()
-    {
-        Ok(out) if out.status.success() => {
-            let content = String::from_utf8_lossy(&out.stdout);
-            write_to_cache(name, &content)
+        let trust_dir = dirs_next::home_dir()
+            .unwrap_or_default()
+            .join(".sindri")
+            .join("trust");
+        match CosignVerifier::load_from_trust_dir(&trust_dir) {
+            Ok(v) => client = client.with_verifier(v),
+            Err(e) => {
+                eprintln!("Cannot load trust keys from {}: {}", trust_dir.display(), e);
+                return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+            }
         }
-        Ok(out) => {
-            eprintln!("curl failed: {}", String::from_utf8_lossy(&out.stderr));
-            EXIT_SCHEMA_OR_RESOLVE_ERROR
-        }
-        Err(e) => {
-            eprintln!(
-                "curl not available: {}. Install curl to fetch registries.",
-                e
+
+        if insecure {
+            client = client.with_insecure(true);
+            tracing::warn!(
+                "INSECURE: cosign verification will be skipped for registry '{}'",
+                name
             );
-            EXIT_SCHEMA_OR_RESOLVE_ERROR
         }
-    }
-}
 
-fn write_to_cache(name: &str, content: &str) -> i32 {
-    let cache_dir = dirs_next::home_dir()
-        .unwrap_or_default()
-        .join(".sindri")
-        .join("cache")
-        .join("registries")
-        .join(name);
-
-    if let Err(e) = std::fs::create_dir_all(&cache_dir) {
-        eprintln!("Cannot create cache dir: {}", e);
-        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
-    }
-
-    let index_path = cache_dir.join("index.yaml");
-    let tmp_path = cache_dir.join("index.yaml.tmp");
-
-    if let Err(e) = std::fs::write(&tmp_path, content) {
-        eprintln!("Cannot write cache: {}", e);
-        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
-    }
-    if let Err(e) = std::fs::rename(&tmp_path, &index_path) {
-        eprintln!("Cannot finalize cache: {}", e);
-        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
-    }
-
-    println!("Registry '{}' refreshed ({} bytes)", name, content.len());
-    EXIT_SUCCESS
+        match client.refresh_index(name, url).await {
+            Ok((index, digest)) => {
+                let bytes_hint = match serde_yaml::to_string(&index) {
+                    Ok(s) => s.len(),
+                    Err(_) => 0,
+                };
+                match digest {
+                    Some(d) => println!(
+                        "Registry '{}' refreshed (digest {}, {} components)",
+                        name,
+                        d,
+                        index.components.len()
+                    ),
+                    None => println!(
+                        "Registry '{}' refreshed from local protocol ({} components, {} bytes)",
+                        name,
+                        index.components.len(),
+                        bytes_hint
+                    ),
+                }
+                EXIT_SUCCESS
+            }
+            Err(e) => {
+                eprintln!("Registry refresh failed: {}", e);
+                EXIT_SCHEMA_OR_RESOLVE_ERROR
+            }
+        }
+    })
 }
 
 fn lint(path: &str, json: bool) -> i32 {
@@ -292,21 +318,70 @@ fn trust(name: &str, signer: &str) -> i32 {
     EXIT_SUCCESS
 }
 
-/// Verify the cosign signature on a registry's manifest (ADR-014).
+/// Verify the cosign signature on a registry's artifact (ADR-014).
 ///
-/// **Wave 3A.1 placeholder.** Verification — fetching the cosign signature
-/// manifest, decoding the simple-signing payload, and verifying the
-/// signature bytes against trusted keys — lands in Wave 3A.2. Today this
-/// command exits non-zero with a clear message so callers can wire it into
-/// CI without it silently passing.
-fn verify(name: &str) -> i32 {
-    eprintln!(
-        "registry verify '{}': not yet implemented (deferred to Wave 3A.2). \
-         Trust-key loading is in place; signature verification will be wired \
-         once the live oci-client fetch path lands.",
-        name
-    );
-    EXIT_SCHEMA_OR_RESOLVE_ERROR
+/// Wave 3A.2: runs the full cosign verification flow against the trust
+/// keys in `~/.sindri/trust/<name>/`. The OCI ref must be supplied because
+/// the CLI does not yet maintain a registry-name → URL map.
+fn verify(name: &str, url: &str) -> i32 {
+    let oci_ref = match OciRef::parse(url) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Invalid OCI reference '{}': {}", url, e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Cannot start async runtime: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    runtime.block_on(async move {
+        let mut client = match RegistryClient::new() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Cannot construct registry client: {}", e);
+                return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+            }
+        };
+        client = client.with_policy(sindri_policy::loader::load_effective_policy().policy);
+        let trust_dir = dirs_next::home_dir()
+            .unwrap_or_default()
+            .join(".sindri")
+            .join("trust");
+        match CosignVerifier::load_from_trust_dir(&trust_dir) {
+            Ok(v) => client = client.with_verifier(v),
+            Err(e) => {
+                eprintln!("Cannot load trust keys: {}", e);
+                return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+            }
+        }
+
+        match client.verify(name, &oci_ref).await {
+            Ok(key_id) if key_id == "<unsigned>" => {
+                println!(
+                    "Registry '{}': no trust keys configured; verification skipped (permissive policy)",
+                    name
+                );
+                EXIT_SUCCESS
+            }
+            Ok(key_id) => {
+                println!(
+                    "Verified registry '{}': signed by trusted key {}",
+                    name, key_id
+                );
+                EXIT_SUCCESS
+            }
+            Err(e) => {
+                eprintln!("Verification failed for registry '{}': {}", name, e);
+                EXIT_SCHEMA_OR_RESOLVE_ERROR
+            }
+        }
+    })
 }
 
 fn fetch_checksums(path: &str) -> i32 {

--- a/v4/crates/sindri/src/commands/resolve.rs
+++ b/v4/crates/sindri/src/commands/resolve.rs
@@ -64,6 +64,16 @@ pub fn run(args: ResolveArgs) -> i32 {
     }
 
     let platform = Platform::current();
+    // Wave 3A.2: when the registry was fetched live via oci-client, its
+    // manifest digest is recorded in the content-addressed cache. Surface
+    // any one such digest into the lockfile so apply-time integrity checks
+    // can prove "this lockfile was resolved against this exact index.yaml
+    // snapshot." Per ADR-003 audit-delta, per-component digests are
+    // deferred to Wave 5 (SBOM).
+    let registry_manifest_digest = sindri_registry::RegistryCache::new()
+        .ok()
+        .and_then(|c| c.any_digest_for_registry(sindri_core::registry::CORE_REGISTRY_NAME));
+
     let opts = sindri_resolver::ResolveOptions {
         manifest_path: manifest_path.clone(),
         lockfile_path: lockfile_path.clone(),
@@ -71,6 +81,7 @@ pub fn run(args: ResolveArgs) -> i32 {
         offline: args.offline,
         strict: args.strict,
         explain: args.explain.clone(),
+        registry_manifest_digest,
     };
 
     match sindri_resolver::resolve(&opts, &registry, &policy, &platform) {

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -212,8 +212,18 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum RegistrySubcmds {
-    /// Fetch and cache the registry index
-    Refresh { name: String, url: String },
+    /// Fetch and cache the registry index (live OCI pull + cosign verify, ADR-003 + ADR-014).
+    Refresh {
+        name: String,
+        url: String,
+        /// Bypass cosign signature verification with a loud warning.
+        ///
+        /// Forbidden when the active install policy requires signed
+        /// registries (strict preset). Intended for development against
+        /// unsigned local registries only.
+        #[arg(long)]
+        insecure: bool,
+    },
     /// Validate a component.yaml or directory
     Lint {
         path: String,
@@ -228,12 +238,18 @@ enum RegistrySubcmds {
     },
     /// Verify a registry's cosign signature against trusted keys (ADR-014).
     ///
-    /// Wave 3A.1 placeholder: trust-key loading is in place, but live
-    /// signature verification (cosign signature manifest fetch +
-    /// simple-signing payload verify) is deferred to Wave 3A.2. This
-    /// subcommand currently exits non-zero with an explanatory message so
-    /// it cannot silently pass in CI.
-    Verify { name: String },
+    /// Resolves the cached OCI ref + digest for the registry and runs the
+    /// full cosign verification flow against the trust set under
+    /// `~/.sindri/trust/<name>/`. Run `sindri registry refresh` first to
+    /// populate the cache.
+    Verify {
+        name: String,
+        /// OCI reference for the registry artifact (e.g.
+        /// `ghcr.io/sindri-dev/registry-core:1.0.0`). Required because the
+        /// CLI does not yet maintain a registry-name → URL map.
+        #[arg(long)]
+        url: String,
+    },
     /// Download assets and write sha256 checksums
     FetchChecksums { path: String },
 }
@@ -291,10 +307,18 @@ fn main() {
         }),
         Some(Commands::Registry { cmd }) => {
             let registry_cmd = match cmd {
-                RegistrySubcmds::Refresh { name, url } => RegistryCmd::Refresh { name, url },
+                RegistrySubcmds::Refresh {
+                    name,
+                    url,
+                    insecure,
+                } => RegistryCmd::Refresh {
+                    name,
+                    url,
+                    insecure,
+                },
                 RegistrySubcmds::Lint { path, json } => RegistryCmd::Lint { path, json },
                 RegistrySubcmds::Trust { name, signer } => RegistryCmd::Trust { name, signer },
-                RegistrySubcmds::Verify { name } => RegistryCmd::Verify { name },
+                RegistrySubcmds::Verify { name, url } => RegistryCmd::Verify { name, url },
                 RegistrySubcmds::FetchChecksums { path } => RegistryCmd::FetchChecksums { path },
             };
             commands::registry::run(registry_cmd)

--- a/v4/docs/review/2026-04-27-implementation-audit-delta.md
+++ b/v4/docs/review/2026-04-27-implementation-audit-delta.md
@@ -53,3 +53,81 @@ is **never modified**; new wave entries are appended here.
     exist).
   - Strict-policy enforcement: `InstallPolicy::require_signed_registries`
     consulted in `RegistryClient::fetch_index`.
+
+## Wave 3A.2 — Live fetch + verify (`feat/v4-registry-oci-cosign-live`)
+
+### ADR-003 (OCI-only registry distribution)
+
+- **Status:** 🟡 → 🟢 (live OCI fetch operational)
+- **What landed:**
+  - `RegistryClient::fetch_index` and `refresh_index` now perform real OCI
+    Distribution Spec pulls via `oci-client::Client::{pull_manifest,
+    pull_blob}`. The legacy `reqwest::get($URL/index.yaml)` shim is gone.
+  - Anonymous auth is the default; `~/.docker/config.json` is parsed for
+    basic-auth credentials when present (`parse_docker_config_auth`).
+    `oci-client` handles the `Www-Authenticate: Bearer` token exchange
+    transparently from there.
+  - Layer media type negotiation:
+    `application/vnd.sindri.registry.index.v1+yaml` is the canonical
+    in-band form for `index.yaml` blobs. Tar+gzip layers and unknown media
+    types fail loudly with `RegistryError::UnsupportedMediaType` rather
+    than silently misbehaving.
+  - The content-addressed cache (`by-digest/sha256/<aa>/<bbcc…>/index.yaml`
+    + `refs/<registry>/<encoded-ref>` digest pointer) is now populated on
+    every successful fetch alongside the legacy
+    `<registry>/index.yaml` path that the resolver still reads.
+  - `RegistryCache::any_digest_for_registry` exposes the linked digest to
+    the resolver so lockfile entries can carry it.
+  - `ResolvedComponent.manifest_digest` is now populated with the
+    *registry-level* OCI digest. Per-component manifest digests (each
+    component carrying its own per-blob digest) are explicitly deferred
+    to Wave 5 / SBOM work.
+- **What's still deferred:**
+  - Tar+gzip layer extraction for registries that bundle `index.yaml`
+    inside a tarball.
+  - Wiremock-backed mock-server tests for the full pull flow
+    (TODO(wave-3a.3) marker in `tests/oci_integration.rs`). The bearer-
+    token handshake balloons the mock-server setup; a live integration
+    test is gated behind `--features live-oci-tests --ignored` instead.
+
+### ADR-014 (signed registries via cosign)
+
+- **Status:** 🟡 → 🟢 (key-based cosign verification operational)
+- **What landed:**
+  - `CosignVerifier::verify_payload` — pure-function verifier over already-
+    fetched bytes. Asserts
+    `critical.image.docker-manifest-digest == expected_digest`, then walks
+    the trusted-key set looking for one whose P-256 ECDSA verification
+    succeeds over the canonical simple-signing payload bytes.
+  - `CosignVerifier::verify_registry_signature` — fetches the cosign
+    signature manifest at `<repo>:sha256-<hex>.sig` via `oci-client`,
+    extracts the simple-signing layer + base64 signature annotation, then
+    delegates to `verify_payload`.
+  - `RegistryClient::with_verifier` + `with_insecure` plumbing.
+    `RegistryClient::fetch_index` now invokes verification before handing
+    the index back to the caller, gated by the `InstallPolicy::
+    require_signed_registries` flag and the `--insecure` escape hatch.
+  - `--insecure` flag on `sindri registry refresh`. Loud `tracing::warn!`
+    on use; rejected with `RegistryError::InsecureForbiddenByPolicy` when
+    strict mode is active.
+  - `sindri registry verify <name> --url <oci-ref>` is no longer a stub —
+    it runs the full verification flow and prints either
+    `Verified registry '<name>': signed by trusted key <key-id>` or a
+    typed `RegistryError`.
+  - Test coverage:
+    - `verify_succeeds_with_test_signature_against_trusted_key`
+    - `verify_fails_with_wrong_payload_digest`
+    - `verify_fails_with_wrong_key`
+    - `strict_policy_no_keys_fails`
+    - `permissive_policy_no_keys_warns_only`
+    - `cosign_signature_tag_round_trip`
+    - `client::tests::registry_local_protocol_unaffected`
+- **What's still deferred (v4.1):**
+  - **Keyless OIDC** (Fulcio + Rekor verification of cosign signatures
+    that carry a transient certificate instead of a long-lived key). The
+    sigstore 0.13 helpers cover this but pull in `tough` and a lot of
+    additional networking; we explicitly chose key-based verification
+    first per ADR-014's "trust model" section.
+  - Per-component cosign signatures (each component blob signed
+    independently). Out of scope until the SBOM work in Wave 5 wires
+    component manifest digests through the lockfile.


### PR DESCRIPTION
## Summary

Wave 3A.2 — promotes the Wave 3A.1 scaffold (PR #216) into an operational
registry engine. ADR-003 and ADR-014 (key-based) move from 🟡 to 🟢 in
`v4/docs/review/2026-04-27-implementation-audit-delta.md`.

- Live OCI Distribution Spec pulls via `oci-client` 0.16
- Full cosign signature verification against trusted P-256 keys
- `--insecure` escape hatch on `sindri registry refresh` (forbidden in strict mode)
- `sindri registry verify` no longer a stub — runs the full flow
- `ResolvedComponent.manifest_digest` populated with the registry artifact digest
- `client::tests::registry_local_protocol_unaffected` confirms `registry:local:` still bypasses OCI/cosign entirely

## Why

The audit at `v4/docs/review/2026-04-27-implementation-audit.md` flagged §3
ADR-003 and §3 ADR-014 as 🔴. Wave 3A.1 (#216) brought them to 🟡 by landing
the scaffold (`OciRef`, content-addressed cache, trust-key loader, error
variants, CLI surface). Wave 3A.2 finishes the job: the engine actually
fetches over OCI and verifies cosign signatures.

## oci-client API used

- `oci_client::Client::pull_manifest(&Reference, &RegistryAuth) -> (OciManifest, String)`
- `oci_client::Client::pull_blob<T: AsyncWrite>(&Reference, layer, out)`
- `RegistryAuth::{Anonymous, Basic, Bearer}` — `Www-Authenticate: Bearer realm=…` token exchange handled transparently by the client
- `oci_client::Reference::with_tag` / `with_digest` constructors

`oci-client` 0.16.1 was confirmed present in the workspace lockfile; the
0.16 API matched the spec hand-off — no surprises.

## cosign verification flow

For an artifact at digest `sha256:<hex>`:

1. Pull the signature manifest from the same repository at tag `sha256-<hex>.sig`
2. Locate the layer with media type `application/vnd.dev.cosign.simplesigning.v1+json` and pull its blob
3. Base64-decode the manifest annotation `dev.cosignproject.cosign/signature`
4. Parse the simple-signing JSON, assert `critical.image.docker-manifest-digest == <fetched_digest>` (mismatch → `SignatureMismatch`)
5. For each trusted key under `~/.sindri/trust/<registry-name>/cosign-*.pub`, attempt `key.verify(payload_bytes, signature_bytes)`. First success wins; no match → `SignatureMismatch`
6. Empty trust set: `SignatureRequired` in strict mode, warn-and-skip in permissive mode

`CosignVerifier::verify_payload` is the pure-function unit-testable core;
`verify_registry_signature` adds the OCI fetch wrapping. Signatures are
parsed as DER first, then raw IEEE-P1363 fixed-width as a fallback.

## --insecure flag semantics

- `sindri registry refresh <name> <url> --insecure` — bypasses cosign verification with a `tracing::warn!`
- Rejected with `RegistryError::InsecureForbiddenByPolicy` when `InstallPolicy::require_signed_registries == Some(true)` (strict preset)
- Permissive policy + empty trust set: warn-and-skip (matches the "no keys yet" bootstrapping case)

## Lockfile schema

`ResolvedComponent.manifest_digest` is now populated with the
*registry-level* OCI digest (the `sha256:<hex>` returned by
`pull_manifest`). The resolver pulls this from the cache via
`RegistryCache::any_digest_for_registry`. The lockfile schema itself is
unchanged from Wave 3A.1 — the field has been there with
`#[serde(default, skip_serializing_if)]` since #216, so old lockfiles
parse unchanged.

Per-component manifest digests (each component carrying its own per-blob
digest) are deferred to Wave 5 / SBOM work.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace` green (36 sindri-registry tests, all workspace tests pass)
- [x] `verify_succeeds_with_test_signature_against_trusted_key` — sign with a generated P-256 key, verify against the same trust set
- [x] `verify_fails_with_wrong_payload_digest` — payload digest mismatches expected → `SignatureMismatch`
- [x] `verify_fails_with_wrong_key` — trust key A, sign with key B → `SignatureMismatch`
- [x] `strict_policy_no_keys_fails` — empty trust + strict policy → `SignatureRequired`
- [x] `permissive_policy_no_keys_warns_only` — empty trust + permissive policy → `Ok("<unsigned>")`
- [x] `cosign_signature_tag_round_trip` — `sha256:<hex>` → `sha256-<hex>.sig`
- [x] `client::tests::registry_local_protocol_unaffected` — `registry:local:` bypasses OCI/cosign entirely
- [x] `parse_docker_config_*` — `~/.docker/config.json` extraction with HTTPS prefix normalisation
- [x] Live integration smoke test gated behind `live-oci-tests` feature + `#[ignore]`. Run with: `cargo test -p sindri-registry --features live-oci-tests --test oci_integration -- --ignored`

## What's still deferred

- **Keyless OIDC** (Fulcio + Rekor verification) → v4.1. The sigstore 0.13 helpers cover this but pull in additional networking surface; ADR-014's "trust model" puts key-based first
- **Per-component cosign signatures** (each blob signed independently) → Wave 5 / SBOM
- **Tar+gzip layer extraction** for registries that bundle `index.yaml` inside a tarball → fails loudly with `UnsupportedMediaType` for now
- **Wiremock-backed mock-server tests** for the full pull flow → TODO(wave-3a.3) marker; bearer-token negotiation balloons mock setup. Live integration test gated behind `--features live-oci-tests --ignored` is the substitute

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)