### PR TITLE
feat(v4): Sprint 12 hardening — doctor --fix, secrets, backup/restore

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -910,6 +910,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,7 +1728,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2099,7 +2113,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2224,6 +2238,12 @@ dependencies = [
  "rand_core 0.6.4",
  "spki",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "poly1305"
@@ -2567,6 +2587,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -3318,6 +3347,7 @@ name = "sindri"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "clap_complete",
@@ -3336,6 +3366,7 @@ dependencies = [
  "sindri-registry",
  "sindri-resolver",
  "sindri-targets",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3597,6 +3628,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4585,6 +4627,16 @@ dependencies = [
  "signature",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/v4/Cargo.toml
+++ b/v4/Cargo.toml
@@ -55,3 +55,5 @@ tempfile = "3"
 # not yet support spec 1.6, so both SPDX 2.3 and CycloneDX 1.6 are emitted by
 # hand against `serde_json::Value` schemas — see `sindri::commands::bom`.
 uuid = { version = "1", features = ["v4"] }
+# Tarball backup/restore (`sindri backup` / `sindri restore`).
+tar = "0.4"

--- a/v4/crates/sindri-core/src/manifest.rs
+++ b/v4/crates/sindri-core/src/manifest.rs
@@ -16,6 +16,13 @@ pub struct BomManifest {
     pub targets: HashMap<String, TargetConfig>,
     pub preferences: Option<Preferences>,
     pub r#override: Option<Vec<OverrideEntry>>,
+    /// Optional secret references (Sprint 12, Wave 4C).
+    ///
+    /// Map of secret-id → prefixed `AuthValue` string (`env:FOO`,
+    /// `file:~/.token`, `cli:gh`, `plain:…`). Resolved on demand by
+    /// `sindri secrets validate`; values are never persisted.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub secrets: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/v4/crates/sindri-targets/src/auth.rs
+++ b/v4/crates/sindri-targets/src/auth.rs
@@ -41,7 +41,17 @@ impl AuthValue {
                 detail: format!("env var {} is not set", var),
             }),
             AuthValue::File(path) => {
-                let expanded = path.replace('~', &home_str());
+                // Tilde expansion: only at the beginning of the path, per
+                // shell convention. A naïve `replace('~', …)` mangles
+                // Windows 8.3 short filenames like `RUNNER~1` that contain
+                // a tilde mid-path.
+                let expanded = if let Some(rest) = path.strip_prefix("~/") {
+                    format!("{}/{}", home_str(), rest)
+                } else if path == "~" {
+                    home_str()
+                } else {
+                    path.clone()
+                };
                 std::fs::read_to_string(&expanded)
                     .map(|s| s.trim().to_string())
                     .map_err(|e| TargetError::AuthFailed {

--- a/v4/crates/sindri/Cargo.toml
+++ b/v4/crates/sindri/Cargo.toml
@@ -31,6 +31,8 @@ hex = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
+tar = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/v4/crates/sindri/src/commands/backup.rs
+++ b/v4/crates/sindri/src/commands/backup.rs
@@ -1,0 +1,496 @@
+//! `sindri backup` / `sindri restore` (Sprint 12, Wave 4C).
+//!
+//! Backup produces a `tar.gz` of the user's sindri state:
+//!   * Project files: `sindri.yaml`, `sindri.policy.yaml`, `sindri.lock`,
+//!     and any `sindri.<target>.lock`.
+//!   * `~/.sindri/ledger.jsonl`
+//!   * `~/.sindri/trust/`
+//!   * `~/.sindri/plugins/`
+//!   * `~/.sindri/history/`
+//!   * `~/.sindri/cache/registries/` only when `--include-cache` is set.
+//!
+//! Restore extracts an archive with default-deny overwrite semantics and
+//! refuses entries with absolute paths or `..` traversal components.
+
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use serde::Serialize;
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use tar::{Archive, Builder, Header};
+
+/// CLI args for `sindri backup`.
+pub struct BackupArgs {
+    /// Destination directory or full file path.
+    pub output: Option<PathBuf>,
+    /// Include `~/.sindri/cache/registries/` (large; off by default).
+    pub include_cache: bool,
+}
+
+/// CLI args for `sindri restore`.
+pub struct RestoreArgs {
+    /// Path to the `.tar.gz` archive.
+    pub archive: PathBuf,
+    /// Print the archive's file list without writing.
+    pub dry_run: bool,
+    /// Overwrite existing destination files.
+    pub force: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct BackupReport {
+    archive: String,
+    entries: usize,
+}
+
+/// Public entry point for `sindri backup`.
+pub fn run_backup(args: BackupArgs) -> i32 {
+    let home = match dirs_next::home_dir() {
+        Some(h) => h,
+        None => {
+            eprintln!("error: cannot determine $HOME");
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("error: cwd: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let dest = resolve_output_path(args.output.as_deref(), &cwd);
+
+    match write_backup(&dest, &cwd, &home, args.include_cache) {
+        Ok(report) => {
+            println!(
+                "Backup written to {} ({} entries)",
+                report.archive_path.display(),
+                report.entries
+            );
+            EXIT_SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: backup failed: {}", e);
+            EXIT_SCHEMA_OR_RESOLVE_ERROR
+        }
+    }
+}
+
+/// Public entry point for `sindri restore`.
+pub fn run_restore(args: RestoreArgs) -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("error: cwd: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let home = match dirs_next::home_dir() {
+        Some(h) => h,
+        None => {
+            eprintln!("error: cannot determine $HOME");
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    match restore_archive(&args.archive, &cwd, &home, args.dry_run, args.force) {
+        Ok(n) => {
+            if args.dry_run {
+                println!("(dry-run) would extract {} entries", n);
+            } else {
+                println!("Restored {} entries", n);
+            }
+            EXIT_SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: restore failed: {}", e);
+            EXIT_SCHEMA_OR_RESOLVE_ERROR
+        }
+    }
+}
+
+fn resolve_output_path(output: Option<&Path>, cwd: &Path) -> PathBuf {
+    let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let default_name = format!("sindri-backup-{}.tar.gz", stamp);
+    match output {
+        Some(p) if p.is_dir() => p.join(default_name),
+        Some(p) => p.to_path_buf(),
+        None => cwd.join(default_name),
+    }
+}
+
+/// Result of [`write_backup`]. Public so tests can assert.
+pub struct WriteReport {
+    /// Path of the archive that was written.
+    pub archive_path: PathBuf,
+    /// Number of file entries appended.
+    pub entries: usize,
+}
+
+/// Write a backup tarball at `dest`. Test-friendly: caller supplies
+/// `project_dir` and `home_dir` so tests can sandbox under `TempDir`s.
+pub fn write_backup(
+    dest: &Path,
+    project_dir: &Path,
+    home_dir: &Path,
+    include_cache: bool,
+) -> std::io::Result<WriteReport> {
+    if let Some(parent) = dest.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let f = File::create(dest)?;
+    let gz = GzEncoder::new(f, Compression::default());
+    let mut tar = Builder::new(gz);
+    let mut entries = 0usize;
+
+    // 1. Project files.
+    let project_files: &[&str] = &["sindri.yaml", "sindri.policy.yaml", "sindri.lock"];
+    for rel in project_files {
+        let abs = project_dir.join(rel);
+        if abs.is_file() {
+            tar.append_path_with_name(&abs, format!("project/{}", rel))?;
+            entries += 1;
+        }
+    }
+    // Per-target lockfiles: sindri.*.lock
+    if let Ok(rd) = std::fs::read_dir(project_dir) {
+        for ent in rd.flatten() {
+            let name = ent.file_name();
+            let name_s = name.to_string_lossy();
+            if name_s.starts_with("sindri.") && name_s.ends_with(".lock") && name_s != "sindri.lock"
+            {
+                tar.append_path_with_name(ent.path(), format!("project/{}", name_s))?;
+                entries += 1;
+            }
+        }
+    }
+
+    // 2. ~/.sindri files & dirs.
+    let ledger = home_dir.join(".sindri").join("ledger.jsonl");
+    if ledger.is_file() {
+        tar.append_path_with_name(&ledger, "home/.sindri/ledger.jsonl")?;
+        entries += 1;
+    }
+    for sub in &["trust", "plugins", "history"] {
+        let dir = home_dir.join(".sindri").join(sub);
+        if dir.is_dir() {
+            entries += append_dir_recursive(&mut tar, &dir, &format!("home/.sindri/{}", sub))?;
+        }
+    }
+    if include_cache {
+        let cache = home_dir.join(".sindri").join("cache").join("registries");
+        if cache.is_dir() {
+            entries += append_dir_recursive(&mut tar, &cache, "home/.sindri/cache/registries")?;
+        }
+    }
+
+    let gz = tar.into_inner()?;
+    gz.finish()?;
+    Ok(WriteReport {
+        archive_path: dest.to_path_buf(),
+        entries,
+    })
+}
+
+fn append_dir_recursive(
+    tar: &mut Builder<GzEncoder<File>>,
+    src: &Path,
+    archive_prefix: &str,
+) -> std::io::Result<usize> {
+    let mut count = 0usize;
+    for entry in walk(src) {
+        let entry = entry?;
+        if !entry.is_file() {
+            continue;
+        }
+        let rel = entry.strip_prefix(src).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "strip_prefix failed")
+        })?;
+        let name = format!("{}/{}", archive_prefix, rel.to_string_lossy());
+        // Use a fresh header so we don't carry over uid/gid weirdness.
+        let mut f = File::open(&entry)?;
+        let metadata = f.metadata()?;
+        let mut header = Header::new_gnu();
+        header.set_size(metadata.len());
+        header.set_mode(0o644);
+        header.set_mtime(
+            metadata
+                .modified()
+                .ok()
+                .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        );
+        header.set_cksum();
+        tar.append_data(&mut header, &name, &mut f)?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn walk(root: &Path) -> Vec<std::io::Result<PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(cur) = stack.pop() {
+        match std::fs::read_dir(&cur) {
+            Ok(rd) => {
+                for ent in rd {
+                    match ent {
+                        Ok(e) => {
+                            let p = e.path();
+                            if p.is_dir() {
+                                stack.push(p);
+                            } else {
+                                out.push(Ok(p));
+                            }
+                        }
+                        Err(e) => out.push(Err(e)),
+                    }
+                }
+            }
+            Err(e) => out.push(Err(e)),
+        }
+    }
+    out
+}
+
+/// Restore `archive` into `project_dir` (for `project/` entries) and
+/// `home_dir` (for `home/.sindri/` entries). Returns the number of
+/// entries written (or that would be written, in `dry_run`).
+pub fn restore_archive(
+    archive: &Path,
+    project_dir: &Path,
+    home_dir: &Path,
+    dry_run: bool,
+    force: bool,
+) -> std::io::Result<usize> {
+    let f = File::open(archive)?;
+    let gz = GzDecoder::new(f);
+    let mut ar = Archive::new(gz);
+    ar.set_preserve_permissions(false);
+    ar.set_unpack_xattrs(false);
+
+    let mut count = 0usize;
+    for entry in ar.entries()? {
+        let mut e = entry?;
+        let path_in_tar = e.path()?.into_owned();
+        validate_entry_path(&path_in_tar)?;
+        let dest = match map_destination(&path_in_tar, project_dir, home_dir) {
+            Some(d) => d,
+            None => continue,
+        };
+        if dry_run {
+            println!("would extract: {}", dest.display());
+            count += 1;
+            continue;
+        }
+        if dest.exists() && !force {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("refusing to overwrite {} without --force", dest.display()),
+            ));
+        }
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut buf = Vec::new();
+        e.read_to_end(&mut buf)?;
+        let mut out = File::create(&dest)?;
+        out.write_all(&buf)?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn validate_entry_path(path: &Path) -> std::io::Result<()> {
+    if path.is_absolute() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("archive contains absolute path: {}", path.display()),
+        ));
+    }
+    for comp in path.components() {
+        if matches!(comp, Component::ParentDir) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("archive contains parent-dir traversal: {}", path.display()),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn map_destination(archive_path: &Path, project_dir: &Path, home_dir: &Path) -> Option<PathBuf> {
+    let mut comps = archive_path.components();
+    match comps.next()? {
+        Component::Normal(top) if top == "project" => {
+            let rest: PathBuf = comps.collect();
+            Some(project_dir.join(rest))
+        }
+        Component::Normal(top) if top == "home" => {
+            let rest: PathBuf = comps.collect();
+            Some(home_dir.join(rest))
+        }
+        _ => None,
+    }
+}
+
+// ---- tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tar::Builder as TarBuilder;
+    use tempfile::TempDir;
+
+    fn populate_state(project: &Path, home: &Path) {
+        std::fs::write(project.join("sindri.yaml"), "name: test\ncomponents: []\n").unwrap();
+        std::fs::write(project.join("sindri.lock"), "lock-v1").unwrap();
+        std::fs::write(project.join("sindri.local.lock"), "per-target").unwrap();
+
+        let sindri_home = home.join(".sindri");
+        std::fs::create_dir_all(sindri_home.join("trust/registry-a")).unwrap();
+        std::fs::write(sindri_home.join("trust/registry-a/cosign-1.pub"), "PEM").unwrap();
+        std::fs::create_dir_all(sindri_home.join("plugins")).unwrap();
+        std::fs::write(sindri_home.join("plugins/local.json"), "{}").unwrap();
+        std::fs::create_dir_all(sindri_home.join("history")).unwrap();
+        std::fs::write(sindri_home.join("history/2026-01.log"), "rolled").unwrap();
+        std::fs::write(
+            sindri_home.join("ledger.jsonl"),
+            "{\"event\":\"install\"}\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn round_trip_preserves_files() {
+        let project = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        populate_state(project.path(), home.path());
+
+        let archive = TempDir::new().unwrap();
+        let dest = archive.path().join("backup.tar.gz");
+        let report = write_backup(&dest, project.path(), home.path(), false).unwrap();
+        assert!(report.entries >= 6);
+        assert!(dest.is_file());
+
+        // Wipe original state.
+        let project2 = TempDir::new().unwrap();
+        let home2 = TempDir::new().unwrap();
+
+        let n = restore_archive(&dest, project2.path(), home2.path(), false, false).unwrap();
+        assert_eq!(n, report.entries);
+
+        assert_eq!(
+            std::fs::read_to_string(project2.path().join("sindri.yaml")).unwrap(),
+            "name: test\ncomponents: []\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(project2.path().join("sindri.local.lock")).unwrap(),
+            "per-target"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home2.path().join(".sindri/ledger.jsonl")).unwrap(),
+            "{\"event\":\"install\"}\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home2.path().join(".sindri/trust/registry-a/cosign-1.pub"))
+                .unwrap(),
+            "PEM"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home2.path().join(".sindri/history/2026-01.log")).unwrap(),
+            "rolled"
+        );
+    }
+
+    #[test]
+    fn restore_dry_run_does_not_write() {
+        let project = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        populate_state(project.path(), home.path());
+        let archive = TempDir::new().unwrap();
+        let dest = archive.path().join("backup.tar.gz");
+        write_backup(&dest, project.path(), home.path(), false).unwrap();
+
+        let project2 = TempDir::new().unwrap();
+        let home2 = TempDir::new().unwrap();
+        let n = restore_archive(&dest, project2.path(), home2.path(), true, false).unwrap();
+        assert!(n > 0);
+        // Nothing actually written.
+        assert!(!project2.path().join("sindri.yaml").exists());
+        assert!(!home2.path().join(".sindri/ledger.jsonl").exists());
+    }
+
+    #[test]
+    fn restore_refuses_overwrite_without_force() {
+        let project = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        populate_state(project.path(), home.path());
+        let archive = TempDir::new().unwrap();
+        let dest = archive.path().join("backup.tar.gz");
+        write_backup(&dest, project.path(), home.path(), false).unwrap();
+
+        // Restore destination already has a sindri.yaml.
+        let project2 = TempDir::new().unwrap();
+        let home2 = TempDir::new().unwrap();
+        std::fs::write(project2.path().join("sindri.yaml"), "EXISTING").unwrap();
+
+        let err = restore_archive(&dest, project2.path(), home2.path(), false, false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        // Pre-existing content untouched.
+        assert_eq!(
+            std::fs::read_to_string(project2.path().join("sindri.yaml")).unwrap(),
+            "EXISTING"
+        );
+
+        // With --force it succeeds.
+        let n = restore_archive(&dest, project2.path(), home2.path(), false, true).unwrap();
+        assert!(n > 0);
+        assert_ne!(
+            std::fs::read_to_string(project2.path().join("sindri.yaml")).unwrap(),
+            "EXISTING"
+        );
+    }
+
+    #[test]
+    fn restore_rejects_path_traversal() {
+        let archive_dir = TempDir::new().unwrap();
+        let archive = archive_dir.path().join("evil.tar.gz");
+        // Hand-craft an archive with a traversal entry. The `tar` builder
+        // refuses to write a `..` filename, so we write the raw header
+        // bytes directly and seed the name field manually.
+        let f = File::create(&archive).unwrap();
+        let mut gz = GzEncoder::new(f, Compression::default());
+        let mut header = Header::new_gnu();
+        let payload = b"pwned";
+        header.set_size(payload.len() as u64);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        // Set the legacy USTAR name field directly (bypasses the
+        // safety checks in `Builder::append_data`).
+        let bytes = header.as_old_mut().name.as_mut();
+        let evil = b"../etc/passwd";
+        bytes[..evil.len()].copy_from_slice(evil);
+        header.set_cksum();
+        gz.write_all(header.as_bytes()).unwrap();
+        // Pad the data block to 512 bytes.
+        let mut block = [0u8; 512];
+        block[..payload.len()].copy_from_slice(payload);
+        gz.write_all(&block).unwrap();
+        // Two zero blocks → end of archive.
+        gz.write_all(&[0u8; 1024]).unwrap();
+        gz.finish().unwrap();
+        let _ = TarBuilder::<File>::new; // keep import alive for other tests
+
+        let project2 = TempDir::new().unwrap();
+        let home2 = TempDir::new().unwrap();
+        let err =
+            restore_archive(&archive, project2.path(), home2.path(), false, true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("parent-dir"));
+    }
+}

--- a/v4/crates/sindri/src/commands/doctor.rs
+++ b/v4/crates/sindri/src/commands/doctor.rs
@@ -1,106 +1,675 @@
-/// Full doctor implementation (Sprint 12)
-use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
-use sindri_targets::traits::Target;
-use sindri_targets::LocalTarget;
+//! `sindri doctor` — health check + auto-fix engine (Sprint 12, Wave 4C).
+//!
+//! `doctor` runs a typed registry of [`HealthCheck`]s. Each check has a
+//! `run` function that returns a [`CheckResult`], and an optional `fix`
+//! function that applies a remediation. With `--fix` the doctor will
+//! invoke the remediation for any failing fixable check; with `--dry-run`
+//! it will instead print what *would* be fixed without writing anything.
+//!
+//! Adding a new check: append a [`HealthCheck`] entry to [`all_checks`].
 
+use serde::Serialize;
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use std::path::{Path, PathBuf};
+
+/// Marker placed in `~/.bashrc` / `~/.zshrc` so doctor's PATH guard block
+/// is appended at most once even across re-runs. Mirrors the pattern in
+/// `sindri_extensions::configure` (PR #215).
+const DOCTOR_PATH_MARKER: &str = "# sindri:auto path";
+
+/// Coarse grouping for human-readable output and `--json` filtering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HealthCategory {
+    /// Filesystem paths under `~/.sindri/`.
+    Paths,
+    /// Shell rc-file content.
+    ShellRc,
+    /// Registry cache + trust state.
+    Registry,
+    /// Active install policy.
+    Policy,
+    /// Backend tools (jq, mise, gh, …).
+    Component,
+}
+
+/// CLI args accepted by `sindri doctor`.
 pub struct DoctorArgs {
+    /// Optional target name for target-specific prerequisites.
     pub target: Option<String>,
+    /// Apply remediations.
     pub fix: bool,
+    /// Print remediations without writing.
+    pub dry_run: bool,
+    /// JSON output.
+    pub json: bool,
+    /// Reserved — component health check (Sprint 12.2 backlog).
     pub components: bool,
 }
 
+/// Context passed to every check. Tests construct one with a
+/// [`tempfile::TempDir`] root so `$HOME` writes are sandboxed.
+#[derive(Debug, Clone)]
+pub struct DoctorContext {
+    /// Effective `$HOME`. Production: `dirs_next::home_dir()`.
+    pub home_dir: PathBuf,
+    /// Whether mutating fixes are allowed.
+    pub apply_fixes: bool,
+    /// Whether to print "Would: …" instead of mutating.
+    pub dry_run: bool,
+}
+
+impl DoctorContext {
+    /// `~/.sindri/`.
+    pub fn sindri_dir(&self) -> PathBuf {
+        self.home_dir.join(".sindri")
+    }
+    /// `~/.sindri/trust/`.
+    pub fn trust_dir(&self) -> PathBuf {
+        self.sindri_dir().join("trust")
+    }
+    /// `~/.sindri/cache/registries/`.
+    pub fn registry_cache_dir(&self) -> PathBuf {
+        self.sindri_dir().join("cache").join("registries")
+    }
+}
+
+/// Outcome of a single non-fix run.
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckResult {
+    pub passed: bool,
+    pub message: String,
+    /// Human-readable suggestion for the user (printed when no `fix` is
+    /// available, or when running without `--fix`).
+    pub suggested_fix: Option<String>,
+}
+
+/// Outcome of an attempted remediation.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "outcome", rename_all = "kebab-case")]
+pub enum FixOutcome {
+    /// Action was performed.
+    Fixed { detail: String },
+    /// Already in the desired state — no-op.
+    AlreadyFixed,
+    /// Check has no remediation function (suggestion only).
+    NotApplicable,
+}
+
+/// Errors a fix function may raise.
+#[derive(Debug, thiserror::Error)]
+pub enum DoctorError {
+    /// I/O failure during remediation.
+    #[error("doctor io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Generic remediation failure with a human message.
+    #[error("doctor fix failed: {0}")]
+    FixFailed(String),
+}
+
+/// Function pointer signature for the read-only `run` step of a check.
+pub type CheckFn = fn(&DoctorContext) -> CheckResult;
+
+/// Function pointer signature for the optional `fix` step of a check.
+pub type FixFn = fn(&DoctorContext) -> Result<FixOutcome, DoctorError>;
+
+/// A single health check. `run` is mandatory; `fix` is optional.
+pub struct HealthCheck {
+    /// Stable, human-readable identifier (`paths.sindri-dir`).
+    pub name: &'static str,
+    /// Coarse grouping.
+    pub category: HealthCategory,
+    /// Read-only check.
+    pub run: CheckFn,
+    /// Optional remediation.
+    pub fix: Option<FixFn>,
+}
+
+/// Per-check structured record for `--json`.
+#[derive(Debug, Serialize)]
+struct CheckRecord<'a> {
+    name: &'a str,
+    category: HealthCategory,
+    passed: bool,
+    message: String,
+    suggested_fix: Option<String>,
+    fixable: bool,
+    /// Only populated when `--fix` runs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fix_outcome: Option<FixOutcome>,
+}
+
+/// Top-level JSON envelope.
+#[derive(Debug, Serialize)]
+struct DoctorReport<'a> {
+    target: &'a str,
+    fix: bool,
+    dry_run: bool,
+    checks: Vec<CheckRecord<'a>>,
+    passed: bool,
+}
+
+/// Entry point used by `main`.
 pub fn run(args: DoctorArgs) -> i32 {
-    let target_name = args.target.as_deref().unwrap_or("local");
-    println!("sindri doctor — target: {}", target_name);
-    println!();
-
-    let mut any_failed = false;
-
-    // 1. Target prerequisites
-    let checks = LocalTarget::new().check_prerequisites();
-    println!("Target prerequisites:");
-    for check in &checks {
-        if check.passed {
-            println!("  [OK]   {}", check.name);
-        } else {
-            println!("  [FAIL] {}", check.name);
-            if let Some(fix) = &check.fix {
-                println!("         Fix: {}", fix);
-            }
-            any_failed = true;
-        }
+    if args.fix && args.dry_run {
+        eprintln!("error: --fix and --dry-run are mutually exclusive");
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
     }
 
-    // 2. Shell configuration
-    println!("\nShell configuration:");
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "(not set)".to_string());
-    println!("  [OK]   SHELL = {}", shell);
+    let home_dir = dirs_next::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    let ctx = DoctorContext {
+        home_dir,
+        apply_fixes: args.fix,
+        dry_run: args.dry_run,
+    };
+    let target_name = args.target.as_deref().unwrap_or("local");
+    let checks = all_checks();
+    run_with_context(
+        &ctx,
+        &checks,
+        target_name,
+        args.json,
+        args.fix,
+        args.dry_run,
+    )
+}
 
-    // 3. Registry access
-    println!("\nRegistry cache:");
-    let cache_dir = sindri_core::paths::home_dir()
-        .unwrap_or_default()
-        .join(".sindri")
-        .join("cache")
-        .join("registries");
-    if cache_dir.exists() {
-        let count = std::fs::read_dir(&cache_dir)
-            .map(|d| d.count())
-            .unwrap_or(0);
-        if count > 0 {
-            println!("  [OK]   {} registry/registries cached", count);
-        } else {
-            println!("  [WARN] No registry cache — run `sindri registry refresh`");
+/// Test-friendly entry point: caller supplies `DoctorContext` and the
+/// list of checks (so tests can scope to a single check).
+pub fn run_with_context(
+    ctx: &DoctorContext,
+    checks: &[HealthCheck],
+    target_name: &str,
+    json: bool,
+    apply_fix: bool,
+    dry_run: bool,
+) -> i32 {
+    let mut records: Vec<CheckRecord<'_>> = Vec::with_capacity(checks.len());
+    let mut any_failed_unfixed = false;
+
+    for check in checks {
+        let res = (check.run)(ctx);
+        let fixable = check.fix.is_some();
+        let mut record = CheckRecord {
+            name: check.name,
+            category: check.category,
+            passed: res.passed,
+            message: res.message.clone(),
+            suggested_fix: res.suggested_fix.clone(),
+            fixable,
+            fix_outcome: None,
+        };
+
+        if !res.passed {
+            if dry_run && fixable {
+                let action = res
+                    .suggested_fix
+                    .clone()
+                    .unwrap_or_else(|| format!("apply remediation for `{}`", check.name));
+                if !json {
+                    println!("Would: {}", action);
+                }
+                // dry-run does not mutate; leave passed=false so exit reflects work outstanding
+                any_failed_unfixed = true;
+            } else if apply_fix {
+                if let Some(fix_fn) = check.fix {
+                    match fix_fn(ctx) {
+                        Ok(outcome) => {
+                            record.fix_outcome = Some(outcome.clone());
+                            // Mark as passed if we actually fixed or it was already fixed.
+                            match outcome {
+                                FixOutcome::Fixed { .. } | FixOutcome::AlreadyFixed => {
+                                    record.passed = true;
+                                }
+                                FixOutcome::NotApplicable => {
+                                    any_failed_unfixed = true;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            record.fix_outcome = Some(FixOutcome::Fixed {
+                                detail: format!("error: {}", e),
+                            });
+                            // record.passed stays false
+                            any_failed_unfixed = true;
+                        }
+                    }
+                } else {
+                    any_failed_unfixed = true;
+                }
+            } else {
+                any_failed_unfixed = true;
+            }
+        }
+        records.push(record);
+    }
+
+    if json {
+        let report = DoctorReport {
+            target: target_name,
+            fix: apply_fix,
+            dry_run,
+            passed: !any_failed_unfixed,
+            checks: records,
+        };
+        match serde_json::to_string_pretty(&report) {
+            Ok(s) => println!("{}", s),
+            Err(e) => {
+                eprintln!("error: serialising doctor report: {}", e);
+                return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+            }
         }
     } else {
-        println!("  [WARN] Registry cache directory not found");
-        println!("         Fix: run `sindri registry refresh <name> <url>`");
-    }
-
-    // 4. Policy validity
-    println!("\nPolicy:");
-    let effective = sindri_policy::load_effective_policy();
-    let preset = match &effective.policy.preset {
-        sindri_core::policy::PolicyPreset::Default => "default",
-        sindri_core::policy::PolicyPreset::Strict => "strict",
-        sindri_core::policy::PolicyPreset::Offline => "offline",
-    };
-    println!("  [OK]   Active preset: {}", preset);
-
-    // 5. Mise availability
-    println!("\nBackend availability:");
-    for (backend, binary) in &[
-        ("mise", "mise"),
-        ("npm", "npm"),
-        ("brew", "brew"),
-        ("docker", "docker"),
-        ("git", "git"),
-    ] {
-        if which(binary).is_some() {
-            println!("  [OK]   {} ({})", backend, binary);
+        println!("sindri doctor — target: {}", target_name);
+        println!();
+        for r in &records {
+            let status = if r.passed { "[OK]  " } else { "[FAIL]" };
+            println!("  {} {} — {}", status, r.name, r.message);
+            if !r.passed {
+                match &r.fix_outcome {
+                    Some(FixOutcome::Fixed { detail }) => {
+                        println!("        Fixed: {}", detail);
+                    }
+                    Some(FixOutcome::AlreadyFixed) => {
+                        println!("        Already fixed.");
+                    }
+                    Some(FixOutcome::NotApplicable) => {
+                        if let Some(s) = &r.suggested_fix {
+                            println!("        Fix: {}", s);
+                        }
+                    }
+                    None => {
+                        if let Some(s) = &r.suggested_fix {
+                            println!("        Fix: {}", s);
+                        }
+                    }
+                }
+            }
+        }
+        println!();
+        if any_failed_unfixed {
+            println!("Doctor found issues.");
         } else {
-            println!("  [SKIP] {} ({}) — not installed", backend, binary);
+            println!("All checks passed.");
         }
     }
 
-    if any_failed {
-        println!("\nDoctor found issues. Apply the fixes above and re-run.");
+    if any_failed_unfixed {
         EXIT_SCHEMA_OR_RESOLVE_ERROR
     } else {
-        println!("\nAll checks passed.");
         EXIT_SUCCESS
     }
 }
 
-fn which(name: &str) -> Option<std::path::PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).find_map(|d| {
-            let c = d.join(name);
-            if c.is_file() {
-                Some(c)
-            } else {
-                None
-            }
-        })
+/// Master list of checks. Order is presentation order.
+pub fn all_checks() -> Vec<HealthCheck> {
+    vec![
+        HealthCheck {
+            name: "paths.sindri-dir",
+            category: HealthCategory::Paths,
+            run: check_sindri_dir,
+            fix: Some(fix_sindri_dir),
+        },
+        HealthCheck {
+            name: "paths.trust-dir",
+            category: HealthCategory::Paths,
+            run: check_trust_dir,
+            fix: Some(fix_trust_dir),
+        },
+        HealthCheck {
+            name: "paths.registry-cache-dir",
+            category: HealthCategory::Paths,
+            run: check_registry_cache_dir,
+            fix: Some(fix_registry_cache_dir),
+        },
+        HealthCheck {
+            name: "shell-rc.cargo-bin-on-path",
+            category: HealthCategory::ShellRc,
+            run: check_cargo_bin_on_path,
+            fix: Some(fix_cargo_bin_on_path),
+        },
+        HealthCheck {
+            name: "registry.lockfile-fresh",
+            category: HealthCategory::Registry,
+            run: check_lockfile_fresh,
+            // Suggestion only — never auto-resolve.
+            fix: None,
+        },
+    ]
+}
+
+// ---- individual checks --------------------------------------------------
+
+fn check_sindri_dir(ctx: &DoctorContext) -> CheckResult {
+    let p = ctx.sindri_dir();
+    if p.is_dir() {
+        CheckResult {
+            passed: true,
+            message: format!("{} exists", p.display()),
+            suggested_fix: None,
+        }
+    } else {
+        CheckResult {
+            passed: false,
+            message: format!("{} missing", p.display()),
+            suggested_fix: Some(format!("mkdir -p {}", p.display())),
+        }
+    }
+}
+
+fn fix_sindri_dir(ctx: &DoctorContext) -> Result<FixOutcome, DoctorError> {
+    let p = ctx.sindri_dir();
+    if p.is_dir() {
+        return Ok(FixOutcome::AlreadyFixed);
+    }
+    std::fs::create_dir_all(&p)?;
+    Ok(FixOutcome::Fixed {
+        detail: format!("created {}", p.display()),
     })
+}
+
+fn check_trust_dir(ctx: &DoctorContext) -> CheckResult {
+    let p = ctx.trust_dir();
+    if p.is_dir() {
+        CheckResult {
+            passed: true,
+            message: format!("{} exists", p.display()),
+            suggested_fix: None,
+        }
+    } else {
+        CheckResult {
+            passed: false,
+            message: format!("{} missing", p.display()),
+            suggested_fix: Some(format!("mkdir -p {}", p.display())),
+        }
+    }
+}
+
+fn fix_trust_dir(ctx: &DoctorContext) -> Result<FixOutcome, DoctorError> {
+    let p = ctx.trust_dir();
+    if p.is_dir() {
+        return Ok(FixOutcome::AlreadyFixed);
+    }
+    std::fs::create_dir_all(&p)?;
+    Ok(FixOutcome::Fixed {
+        detail: format!("created {}", p.display()),
+    })
+}
+
+fn check_registry_cache_dir(ctx: &DoctorContext) -> CheckResult {
+    let p = ctx.registry_cache_dir();
+    if p.is_dir() {
+        CheckResult {
+            passed: true,
+            message: format!("{} exists", p.display()),
+            suggested_fix: None,
+        }
+    } else {
+        CheckResult {
+            passed: false,
+            message: format!("{} missing", p.display()),
+            suggested_fix: Some(format!("mkdir -p {}", p.display())),
+        }
+    }
+}
+
+fn fix_registry_cache_dir(ctx: &DoctorContext) -> Result<FixOutcome, DoctorError> {
+    let p = ctx.registry_cache_dir();
+    if p.is_dir() {
+        return Ok(FixOutcome::AlreadyFixed);
+    }
+    std::fs::create_dir_all(&p)?;
+    Ok(FixOutcome::Fixed {
+        detail: format!("created {}", p.display()),
+    })
+}
+
+fn check_cargo_bin_on_path(ctx: &DoctorContext) -> CheckResult {
+    let cargo_bin = ctx.home_dir.join(".cargo").join("bin");
+    let path = std::env::var("PATH").unwrap_or_default();
+    let on_path = std::env::split_paths(&path).any(|p| p == cargo_bin);
+    let bashrc_ok = rc_has_marker(&ctx.home_dir.join(".bashrc"));
+    let zshrc_ok = rc_has_marker(&ctx.home_dir.join(".zshrc"));
+    if on_path || (bashrc_ok && zshrc_ok) {
+        CheckResult {
+            passed: true,
+            message: format!(
+                "{} on PATH (or guarded block already in shell rc)",
+                cargo_bin.display()
+            ),
+            suggested_fix: None,
+        }
+    } else {
+        CheckResult {
+            passed: false,
+            message: format!("{} not on PATH", cargo_bin.display()),
+            suggested_fix: Some(format!(
+                "append `# sindri:auto path` block to ~/.bashrc and ~/.zshrc adding {} to PATH",
+                cargo_bin.display()
+            )),
+        }
+    }
+}
+
+fn fix_cargo_bin_on_path(ctx: &DoctorContext) -> Result<FixOutcome, DoctorError> {
+    let cargo_bin = ctx.home_dir.join(".cargo").join("bin");
+    let mut wrote_any = false;
+    let mut already_any = false;
+    for rc_name in &[".bashrc", ".zshrc"] {
+        let rc_path = ctx.home_dir.join(rc_name);
+        match ensure_path_block(&rc_path, &cargo_bin)? {
+            FixOutcome::Fixed { .. } => wrote_any = true,
+            FixOutcome::AlreadyFixed => already_any = true,
+            FixOutcome::NotApplicable => {}
+        }
+    }
+    if wrote_any {
+        Ok(FixOutcome::Fixed {
+            detail: format!(
+                "appended PATH guard to bashrc/zshrc for {}",
+                cargo_bin.display()
+            ),
+        })
+    } else if already_any {
+        Ok(FixOutcome::AlreadyFixed)
+    } else {
+        Ok(FixOutcome::NotApplicable)
+    }
+}
+
+fn check_lockfile_fresh(_ctx: &DoctorContext) -> CheckResult {
+    let lockfile = std::path::Path::new("sindri.lock");
+    let manifest = std::path::Path::new("sindri.yaml");
+    if !lockfile.exists() {
+        // No lockfile → not stale, just not yet resolved. Treat as informational pass.
+        return CheckResult {
+            passed: true,
+            message: "no sindri.lock found (run `sindri resolve` to create one)".into(),
+            suggested_fix: None,
+        };
+    }
+    if !manifest.exists() {
+        return CheckResult {
+            passed: true,
+            message: "sindri.lock present, no sindri.yaml to compare".into(),
+            suggested_fix: None,
+        };
+    }
+    // We can't recompute the bom_hash without the full resolver pipeline here,
+    // so we use a coarser signal: lockfile mtime vs manifest mtime.
+    let mtime = |p: &Path| -> Option<std::time::SystemTime> {
+        std::fs::metadata(p).ok().and_then(|m| m.modified().ok())
+    };
+    let stale = match (mtime(manifest), mtime(lockfile)) {
+        (Some(m), Some(l)) => m > l,
+        _ => false,
+    };
+    if stale {
+        CheckResult {
+            passed: false,
+            message: "sindri.yaml is newer than sindri.lock".into(),
+            suggested_fix: Some("Run `sindri resolve`".into()),
+        }
+    } else {
+        CheckResult {
+            passed: true,
+            message: "sindri.lock is up-to-date with sindri.yaml".into(),
+            suggested_fix: None,
+        }
+    }
+}
+
+// ---- shell-rc helpers ---------------------------------------------------
+
+fn rc_has_marker(rc_path: &Path) -> bool {
+    std::fs::read_to_string(rc_path)
+        .map(|s| s.contains(DOCTOR_PATH_MARKER))
+        .unwrap_or(false)
+}
+
+/// Append a guarded block to `rc_path` that prepends `bin_dir` to `$PATH`.
+/// Idempotent: the marker line is checked first.
+fn ensure_path_block(rc_path: &Path, bin_dir: &Path) -> Result<FixOutcome, DoctorError> {
+    let existing = std::fs::read_to_string(rc_path).unwrap_or_default();
+    if existing.contains(DOCTOR_PATH_MARKER) {
+        return Ok(FixOutcome::AlreadyFixed);
+    }
+    if let Some(parent) = rc_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let block = format!(
+        "\n{marker}\n\
+         # Sindri-managed PATH addition. Edit via `sindri doctor --fix`; do not modify by hand.\n\
+         case \":$PATH:\" in\n\
+         \t*\":{bin}:\"*) ;;\n\
+         \t*) export PATH=\"{bin}:$PATH\" ;;\n\
+         esac\n\
+         {marker}\n",
+        marker = DOCTOR_PATH_MARKER,
+        bin = bin_dir.display(),
+    );
+    let mut body = existing;
+    body.push_str(&block);
+    std::fs::write(rc_path, body)?;
+    Ok(FixOutcome::Fixed {
+        detail: format!("wrote PATH guard to {}", rc_path.display()),
+    })
+}
+
+// ---- tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn ctx_for(home: &TempDir, apply_fixes: bool, dry_run: bool) -> DoctorContext {
+        DoctorContext {
+            home_dir: home.path().to_path_buf(),
+            apply_fixes,
+            dry_run,
+        }
+    }
+
+    #[test]
+    fn missing_sindri_dir_check_detects_and_fixes() {
+        let home = TempDir::new().unwrap();
+        let ctx = ctx_for(&home, true, false);
+
+        // Detect.
+        let res = check_sindri_dir(&ctx);
+        assert!(!res.passed, "expected sindri dir to be missing");
+        assert!(res.suggested_fix.is_some());
+
+        // Fix.
+        let outcome = fix_sindri_dir(&ctx).unwrap();
+        match outcome {
+            FixOutcome::Fixed { .. } => {}
+            other => panic!("expected Fixed, got {:?}", other),
+        }
+        assert!(ctx.sindri_dir().is_dir());
+
+        // Re-run check is now passing.
+        let res2 = check_sindri_dir(&ctx);
+        assert!(res2.passed);
+    }
+
+    #[test]
+    fn dry_run_does_not_modify_filesystem() {
+        let home = TempDir::new().unwrap();
+        let ctx = ctx_for(&home, false, true);
+        let checks = all_checks();
+        let code = run_with_context(&ctx, &checks, "local", false, false, true);
+        // Dry-run keeps failures unfixed → non-zero.
+        assert_eq!(code, EXIT_SCHEMA_OR_RESOLVE_ERROR);
+        // No files created.
+        assert!(!ctx.sindri_dir().exists());
+        assert!(!ctx.trust_dir().exists());
+        assert!(!ctx.registry_cache_dir().exists());
+        assert!(!home.path().join(".bashrc").exists());
+        assert!(!home.path().join(".zshrc").exists());
+    }
+
+    #[test]
+    fn fix_is_idempotent() {
+        let home = TempDir::new().unwrap();
+        let ctx = ctx_for(&home, true, false);
+        let first = fix_sindri_dir(&ctx).unwrap();
+        assert!(matches!(first, FixOutcome::Fixed { .. }));
+        let second = fix_sindri_dir(&ctx).unwrap();
+        assert!(matches!(second, FixOutcome::AlreadyFixed));
+    }
+
+    #[test]
+    fn shell_rc_fix_appends_guarded_block_only_once() {
+        let home = TempDir::new().unwrap();
+        let ctx = ctx_for(&home, true, false);
+
+        let first = fix_cargo_bin_on_path(&ctx).unwrap();
+        assert!(matches!(first, FixOutcome::Fixed { .. }));
+        let bashrc = std::fs::read_to_string(home.path().join(".bashrc")).unwrap();
+        let zshrc = std::fs::read_to_string(home.path().join(".zshrc")).unwrap();
+        assert_eq!(
+            bashrc.matches(DOCTOR_PATH_MARKER).count(),
+            2,
+            "open + close marker"
+        );
+        assert_eq!(zshrc.matches(DOCTOR_PATH_MARKER).count(), 2);
+
+        let second = fix_cargo_bin_on_path(&ctx).unwrap();
+        assert!(matches!(second, FixOutcome::AlreadyFixed));
+        let bashrc2 = std::fs::read_to_string(home.path().join(".bashrc")).unwrap();
+        assert_eq!(bashrc, bashrc2, "second fix must not touch the file");
+    }
+
+    #[test]
+    fn stale_lockfile_emits_suggestion_only() {
+        // Run inside a tempdir CWD so we don't accidentally pick up the
+        // workspace's real sindri.yaml/sindri.lock.
+        let cwd_keep = std::env::current_dir().unwrap();
+        let work = TempDir::new().unwrap();
+        std::env::set_current_dir(work.path()).unwrap();
+
+        // Create sindri.yaml newer than sindri.lock.
+        std::fs::write(work.path().join("sindri.lock"), "old").unwrap();
+        // Sleep an instant so mtimes differ on coarse-grained filesystems.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::fs::write(work.path().join("sindri.yaml"), "newer").unwrap();
+
+        let home = TempDir::new().unwrap();
+        let ctx = ctx_for(&home, false, false);
+        let res = check_lockfile_fresh(&ctx);
+
+        // Restore CWD before any panics.
+        std::env::set_current_dir(cwd_keep).unwrap();
+
+        assert!(!res.passed, "expected stale lockfile fail");
+        assert_eq!(res.suggested_fix.as_deref(), Some("Run `sindri resolve`"));
+        // No `fix` function attached → suggestion-only.
+        let entry = all_checks()
+            .into_iter()
+            .find(|c| c.name == "registry.lockfile-fresh")
+            .unwrap();
+        assert!(entry.fix.is_none());
+    }
 }

--- a/v4/crates/sindri/src/commands/mod.rs
+++ b/v4/crates/sindri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod apply;
 pub mod apply_lifecycle;
+pub mod backup;
 pub mod bom;
 pub mod completions;
 pub mod diff;
@@ -21,6 +22,7 @@ pub mod remove;
 pub mod resolve;
 pub mod rollback;
 pub mod search;
+pub mod secrets;
 pub mod self_upgrade;
 pub mod show;
 pub mod target;

--- a/v4/crates/sindri/src/commands/secrets.rs
+++ b/v4/crates/sindri/src/commands/secrets.rs
@@ -1,0 +1,447 @@
+//! `sindri secrets *` — secret reference validation, listing, and S3
+//! storage helpers (Sprint 12, Wave 4C).
+//!
+//! This module never prints raw secret values. It validates that
+//! configured `AuthValue`-style references resolve, lists their
+//! source-kinds, and shells out to `aws s3` for an S3-backed secrets
+//! store.
+//!
+//! Why shell out to `aws`? Pulling in `aws-sdk-s3` would add a multi-
+//! megabyte dependency for what is, today, a thin convenience over
+//! `aws s3 cp/ls`. The simplification is documented in the PR body and
+//! can be revisited when v4 grows a real S3 backend.
+
+use base64::Engine;
+use serde::Serialize;
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use sindri_core::manifest::BomManifest;
+use sindri_targets::auth::AuthValue;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// CLI args parsed in `main.rs` for `sindri secrets *`.
+pub enum SecretsCmd {
+    /// `sindri secrets validate <id>`.
+    Validate { id: String, manifest: PathBuf },
+    /// `sindri secrets list [--json]`.
+    List { json: bool, manifest: PathBuf },
+    /// `sindri secrets test-vault`.
+    TestVault,
+    /// `sindri secrets encode-file <path> [--algorithm …] [--output …]`.
+    EncodeFile {
+        path: PathBuf,
+        algorithm: String,
+        output: Option<PathBuf>,
+    },
+    /// `sindri secrets s3 get <key> --bucket <b>`.
+    S3Get { bucket: String, key: String },
+    /// `sindri secrets s3 put <key> <file> --bucket <b>`.
+    S3Put {
+        bucket: String,
+        key: String,
+        file: PathBuf,
+    },
+    /// `sindri secrets s3 list --bucket <b> [--prefix <p>]`.
+    S3List {
+        bucket: String,
+        prefix: Option<String>,
+    },
+}
+
+/// Source kind reported by `secrets list`. Never carries the value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SourceKind {
+    Env,
+    File,
+    Cli,
+    Plain,
+}
+
+impl SourceKind {
+    fn of(value: &str) -> Self {
+        if value.starts_with("env:") {
+            Self::Env
+        } else if value.starts_with("file:") {
+            Self::File
+        } else if value.starts_with("cli:") {
+            Self::Cli
+        } else {
+            Self::Plain
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SecretEntry<'a> {
+    id: &'a str,
+    kind: SourceKind,
+}
+
+/// Top-level dispatcher for `secrets *`.
+pub fn run(cmd: SecretsCmd) -> i32 {
+    match cmd {
+        SecretsCmd::Validate { id, manifest } => run_validate(&id, &manifest),
+        SecretsCmd::List { json, manifest } => run_list(json, &manifest),
+        SecretsCmd::TestVault => run_test_vault(),
+        SecretsCmd::EncodeFile {
+            path,
+            algorithm,
+            output,
+        } => run_encode_file(&path, &algorithm, output.as_deref()),
+        SecretsCmd::S3Get { bucket, key } => exec_status(s3_get_cmd(&bucket, &key)),
+        SecretsCmd::S3Put { bucket, key, file } => exec_status(s3_put_cmd(&bucket, &key, &file)),
+        SecretsCmd::S3List { bucket, prefix } => {
+            exec_status(s3_list_cmd(&bucket, prefix.as_deref()))
+        }
+    }
+}
+
+fn load_manifest(path: &Path) -> Result<BomManifest, String> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+    serde_yaml::from_str::<BomManifest>(&text)
+        .map_err(|e| format!("parse {}: {}", path.display(), e))
+}
+
+fn run_validate(id: &str, manifest_path: &Path) -> i32 {
+    let manifest = match load_manifest(manifest_path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let raw = match manifest.secrets.get(id) {
+        Some(v) => v,
+        None => {
+            eprintln!(
+                "error: secret `{}` not configured in {}",
+                id,
+                manifest_path.display()
+            );
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let av = match AuthValue::parse(raw) {
+        Some(v) => v,
+        None => {
+            eprintln!("error: secret `{}` has unparseable value", id);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    match av.resolve() {
+        Ok(_value) => {
+            // NEVER print the value.
+            println!("OK: secret `{}` resolves ({:?})", id, SourceKind::of(raw));
+            EXIT_SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: secret `{}` failed to resolve: {}", id, e);
+            EXIT_SCHEMA_OR_RESOLVE_ERROR
+        }
+    }
+}
+
+fn run_list(json: bool, manifest_path: &Path) -> i32 {
+    let manifest = match load_manifest(manifest_path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let mut entries: Vec<SecretEntry<'_>> = manifest
+        .secrets
+        .iter()
+        .map(|(id, v)| SecretEntry {
+            id: id.as_str(),
+            kind: SourceKind::of(v.as_str()),
+        })
+        .collect();
+    entries.sort_by(|a, b| a.id.cmp(b.id));
+    if json {
+        match serde_json::to_string_pretty(&entries) {
+            Ok(s) => println!("{}", s),
+            Err(e) => {
+                eprintln!("error: serialise: {}", e);
+                return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+            }
+        }
+    } else if entries.is_empty() {
+        println!("(no secrets configured)");
+    } else {
+        println!("{:<32} SOURCE", "ID");
+        for e in &entries {
+            println!("{:<32} {:?}", e.id, e.kind);
+        }
+    }
+    EXIT_SUCCESS
+}
+
+fn run_test_vault() -> i32 {
+    // Try `vault status` first; fall back to `aws secretsmanager list-secrets --max-results 1`.
+    if let Some(vault) = which("vault") {
+        let status = Command::new(vault).arg("status").status();
+        return match status {
+            Ok(s) if s.success() => {
+                println!("OK: vault status responded successfully");
+                EXIT_SUCCESS
+            }
+            _ => {
+                eprintln!("error: `vault status` did not return success");
+                EXIT_SCHEMA_OR_RESOLVE_ERROR
+            }
+        };
+    }
+    if let Some(aws) = which("aws") {
+        let status = Command::new(aws)
+            .args(["secretsmanager", "list-secrets", "--max-results", "1"])
+            .status();
+        return match status {
+            Ok(s) if s.success() => {
+                println!("OK: aws secretsmanager reachable");
+                EXIT_SUCCESS
+            }
+            _ => {
+                eprintln!("error: aws secretsmanager list-secrets failed");
+                EXIT_SCHEMA_OR_RESOLVE_ERROR
+            }
+        };
+    }
+    eprintln!("error: neither `vault` nor `aws` CLI found on PATH");
+    EXIT_SCHEMA_OR_RESOLVE_ERROR
+}
+
+fn run_encode_file(path: &Path, algorithm: &str, output: Option<&Path>) -> i32 {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("error: read {}: {}", path.display(), e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let encoded = match algorithm {
+        "base64" => base64::engine::general_purpose::STANDARD.encode(&bytes),
+        "sha256" => {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(&bytes);
+            hex::encode(h.finalize())
+        }
+        other => {
+            eprintln!(
+                "error: unsupported algorithm `{}` (use base64 or sha256)",
+                other
+            );
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    match output {
+        Some(out) => {
+            if let Err(e) = std::fs::write(out, &encoded) {
+                eprintln!("error: write {}: {}", out.display(), e);
+                return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+            }
+            println!("Wrote {} bytes to {}", encoded.len(), out.display());
+        }
+        None => println!("{}", encoded),
+    }
+    EXIT_SUCCESS
+}
+
+// ---- aws s3 shell-out helpers -------------------------------------------
+
+/// Build the argv for `aws s3 ls s3://<bucket>/<prefix>`. Pure function so
+/// tests can assert the shape without invoking aws.
+pub fn s3_list_argv(bucket: &str, prefix: Option<&str>) -> Vec<String> {
+    let url = match prefix {
+        Some(p) if !p.is_empty() => format!("s3://{}/{}", bucket, p),
+        _ => format!("s3://{}/", bucket),
+    };
+    vec!["s3".into(), "ls".into(), url]
+}
+
+/// Build the argv for `aws s3 cp s3://<bucket>/<key> -`.
+pub fn s3_get_argv(bucket: &str, key: &str) -> Vec<String> {
+    vec![
+        "s3".into(),
+        "cp".into(),
+        format!("s3://{}/{}", bucket, key),
+        "-".into(),
+    ]
+}
+
+/// Build the argv for `aws s3 cp <file> s3://<bucket>/<key>`.
+pub fn s3_put_argv(bucket: &str, key: &str, file: &Path) -> Vec<String> {
+    vec![
+        "s3".into(),
+        "cp".into(),
+        file.display().to_string(),
+        format!("s3://{}/{}", bucket, key),
+    ]
+}
+
+fn s3_list_cmd(bucket: &str, prefix: Option<&str>) -> Command {
+    let mut c = Command::new("aws");
+    c.args(s3_list_argv(bucket, prefix));
+    c
+}
+fn s3_get_cmd(bucket: &str, key: &str) -> Command {
+    let mut c = Command::new("aws");
+    c.args(s3_get_argv(bucket, key));
+    c
+}
+fn s3_put_cmd(bucket: &str, key: &str, file: &Path) -> Command {
+    let mut c = Command::new("aws");
+    c.args(s3_put_argv(bucket, key, file));
+    c
+}
+
+fn exec_status(mut c: Command) -> i32 {
+    match c.status() {
+        Ok(s) if s.success() => EXIT_SUCCESS,
+        Ok(s) => s.code().unwrap_or(EXIT_SCHEMA_OR_RESOLVE_ERROR),
+        Err(e) => {
+            eprintln!("error: spawn aws: {}", e);
+            EXIT_SCHEMA_OR_RESOLVE_ERROR
+        }
+    }
+}
+
+fn which(name: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|d| {
+            let c = d.join(name);
+            if c.is_file() {
+                Some(c)
+            } else {
+                None
+            }
+        })
+    })
+}
+
+// ---- tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_manifest(dir: &TempDir, body: &str) -> PathBuf {
+        let p = dir.path().join("sindri.yaml");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        p
+    }
+
+    #[test]
+    fn validate_env_value_present() {
+        let dir = TempDir::new().unwrap();
+        let key = "SINDRI_TEST_SECRET_PRESENT";
+        // Ensure unique key to avoid cross-test interference.
+        std::env::set_var(key, "shhh");
+        let manifest = write_manifest(
+            &dir,
+            &format!("components: []\nsecrets:\n  api: env:{}\n", key),
+        );
+        let code = run_validate("api", &manifest);
+        std::env::remove_var(key);
+        assert_eq!(code, EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn validate_env_value_missing_errors() {
+        let dir = TempDir::new().unwrap();
+        let key = "SINDRI_TEST_SECRET_DEFINITELY_NOT_SET_X9";
+        std::env::remove_var(key);
+        let manifest = write_manifest(
+            &dir,
+            &format!("components: []\nsecrets:\n  api: env:{}\n", key),
+        );
+        let code = run_validate("api", &manifest);
+        assert_ne!(code, EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn validate_file_value_present() {
+        let dir = TempDir::new().unwrap();
+        let secret = dir.path().join("token");
+        std::fs::write(&secret, "topsecretvalue").unwrap();
+        let manifest = write_manifest(
+            &dir,
+            &format!(
+                "components: []\nsecrets:\n  tok: file:{}\n",
+                secret.display()
+            ),
+        );
+        let code = run_validate("tok", &manifest);
+        assert_eq!(code, EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn list_never_prints_values() {
+        let dir = TempDir::new().unwrap();
+        let secret_value = "DO_NOT_LEAK_ABCDEF";
+        std::env::set_var("SINDRI_LIST_TEST", secret_value);
+        let manifest = write_manifest(
+            &dir,
+            "components: []\nsecrets:\n  api: env:SINDRI_LIST_TEST\n",
+        );
+
+        // Invoke list and ensure the secret value never makes it into a
+        // serialised JSON dump (we test the data shape because capturing
+        // stdout from run_list is awkward in unit tests).
+        let parsed = load_manifest(&manifest).unwrap();
+        let entries: Vec<SecretEntry<'_>> = parsed
+            .secrets
+            .iter()
+            .map(|(id, v)| SecretEntry {
+                id,
+                kind: SourceKind::of(v),
+            })
+            .collect();
+        let json = serde_json::to_string(&entries).unwrap();
+        assert!(
+            !json.contains(secret_value),
+            "list output leaked secret value"
+        );
+        std::env::remove_var("SINDRI_LIST_TEST");
+    }
+
+    #[test]
+    fn encode_file_base64_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("payload.bin");
+        let payload = b"hello sindri";
+        std::fs::write(&src, payload).unwrap();
+        let out = dir.path().join("encoded.txt");
+        let code = run_encode_file(&src, "base64", Some(&out));
+        assert_eq!(code, EXIT_SUCCESS);
+        let encoded = std::fs::read_to_string(&out).unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded.trim())
+            .unwrap();
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn s3_list_command_built_correctly() {
+        assert_eq!(
+            s3_list_argv("my-bucket", Some("path/")),
+            vec!["s3", "ls", "s3://my-bucket/path/"]
+        );
+        assert_eq!(
+            s3_list_argv("my-bucket", None),
+            vec!["s3", "ls", "s3://my-bucket/"]
+        );
+        assert_eq!(s3_get_argv("b", "k"), vec!["s3", "cp", "s3://b/k", "-"]);
+        let f = std::path::PathBuf::from("/tmp/payload");
+        assert_eq!(
+            s3_put_argv("b", "k", &f),
+            vec!["s3", "cp", "/tmp/payload", "s3://b/k"]
+        );
+    }
+}

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -189,14 +189,43 @@ enum Commands {
     Doctor {
         #[arg(long)]
         target: Option<String>,
-        #[arg(long)]
+        /// Apply remediations for fixable failures.
+        #[arg(long, conflicts_with = "dry_run")]
         fix: bool,
+        /// Print would-be remediations without writing.
         #[arg(long, conflicts_with = "fix")]
         dry_run: bool,
+        /// Machine-readable output.
         #[arg(long)]
         json: bool,
         #[arg(long)]
         components: bool,
+    },
+    /// Validate / inspect / store secret references (Sprint 12)
+    Secrets {
+        #[command(subcommand)]
+        cmd: SecretsSubcmds,
+    },
+    /// Create a tarball of the user's sindri state
+    Backup {
+        /// Output path (file or directory). Defaults to cwd with a
+        /// timestamped filename.
+        #[arg(long, short)]
+        output: Option<std::path::PathBuf>,
+        /// Include `~/.sindri/cache/registries/` (large; off by default).
+        #[arg(long)]
+        include_cache: bool,
+    },
+    /// Restore a `sindri backup` archive
+    Restore {
+        /// Path to the archive.
+        archive: std::path::PathBuf,
+        /// Print the file list without writing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite existing destination files.
+        #[arg(long)]
+        force: bool,
     },
     /// Target management (ADR-017, ADR-023)
     Target {
@@ -398,6 +427,62 @@ enum LedgerSubcmds {
 }
 
 #[derive(Subcommand)]
+enum SecretsSubcmds {
+    /// Resolve a configured secret and assert it succeeds (no value printed)
+    Validate {
+        id: String,
+        #[arg(short, long, default_value = "sindri.yaml")]
+        manifest: std::path::PathBuf,
+    },
+    /// List configured secrets (id + source kind only)
+    List {
+        #[arg(long)]
+        json: bool,
+        #[arg(short, long, default_value = "sindri.yaml")]
+        manifest: std::path::PathBuf,
+    },
+    /// Test connectivity to the configured vault backend
+    TestVault,
+    /// Encode a file for embedding in sindri.yaml
+    EncodeFile {
+        path: std::path::PathBuf,
+        #[arg(long, default_value = "base64")]
+        algorithm: String,
+        #[arg(long, short)]
+        output: Option<std::path::PathBuf>,
+    },
+    /// S3 secrets backend (shells out to `aws s3`)
+    S3 {
+        #[command(subcommand)]
+        cmd: SecretsS3Subcmds,
+    },
+}
+
+#[derive(Subcommand)]
+enum SecretsS3Subcmds {
+    /// `aws s3 cp s3://<bucket>/<key> -`
+    Get {
+        key: String,
+        #[arg(long)]
+        bucket: String,
+    },
+    /// `aws s3 cp <file> s3://<bucket>/<key>`
+    Put {
+        key: String,
+        file: std::path::PathBuf,
+        #[arg(long)]
+        bucket: String,
+    },
+    /// `aws s3 ls s3://<bucket>/<prefix>`
+    List {
+        #[arg(long)]
+        bucket: String,
+        #[arg(long)]
+        prefix: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 enum PolicySubcmds {
     /// Set the active policy preset (default | strict | offline)
     Use { preset: String },
@@ -488,6 +573,49 @@ fn main() {
             dry_run,
             json,
             components,
+        }),
+        Some(Commands::Secrets { cmd }) => {
+            use commands::secrets::SecretsCmd;
+            let mapped = match cmd {
+                SecretsSubcmds::Validate { id, manifest } => SecretsCmd::Validate { id, manifest },
+                SecretsSubcmds::List { json, manifest } => SecretsCmd::List { json, manifest },
+                SecretsSubcmds::TestVault => SecretsCmd::TestVault,
+                SecretsSubcmds::EncodeFile {
+                    path,
+                    algorithm,
+                    output,
+                } => SecretsCmd::EncodeFile {
+                    path,
+                    algorithm,
+                    output,
+                },
+                SecretsSubcmds::S3 { cmd } => match cmd {
+                    SecretsS3Subcmds::Get { key, bucket } => SecretsCmd::S3Get { bucket, key },
+                    SecretsS3Subcmds::Put { key, file, bucket } => {
+                        SecretsCmd::S3Put { bucket, key, file }
+                    }
+                    SecretsS3Subcmds::List { bucket, prefix } => {
+                        SecretsCmd::S3List { bucket, prefix }
+                    }
+                },
+            };
+            commands::secrets::run(mapped)
+        }
+        Some(Commands::Backup {
+            output,
+            include_cache,
+        }) => commands::backup::run_backup(commands::backup::BackupArgs {
+            output,
+            include_cache,
+        }),
+        Some(Commands::Restore {
+            archive,
+            dry_run,
+            force,
+        }) => commands::backup::run_restore(commands::backup::RestoreArgs {
+            archive,
+            dry_run,
+            force,
         }),
         Some(Commands::Target { cmd }) => {
             let tc = match cmd {

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -191,6 +191,10 @@ enum Commands {
         target: Option<String>,
         #[arg(long)]
         fix: bool,
+        #[arg(long, conflicts_with = "fix")]
+        dry_run: bool,
+        #[arg(long)]
+        json: bool,
         #[arg(long)]
         components: bool,
     },
@@ -475,10 +479,14 @@ fn main() {
         Some(Commands::Doctor {
             target,
             fix,
+            dry_run,
+            json,
             components,
         }) => commands::doctor::run(commands::doctor::DoctorArgs {
             target,
             fix,
+            dry_run,
+            json,
             components,
         }),
         Some(Commands::Target { cmd }) => {

--- a/v4/docs/review/2026-04-27-implementation-audit-delta.md
+++ b/v4/docs/review/2026-04-27-implementation-audit-delta.md
@@ -131,3 +131,52 @@ is **never modified**; new wave entries are appended here.
   - Per-component cosign signatures (each component blob signed
     independently). Out of scope until the SBOM work in Wave 5 wires
     component manifest digests through the lockfile.
+
+## Wave 4C — Sprint 12 hardening (`feat/v4-doctor-secrets-backup`)
+
+### Sprint 12 verbs (`doctor --fix`, `secrets *`, `backup` / `restore`)
+
+- **Status:** 🔴 → 🟢
+- **What landed:**
+  - `crates/sindri/src/commands/doctor.rs` rewritten as a typed
+    [`HealthCheck`] registry. Initial fixable checks: `~/.sindri/`,
+    `~/.sindri/trust/`, `~/.sindri/cache/registries/`,
+    `~/.cargo/bin` on `PATH` via guarded shell-rc block. Stale-lockfile
+    detection is suggestion-only (never auto-resolves).
+  - New `--fix`, `--dry-run`, and `--json` flags on `sindri doctor`.
+    `--fix` and `--dry-run` are mutually exclusive at the clap layer.
+  - Shell-rc remediation reuses the `# sindri:auto`-marker idempotent
+    pattern from `sindri-extensions::configure` (PR #215). The doctor
+    block uses a distinct `# sindri:auto path` marker so it does not
+    collide with the per-component env-fragment block.
+  - New `crates/sindri/src/commands/secrets.rs`: `validate`, `list`,
+    `test-vault`, `encode-file`, and `s3 {get,put,list}`. `secrets list`
+    and `secrets validate` never print the resolved secret value.
+  - **S3 backend simplification.** Rather than depend on `aws-sdk-s3`,
+    `secrets s3 *` shells out to the `aws` CLI. Documented in the PR
+    body. Argv builders are pure functions (`s3_list_argv`, …) so unit
+    tests assert command shape without invoking aws.
+  - `BomManifest` gained an optional `secrets: HashMap<String,String>`
+    field (additive, `#[serde(default)]`) to back `secrets validate`.
+  - New `crates/sindri/src/commands/backup.rs`: `sindri backup`
+    produces `sindri-backup-<iso8601>.tar.gz` containing project
+    files (`sindri.yaml`, `sindri.policy.yaml`, `sindri.lock`,
+    `sindri.<target>.lock`), `~/.sindri/ledger.jsonl`,
+    `~/.sindri/{trust,plugins,history}/`, and optionally
+    `~/.sindri/cache/registries/` under `--include-cache`.
+  - `sindri restore` honours default-deny overwrite (`--force` to
+    override) and rejects archives containing absolute paths or `..`
+    traversal entries before any extraction.
+  - `flate2`, `tar`, `base64`, and `chrono` added as workspace
+    dependencies.
+  - Wired into `main.rs` as `Doctor`, `Secrets { … }`, `Backup`, and
+    `Restore` subcommands.
+  - Tests added (all passing): 5 in `doctor::tests`, 6 in
+    `secrets::tests`, 4 in `backup::tests`.
+- **What's deferred:**
+  - Full HashiCorp Vault protocol-level health checks (today: shell out
+    to `vault status`).
+  - `sindri doctor --components` runs validate commands from the
+    lockfile (Sprint 12.2 backlog item; flag exists but is reserved).
+  - Compression alternatives (zstd) for backup; `flate2` is the
+    initial choice for portability.


### PR DESCRIPTION
## Summary

Implements the Wave 4C scope of Sprint 12 hardening:

- `sindri doctor` rewritten as a typed `HealthCheck` registry with
  `--fix`, `--dry-run`, and `--json` flags.
- New `sindri secrets {validate,list,test-vault,encode-file,s3 …}`
  subsystem.
- New `sindri backup` + `sindri restore` (tar.gz, default-deny
  overwrite, path-traversal rejection).

## Why (audit)

The 2026-04-27 implementation audit flagged Sprint 12 verbs as 🔴
(missing). This PR moves them to 🟢 with the deferrals listed below.

## Per-verb behaviour

### `sindri doctor`

`commands/doctor.rs` now exposes a typed registry of checks, each
with optional remediation. Initial checks:

| Name | Fix |
|---|---|
| `paths.sindri-dir` | `mkdir -p ~/.sindri/` |
| `paths.trust-dir` | `mkdir -p ~/.sindri/trust/` |
| `paths.registry-cache-dir` | `mkdir -p ~/.sindri/cache/registries/` |
| `shell-rc.cargo-bin-on-path` | append `# sindri:auto path` guard to `~/.bashrc` + `~/.zshrc` (idempotent) |
| `registry.lockfile-fresh` | suggestion-only (`Run sindri resolve`); never auto-resolves |

The shell-rc guard mirrors the idempotent marker pattern from
`sindri-extensions::configure` (PR #215) but uses a distinct
`# sindri:auto path` marker so the two blocks coexist.

`--fix` continues past failures (does not abort on first error).
`--fix` and `--dry-run` are mutually exclusive at the clap layer.

### `sindri secrets *`

- `validate <id>` — resolves an `AuthValue` (ADR-020) and asserts it
  succeeds. **Never prints the resolved value.**
- `list [--json]` — id + source kind only.
- `test-vault` — pings `vault status`, falls back to
  `aws secretsmanager list-secrets --max-results 1`.
- `encode-file <path> [--algorithm base64|sha256] [--output …]` —
  default algorithm is base64.
- `s3 {get, put, list}` — see simplification note below.

`BomManifest` gained an additive `secrets: HashMap<String,String>`
(`#[serde(default)]`).

### `sindri backup` / `sindri restore`

`backup [--output <path>] [--include-cache]` writes
`sindri-backup-<iso8601>.tar.gz` containing:

- Project: `sindri.yaml`, `sindri.policy.yaml`, `sindri.lock`,
  `sindri.<target>.lock`.
- `~/.sindri/ledger.jsonl`
- `~/.sindri/{trust,plugins,history}/`
- `~/.sindri/cache/registries/` only with `--include-cache`.

`restore <archive> [--dry-run] [--force]`:

- Refuses to overwrite existing files unless `--force` (default-deny;
  matches v3 behaviour).
- Validates entries before extraction: rejects absolute paths and any
  entry containing a `..` component.
- Sets `preserve_permissions(false)` and `unpack_xattrs(false)` on
  the archive.

## S3 secrets simplification (shell out to aws CLI)

Rather than depend on `aws-sdk-s3` (multi-megabyte build cost),
`secrets s3 *` shells out to the `aws` CLI:

- `get <key> --bucket <b>` → `aws s3 cp s3://<b>/<key> -`
- `put <key> <file> --bucket <b>` → `aws s3 cp <file> s3://<b>/<key>`
- `list --bucket <b> [--prefix <p>]` → `aws s3 ls s3://<b>/<p>`

The argv builders are pure functions (`s3_list_argv`, …) so unit
tests assert the command shape without actually invoking aws.
This can be revisited when v4 grows a real S3 backend.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` — all green (155 tests; 15 new in
      `commands::{doctor,secrets,backup}::tests`)
- [x] doctor: detects + fixes missing paths, dry-run is read-only,
      shell-rc fix is idempotent, stale-lockfile is suggestion-only.
- [x] secrets: env/file resolution, list never prints values,
      base64 round-trip, s3 argv shape.
- [x] backup: round-trip restores all files, dry-run is read-only,
      overwrite refused without `--force`, traversal archive
      rejected with `InvalidData`.

## What's deferred

- Full HashiCorp Vault protocol-level health checks (`test-vault`
  shells out to `vault status` today).
- `sindri doctor --components` runs validate commands from the
  lockfile (Sprint 12.2 backlog; flag is reserved).
- Compression alternatives (zstd) for backup; `flate2` chosen for
  portability.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)