### PR TITLE
docs(v4): Wave 5D — v4 documentation set (D20)

### DIFF
--- a/v4/docs/AUTHORING.md
+++ b/v4/docs/AUTHORING.md
@@ -1,0 +1,348 @@
+# Authoring a Sindri Component Manifest
+
+This document explains how to write a `component.yaml` for the Sindri v4 registry. It is aimed at maintainers who want to publish a tool as a first-class Sindri component, and at contributors who are adding components to `registry-core`. You will finish this guide having written a complete, lint-clean manifest from scratch.
+
+For design rationale, consult the ADRs cross-linked throughout this document.
+
+---
+
+## Concepts Before You Write
+
+### One tool, one component ([ADR-002](architecture/adr/002-atomic-component-unit.md))
+
+Each `component.yaml` wraps exactly one logical tool and one install backend. If your tool requires two operations — for example, installing a system package and then running a configure script — model them as two separate components connected with a `dependsOn` edge.
+
+### Backend-addressed install ([ADR-004](architecture/adr/004-backend-addressed-manifest-syntax.md))
+
+The backend (`mise`, `npm`, `binary`, `script`, etc.) is explicit in the manifest and in the user's `sindri.yaml`. There is no silent auto-pick.
+
+### Policy gates ([ADR-008](architecture/adr/008-install-policy-subsystem.md))
+
+During `sindri resolve`, every component passes through four admission gates:
+
+1. **Platform eligibility** — the current host matches at least one entry in `platforms:`.
+2. **Policy eligibility** — the resolved policy allows the license, source, and capabilities.
+3. **Dependency closure** — every transitive dependency also passes gates 1 and 2.
+4. **Capability trust** — `collision_handling` and `project_init` from third-party registries are gated by the trust policy.
+
+### Cross-platform coverage ([ADR-009](architecture/adr/009-cross-platform-backend-coverage.md))
+
+Declare every platform your component supports. Resolution fails loudly for undeclared platforms rather than falling back silently. Prefer typed backends (`mise`, `brew`, `winget`) over `script` wherever possible.
+
+### Script lifecycle contract ([ADR-024](architecture/adr/024-script-component-lifecycle-contract.md))
+
+If your component uses the `script` backend, the CLI injects `SINDRI_COMPONENT_VERSION` before every lifecycle script. Your `install.sh` must implement version-aware idempotency using the `at_version` helper.
+
+---
+
+## Component Manifest Schema
+
+The canonical schema is at [`v4/schemas/component.json`](../schemas/component.json). A minimal valid manifest:
+
+```yaml
+apiVersion: sindri.dev/v4
+kind: Component
+metadata:
+  name: my-tool
+  version: "1.0.0"
+  description: "A great tool"
+  license: MIT
+  homepage: https://example.com/my-tool
+  tags:
+    - utility
+
+platforms:
+  - os: linux
+    arch: x86_64
+  - os: macos
+    arch: aarch64
+
+install:
+  binary:
+    url_template: "https://example.com/releases/my-tool-{version}-{os}-{arch}.tar.gz"
+    install_path: "~/.local/bin/my-tool"
+    checksums:
+      linux-x86_64: "sha256:abcdef1234567890..."
+      macos-aarch64: "sha256:abcdef0987654321..."
+
+depends_on: []
+```
+
+---
+
+## Field Reference
+
+### `metadata`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Lowercase, hyphens only. Must be unique within a registry. |
+| `version` | string | Yes | The tool version this component installs, not the manifest version. Use exact semver or the tool's own versioning scheme. |
+| `description` | string | Yes | One sentence, under 80 characters. |
+| `license` | string | Yes | SPDX identifier (e.g. `MIT`, `Apache-2.0`, `GPL-3.0-only`). Used by policy gates. |
+| `homepage` | string | No | Upstream project URL. |
+| `tags` | string[] | No | Free-form tags for `sindri search`. |
+
+### `platforms`
+
+List of `{ os, arch }` pairs the component supports. Every platform a user might install on must be listed explicitly.
+
+Valid `os` values: `linux`, `macos`, `windows`.
+Valid `arch` values: `x86_64`, `aarch64`.
+
+```yaml
+platforms:
+  - os: linux
+    arch: x86_64
+  - os: linux
+    arch: aarch64
+  - os: macos
+    arch: aarch64
+  - os: windows
+    arch: x86_64
+```
+
+Note: macOS `x86_64` (Intel) is intentionally out of scope for v4.0 (Apple-deprecated host). See [ADR-009](architecture/adr/009-cross-platform-backend-coverage.md).
+
+### `install`
+
+The install block declares how the tool is installed. Exactly one of the sub-blocks must be present in `default:`. Per-platform `overrides:` override the default on matching platforms.
+
+#### `mise` backend
+
+```yaml
+install:
+  mise:
+    tools:
+      node: "22.0.0"
+```
+
+The `tools` map is passed directly to `mise install`. The key is the mise plugin name; the value is the version.
+
+#### `binary` backend
+
+```yaml
+install:
+  binary:
+    url_template: "https://github.com/{repo}/releases/download/v{version}/tool-{os}-{arch}.tar.gz"
+    install_path: "~/.local/bin/my-tool"
+    checksums:
+      linux-x86_64: "sha256:..."
+      linux-aarch64: "sha256:..."
+      macos-aarch64: "sha256:..."
+      windows-x86_64: "sha256:..."
+```
+
+Template variables: `{version}`, `{os}` (lowercase), `{arch}` (lowercase).
+
+Binary components **must** declare checksums for every supported platform. `sindri registry lint` enforces this.
+
+#### `npm` backend
+
+```yaml
+install:
+  npm:
+    package: "@anthropic-ai/claude-code"
+    version: "1.0.0"
+    global: true
+```
+
+#### `script` backend
+
+```yaml
+install:
+  script:
+    install_sh: "install.sh"
+    uninstall_sh: "uninstall.sh"
+    validate_sh: "validate.sh"
+    upgrade_sh: "upgrade.sh"
+```
+
+Every script receives `SINDRI_COMPONENT_VERSION` from the CLI (see [ADR-024](architecture/adr/024-script-component-lifecycle-contract.md)). Scripts must implement version-aware idempotency.
+
+#### Per-platform overrides
+
+```yaml
+install:
+  default:
+    binary:
+      url_template: "..."
+  overrides:
+    macos-aarch64:
+      brew:
+        package: my-tool
+    linux-x86_64:
+      apt:
+        packages:
+          - my-tool
+```
+
+### `depends_on`
+
+List of component addresses (in `backend:name` format) that must be installed before this component. The resolver builds a DAG from all `depends_on` edges and topologically sorts the install order.
+
+```yaml
+depends_on:
+  - mise-config
+  - binary:gh
+```
+
+### `options`
+
+Typed user-configurable options exposed in `sindri.yaml`.
+
+```yaml
+options:
+  enable_corepack:
+    type: bool
+    default: true
+  extra_flags:
+    type: string
+    default: ""
+```
+
+### `capabilities`
+
+Optional capabilities block for post-install integration.
+
+```yaml
+capabilities:
+  hooks:
+    pre_install:
+      - command: "echo 'about to install'"
+    post_install:
+      - command: "node --version"
+    pre_project_init:
+      - command: "corepack enable"
+    post_project_init:
+      - command: "npm install"
+
+  project_init:
+    - name: "Install dependencies"
+      command: "npm install"
+      workdir: "."
+      priority: 10
+
+  collision_handling:
+    path_prefix: "nodejs/"   # must start with `{name}/`
+    on_conflict: skip        # skip | stop | proceed
+
+  mcp:
+    server_command: "my-tool mcp serve"
+    protocol: "stdio"
+```
+
+**Collision handling path prefix rule:** the `path_prefix` field must start with `{component-name}/`. Core registry components may also use `:shared`. See [ADR-008](architecture/adr/008-install-policy-subsystem.md) Gate 4 and [ADR-024](architecture/adr/024-script-component-lifecycle-contract.md).
+
+### `validate`
+
+Commands run by `sindri validate` and `sindri doctor --components` to assert the tool is correctly installed.
+
+```yaml
+validate:
+  commands:
+    - name: node
+      version_flag: "--version"
+      expected_pattern: "v22\\."
+```
+
+---
+
+## Worked Example: `gh` CLI via Binary Backend
+
+The following is a complete, lint-clean component manifest for the GitHub CLI (`gh`).
+
+```yaml
+apiVersion: sindri.dev/v4
+kind: Component
+metadata:
+  name: gh
+  version: "2.67.0"
+  description: "GitHub CLI — work with GitHub from the command line"
+  license: MIT
+  homepage: https://cli.github.com
+  tags:
+    - developer-tools
+    - github
+    - vcs
+
+platforms:
+  - os: linux
+    arch: x86_64
+  - os: linux
+    arch: aarch64
+  - os: macos
+    arch: aarch64
+  - os: windows
+    arch: x86_64
+
+install:
+  default:
+    binary:
+      url_template: >-
+        https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch_alias}.tar.gz
+      install_path: "~/.local/bin/gh"
+      checksums:
+        linux-x86_64:   "sha256:aaaa..."
+        linux-aarch64:  "sha256:bbbb..."
+        macos-aarch64:  "sha256:cccc..."
+        windows-x86_64: "sha256:dddd..."
+  overrides:
+    macos-aarch64:
+      brew:
+        package: gh
+    linux-x86_64:
+      apt:
+        packages:
+          - gh
+
+depends_on: []
+
+validate:
+  commands:
+    - name: gh
+      version_flag: "--version"
+      expected_pattern: "gh version 2\\.67"
+
+capabilities:
+  hooks:
+    post_install:
+      - command: "gh --version"
+```
+
+---
+
+## Publishing to registry-core
+
+1. Create a directory under `v4/registry-core/components/<name>/`.
+2. Write `component.yaml` following this guide.
+3. Run the linter: `sindri registry lint v4/registry-core/components/<name>/component.yaml`.
+4. Add an entry to `v4/registry-core/index.yaml` with the component name, backend, latest version, license, and OCI reference.
+5. Open a PR. The CI workflow (`ci-v4.yml`) will re-run the linter and schema validation.
+6. After merge, the registry-core publish workflow (`registry-core-publish.yml`, see [ADR-016](architecture/adr/016-registry-tag-cadence.md)) creates a patch tag and cosign-signs the new OCI artifact (see [ADR-014](architecture/adr/014-signed-registries-cosign.md)).
+
+### OCI reference format
+
+```
+ghcr.io/sindri-dev/registry-core/<name>:<version>
+```
+
+For collections:
+
+```
+ghcr.io/sindri-dev/registry-core/collections/<name>:<version>
+```
+
+---
+
+## Common Lint Errors
+
+| Code | Cause | Fix |
+|------|-------|-----|
+| `LINT_EMPTY_PLATFORMS` | `platforms:` is an empty list | Add at least one platform entry |
+| `LINT_MISSING_LICENSE` | `metadata.license` is empty or missing | Add a valid SPDX identifier |
+| `LINT_MISSING_CHECKSUMS` | `binary` component has no checksums | Run `sindri registry fetch-checksums` |
+| `LINT_COLLISION_PREFIX` | `collision_handling.path_prefix` does not start with `{name}/` | Prefix must be `{component-name}/` |
+| `PARSE_ERROR` | YAML is malformed | Check indentation and quoting |
+
+Run `sindri registry lint --json` for machine-readable output in CI.

--- a/v4/docs/CLI.md
+++ b/v4/docs/CLI.md
@@ -1,0 +1,926 @@
+# Sindri v4 CLI Reference
+
+This document is the authoritative reference for every `sindri` command. It is aimed at developers and platform engineers who use Sindri to declare, resolve, and apply component environments. For a conceptual overview of the three-artifact model (`sindri.yaml` → `sindri.lock` → installed state) see [ADR-011](architecture/adr/011-full-imperative-verb-set.md). For exit code semantics used in CI pipelines see [ADR-012](architecture/adr/012-exit-code-contract.md).
+
+---
+
+## Exit Codes
+
+All verbs return one of the following codes. Codes are stable within a major version.
+
+| Code | Constant              | Meaning                                                         |
+|------|-----------------------|-----------------------------------------------------------------|
+| 0    | `SUCCESS`             | Operation completed successfully                                |
+| 1    | `ERROR`               | Generic error (I/O, network, unexpected panic)                  |
+| 2    | `POLICY_DENIED`       | One or more components denied by install policy                 |
+| 3    | `RESOLUTION_CONFLICT` | Dependency closure has an unresolvable conflict                 |
+| 4    | `SCHEMA_ERROR`        | `sindri.yaml` or `sindri.policy.yaml` failed schema validation  |
+| 5    | `STALE_LOCKFILE`      | `sindri.lock` is absent or does not match `sindri.yaml`         |
+
+Every verb that produces structured output supports `--json`. The exit code is always set independently of `--json`.
+
+---
+
+## Initialization and Lifecycle
+
+### `sindri init`
+
+**Synopsis**
+
+```
+sindri init [--template <name>] [--name <project>] [--policy <preset>]
+            [--non-interactive] [--force]
+```
+
+Writes `sindri.yaml` in the current directory and appends `.sindri/` to `.gitignore`. Prompts interactively unless `--non-interactive` is set. If `sindri.yaml` already exists, returns exit code 4 unless `--force` is given.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--template <name>` | Seed the manifest with a predefined component set. Built-in templates: `minimal` (default), `anthropic-dev` |
+| `--name <project>` | Override the project name (default: current directory name) |
+| `--policy <preset>` | Write a `sindri.policy.yaml` pre-configured to `default`, `strict`, or `offline` |
+| `--non-interactive` | Skip all prompts; use defaults |
+| `--force` | Overwrite an existing `sindri.yaml` |
+
+**Examples**
+
+```bash
+# Minimal init — one nodejs entry
+sindri init
+
+# Anthropic dev environment scaffold
+sindri init --template anthropic-dev --name my-ai-project
+
+# CI-safe init with strict policy, no prompts
+sindri init --policy strict --non-interactive
+```
+
+---
+
+### `sindri validate`
+
+**Synopsis**
+
+```
+sindri validate [<path>] [--online] [--json]
+```
+
+Validates `sindri.yaml` (or `<path>`) against the JSON Schema at [v4/schemas/bom.json](../schemas/bom.json) and runs constraint checks. `--online` additionally probes registry reachability. Returns exit code 4 on any schema or constraint failure.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `<path>` | Path to manifest (default: `sindri.yaml`) |
+| `--online` | Also verify registry URLs are reachable |
+| `--json` | Emit a JSON result object to stdout |
+
+**Examples**
+
+```bash
+sindri validate
+sindri validate --json | jq '.errors[]'
+sindri validate custom-path/sindri.yaml --online
+```
+
+---
+
+### `sindri resolve`
+
+**Synopsis**
+
+```
+sindri resolve [-m <manifest>] [--offline] [--refresh] [--strict]
+               [--explain <address>] [--target <name>]
+```
+
+Reads `sindri.yaml`, fetches registry indices (unless `--offline`), applies policy gates (see [ADR-008](architecture/adr/008-install-policy-subsystem.md)), and writes `sindri.lock` (or `sindri.<target>.lock` for non-local targets, per [ADR-018](architecture/adr/018-per-target-lockfiles.md)). Returns exit code 5 if the manifest is not found, exit code 2 if policy denies any component, exit code 3 if the dependency closure is unresolvable.
+
+**Options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-m, --manifest <path>` | `sindri.yaml` | Manifest file to resolve |
+| `--offline` | false | Use cached registry index only; do not fetch |
+| `--refresh` | false | Force refresh of registry index before resolving |
+| `--strict` | false | Apply the `strict` policy preset regardless of `sindri.policy.yaml` |
+| `--explain <address>` | — | Print the full admission trace for a component address |
+| `--target <name>` | `local` | Write to `sindri.<name>.lock` for the named target |
+
+**Examples**
+
+```bash
+sindri resolve
+sindri resolve --strict
+sindri resolve --explain mise:nodejs
+sindri resolve --target e2b-sandbox
+```
+
+---
+
+### `sindri plan`
+
+**Synopsis**
+
+```
+sindri plan [--target <name>] [--json]
+```
+
+Reads `sindri.lock` and prints what `sindri apply` would do, without making any changes. Returns exit code 5 if the lockfile is absent.
+
+**Options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target <name>` | `local` | Show plan for the given target's lockfile |
+| `--json` | false | Emit a JSON plan object |
+
+**Examples**
+
+```bash
+sindri plan
+sindri plan --json | jq '.plan[] | select(.action == "install")'
+```
+
+---
+
+### `sindri diff`
+
+**Synopsis**
+
+```
+sindri diff [--target <name>] [--json]
+```
+
+Shows divergences between `sindri.lock` and the currently-installed state on the target. Returns exit code 5 if no lockfile exists.
+
+**Options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target <name>` | `local` | Diff lockfile for the given target |
+| `--json` | false | Emit JSON array of divergences |
+
+**Examples**
+
+```bash
+sindri diff
+sindri diff --target e2b-sandbox --json
+```
+
+---
+
+### `sindri apply`
+
+**Synopsis**
+
+```
+sindri apply [--yes] [--dry-run] [--target <name>]
+```
+
+Executes the lockfile against the target following the eight-step pipeline defined in [ADR-024](architecture/adr/024-script-component-lifecycle-contract.md): collision validation → pre-install hooks → backend install → configure → validate → post-install hooks → project-init hooks → project-init steps. Prompts for confirmation unless `--yes` is set.
+
+Returns exit code 3 if any component install fails or if collision validation rejects the closure.
+
+**Options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--yes` | false | Skip confirmation prompt |
+| `--dry-run` | false | Print plan and exit without applying |
+| `--target <name>` | `local` | Apply to this target (only `local` is fully wired in Wave 2A; remote targets land in Wave 3) |
+
+**Examples**
+
+```bash
+sindri apply
+sindri apply --yes
+sindri apply --dry-run
+sindri apply --target e2b-sandbox --yes
+```
+
+---
+
+### `sindri edit`
+
+**Synopsis**
+
+```
+sindri edit
+```
+
+Opens `sindri.yaml` in `$EDITOR`. On save, runs `sindri validate` automatically. Aborts if validation fails without writing.
+
+**Examples**
+
+```bash
+EDITOR=vim sindri edit
+```
+
+---
+
+### `sindri rollback`
+
+**Synopsis**
+
+```
+sindri rollback <address>
+```
+
+Rolls one component back to its prior lockfile entry by consulting the StatusLedger (`~/.sindri/ledger.jsonl`). The lockfile is rewritten and `sindri apply` should be re-run.
+
+**Examples**
+
+```bash
+sindri rollback mise:nodejs
+```
+
+---
+
+### `sindri self-upgrade`
+
+**Synopsis**
+
+```
+sindri self-upgrade
+```
+
+Upgrades the `sindri` CLI binary itself. Distinct from `sindri upgrade`, which upgrades components listed in `sindri.yaml`.
+
+**Examples**
+
+```bash
+sindri self-upgrade
+```
+
+---
+
+### `sindri completions`
+
+**Synopsis**
+
+```
+sindri completions <shell>
+```
+
+Prints shell completion script for the given shell to stdout.
+
+**Options**
+
+| Argument | Description |
+|----------|-------------|
+| `<shell>` | One of: `bash`, `zsh`, `fish`, `powershell` |
+
+**Examples**
+
+```bash
+sindri completions bash >> ~/.bash_completion
+sindri completions zsh > ~/.zfunc/_sindri
+```
+
+---
+
+## Manifest Mutations
+
+All mutation verbs affect `sindri.yaml` only and accept `--dry-run` to preview changes without writing.
+
+### `sindri add`
+
+**Synopsis**
+
+```
+sindri add <address> [-m <manifest>] [--dry-run] [--apply]
+```
+
+Adds a component entry to `sindri.yaml`. `<address>` must be in `backend:name[@version]` format as defined in [ADR-004](architecture/adr/004-backend-addressed-manifest-syntax.md).
+
+**Options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `<address>` | required | Component address, e.g. `mise:nodejs@22.0.0` |
+| `-m, --manifest <path>` | `sindri.yaml` | Target manifest file |
+| `--dry-run` | false | Print the change without writing |
+| `--apply` | false | Print a hint to run `sindri resolve && sindri apply` |
+
+**Examples**
+
+```bash
+sindri add mise:nodejs
+sindri add npm:claude-code --dry-run
+sindri add binary:gh@2.67.0
+```
+
+---
+
+### `sindri remove`
+
+**Synopsis**
+
+```
+sindri remove <address> [-m <manifest>]
+```
+
+Removes a component from `sindri.yaml`. Warns if other listed components depend on the removed entry.
+
+**Examples**
+
+```bash
+sindri remove mise:nodejs
+```
+
+---
+
+### `sindri pin`
+
+**Synopsis**
+
+```
+sindri pin <address> <version> [-m <manifest>]
+```
+
+Pins `<address>` to an exact version by appending `@<version>` to the address in `sindri.yaml`.
+
+**Examples**
+
+```bash
+sindri pin mise:nodejs 22.11.0
+```
+
+---
+
+### `sindri unpin`
+
+**Synopsis**
+
+```
+sindri unpin <address> [-m <manifest>]
+```
+
+Removes the `@version` suffix, restoring the component to track the latest available version.
+
+**Examples**
+
+```bash
+sindri unpin mise:nodejs
+```
+
+---
+
+### `sindri upgrade`
+
+**Synopsis**
+
+```
+sindri upgrade [<address>] [--all] [--check] [-m <manifest>]
+```
+
+Bumps one or all component versions to the latest available version in the registry cache. `--check` is read-only.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `<address>` | Upgrade a single component by address |
+| `--all` | Upgrade every component |
+| `--check` | Print available upgrades without modifying `sindri.yaml` |
+| `-m, --manifest <path>` | Target manifest (default: `sindri.yaml`) |
+
+**Examples**
+
+```bash
+sindri upgrade mise:nodejs
+sindri upgrade --all
+sindri upgrade --check
+```
+
+---
+
+## Discovery
+
+### `sindri ls`
+
+**Synopsis**
+
+```
+sindri ls [--registry <name>] [--backend <name>] [--installed] [--outdated]
+          [--json] [--refresh]
+```
+
+Lists components from configured registries. Replaces `sindri extension list` from v3.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--registry <name>` | Filter by registry name |
+| `--backend <name>` | Filter by backend (e.g. `mise`, `npm`) |
+| `--installed` | Show only installed components |
+| `--outdated` | Show only components with newer versions available |
+| `--json` | JSON output |
+| `--refresh` | Fetch the latest registry index before listing |
+
+**Examples**
+
+```bash
+sindri ls
+sindri ls --backend mise
+sindri ls --outdated --json
+```
+
+---
+
+### `sindri search`
+
+**Synopsis**
+
+```
+sindri search <query> [--registry <name>] [--backend <name>] [--json]
+```
+
+Fuzzy-searches components by name, description, and tags.
+
+**Examples**
+
+```bash
+sindri search nodejs
+sindri search "cloud cli" --backend binary
+```
+
+---
+
+### `sindri show`
+
+**Synopsis**
+
+```
+sindri show <address> [--versions] [--json]
+```
+
+Shows detailed metadata for a single component, including description, license, latest version, OCI reference, and dependency list.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--versions` | Also list all available versions |
+| `--json` | JSON output |
+
+**Examples**
+
+```bash
+sindri show mise:nodejs
+sindri show binary:gh --versions --json
+```
+
+---
+
+### `sindri graph`
+
+**Synopsis**
+
+```
+sindri graph <address> [--format <fmt>] [--reverse]
+```
+
+Renders the dependency DAG for a component or collection.
+
+**Options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format <fmt>` | `text` | Output format: `text` or `mermaid` |
+| `--reverse` | false | Show reverse dependencies (what depends on this component) |
+
+**Examples**
+
+```bash
+sindri graph collection:anthropic-dev
+sindri graph mise:nodejs --format mermaid
+```
+
+---
+
+### `sindri explain`
+
+**Synopsis**
+
+```
+sindri explain <component> [--in <collection>]
+```
+
+Prints why a component is in the dependency graph, tracing the path from the root manifest entry to the component via `dependsOn` edges.
+
+**Examples**
+
+```bash
+sindri explain mise:nodejs
+sindri explain mise:nodejs --in collection:anthropic-dev
+```
+
+---
+
+### `sindri bom`
+
+**Synopsis**
+
+```
+sindri bom [--format <fmt>] [--target <name>] [-o <path>]
+```
+
+Generates a Software Bill of Materials (SBOM) from the resolved lockfile. Output defaults to `sindri.bom.spdx.json` (SPDX 2.3) or `sindri.bom.cdx.xml` (CycloneDX 1.6).
+
+**Options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format <fmt>` | `spdx` | Format: `spdx` (SPDX 2.3 JSON) or `cyclonedx` (CycloneDX 1.6 XML) |
+| `--target <name>` | `local` | Read lockfile for this target |
+| `-o, --output <path>` | auto | Override output file path |
+
+**Examples**
+
+```bash
+sindri bom
+sindri bom --format cyclonedx -o sbom.xml
+```
+
+---
+
+## Diagnostics
+
+### `sindri doctor`
+
+**Synopsis**
+
+```
+sindri doctor [--target <name>] [--fix] [--components]
+```
+
+Runs environment health checks: target prerequisites, shell configuration, registry cache state, policy validity, and backend binary availability.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--target <name>` | Run checks for this target (default: `local`) |
+| `--fix` | Attempt to auto-fix identified issues |
+| `--components` | Also check installed component state |
+
+**Exit Codes**
+
+Returns 0 if all checks pass; 4 if any check fails.
+
+**Examples**
+
+```bash
+sindri doctor
+sindri doctor --fix
+sindri doctor --target e2b-sandbox
+```
+
+---
+
+### `sindri log`
+
+**Synopsis**
+
+```
+sindri log [--last <n>] [--json]
+```
+
+Shows the StatusLedger (`~/.sindri/ledger.jsonl`) — a JSONL append-only audit log of all install, upgrade, and remove events.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--last <n>` | Show only the most recent `n` entries |
+| `--json` | Emit JSON array |
+
+**Examples**
+
+```bash
+sindri log
+sindri log --last 20 --json
+```
+
+---
+
+### `sindri ledger`
+
+**Synopsis**
+
+```
+sindri ledger compact | export | stats
+```
+
+StatusLedger maintenance subcommands.
+
+| Subcommand | Description |
+|------------|-------------|
+| `compact` | Deduplicate and compact ledger entries |
+| `export` | Export ledger to a file |
+| `stats` | Print aggregate statistics |
+
+---
+
+## Registry Management
+
+### `sindri registry refresh`
+
+**Synopsis**
+
+```
+sindri registry refresh <name> <url>
+```
+
+Fetches and caches the registry index from `<url>`. Accepts `registry:local:<path>` for local development registries or an HTTPS URL. On success, writes `~/.sindri/cache/registries/<name>/index.yaml`.
+
+**Examples**
+
+```bash
+sindri registry refresh core registry:local:./v4/registry-core
+sindri registry refresh myorg https://registries.example.com/myorg
+```
+
+---
+
+### `sindri registry lint`
+
+**Synopsis**
+
+```
+sindri registry lint <path> [--json]
+```
+
+Validates a `component.yaml` file or all `*.yaml` files in a directory against the component schema at [v4/schemas/component.json](../schemas/component.json). Checks include: non-empty `platforms`, valid SPDX `license`, checksums for `binary` components, and collision-handling path prefix rules.
+
+**Examples**
+
+```bash
+sindri registry lint ./registry-core/components/nodejs/component.yaml
+sindri registry lint ./registry-core/components/ --json
+```
+
+---
+
+### `sindri registry trust`
+
+**Synopsis**
+
+```
+sindri registry trust <name> --signer cosign:key=<path>
+```
+
+Copies a cosign P-256 SPKI PEM public key to `~/.sindri/trust/<name>/cosign-<key-id>.pub`. This key is used by `sindri registry refresh` to verify the registry's cosign signature. See [ADR-014](architecture/adr/014-signed-registries-cosign.md) for the full trust model.
+
+**Examples**
+
+```bash
+sindri registry trust core --signer cosign:key=./sindri-core.pub
+sindri registry trust acme --signer cosign:key=/path/to/acme-registry.pub
+```
+
+---
+
+### `sindri registry verify`
+
+**Synopsis**
+
+```
+sindri registry verify <name>
+```
+
+Verifies the cosign signature on the named registry's index against the stored trusted key. Note: live signature verification is deferred to Wave 3A.2; this subcommand currently exits non-zero with an explanatory message to prevent silent CI passes.
+
+---
+
+### `sindri registry fetch-checksums`
+
+**Synopsis**
+
+```
+sindri registry fetch-checksums <path>
+```
+
+Downloads binary assets declared in `<path>` (a `component.yaml`) and writes SHA-256 checksums to the file. Used by registry maintainers when publishing new component versions.
+
+---
+
+## Policy Management
+
+### `sindri policy use`
+
+**Synopsis**
+
+```
+sindri policy use <preset>
+```
+
+Sets the active policy preset globally in `~/.sindri/policy.yaml`. Valid presets: `default` (permissive), `strict` (pinned-only, signed, license allowlist), `offline`.
+
+**Examples**
+
+```bash
+sindri policy use strict
+sindri policy use default
+```
+
+---
+
+### `sindri policy show`
+
+**Synopsis**
+
+```
+sindri policy show
+```
+
+Prints the effective merged policy with source annotations (which file each field comes from).
+
+---
+
+### `sindri policy allow-license`
+
+**Synopsis**
+
+```
+sindri policy allow-license <spdx> [--reason <text>]
+```
+
+Appends an SPDX identifier to the global allow list. `--reason` is optional by default but required when `policy.audit.require_justification: true`.
+
+**Examples**
+
+```bash
+sindri policy allow-license MIT
+sindri policy allow-license BUSL-1.1 --reason "vendor contract SA-2342"
+```
+
+---
+
+## Preference
+
+### `sindri prefer`
+
+**Synopsis**
+
+```
+sindri prefer <os> <backend-order>
+```
+
+Sets the backend preference order for the given OS in `sindri.yaml`. This is the project-wide override in the backend selection chain (see [ADR-008](architecture/adr/008-install-policy-subsystem.md)).
+
+**Examples**
+
+```bash
+sindri prefer macos "brew,mise,binary"
+sindri prefer linux "apt,mise,binary,script"
+```
+
+---
+
+## Target Management
+
+See [TARGETS.md](TARGETS.md) for the full target abstraction reference. All `target` subcommands use the `Target` trait defined in [ADR-017](architecture/adr/017-rename-provider-to-target.md).
+
+### `sindri target add`
+
+```
+sindri target add <name> <kind>
+```
+
+Registers a named target in `sindri.yaml`. Available kinds: `local`, `docker`, `ssh`, `e2b`, `fly`, `kubernetes`.
+
+### `sindri target ls`
+
+```
+sindri target ls
+```
+
+Lists all configured targets. `local` is always present as the implicit default ([ADR-023](architecture/adr/023-implicit-local-default-target.md)).
+
+### `sindri target status`
+
+```
+sindri target status <name>
+```
+
+Shows platform and capabilities for the named target.
+
+### `sindri target create`
+
+```
+sindri target create <name>
+```
+
+Provisions the target resource (e.g., starts a Docker container or an E2B sandbox).
+
+### `sindri target destroy`
+
+```
+sindri target destroy <name>
+```
+
+Tears down the target resource.
+
+### `sindri target doctor`
+
+```
+sindri target doctor [<name>]
+```
+
+Runs prerequisite checks for the named target (default: `local`).
+
+### `sindri target shell`
+
+```
+sindri target shell <name>
+```
+
+Opens an interactive shell on the target.
+
+---
+
+## Secrets Management
+
+### `sindri secrets validate`
+
+```
+sindri secrets validate <id> [-m <manifest>]
+```
+
+Checks that the secret reference `<id>` in `sindri.yaml` resolves successfully without printing the value. Supported source kinds: `env:<VAR>`, `file:<path>`, `cli:<cmd>`, or a plain literal.
+
+### `sindri secrets list`
+
+```
+sindri secrets list [-m <manifest>] [--json]
+```
+
+Lists all secret IDs and their source kinds. Never prints secret values.
+
+### `sindri secrets test-vault`
+
+```
+sindri secrets test-vault
+```
+
+Probes for a reachable HashiCorp Vault (`vault status`) or AWS Secrets Manager (`aws secretsmanager list-secrets`).
+
+### `sindri secrets encode-file`
+
+```
+sindri secrets encode-file <path> [--algorithm <alg>] [-o <output>]
+```
+
+Encodes a file as `base64` or `sha256`. Useful for embedding small secrets or computing checksums.
+
+### `sindri secrets s3`
+
+```
+sindri secrets s3 get <key> --bucket <b>
+sindri secrets s3 put <key> <file> --bucket <b>
+sindri secrets s3 list --bucket <b> [--prefix <p>]
+```
+
+Convenience wrappers around `aws s3 cp` / `aws s3 ls` for S3-backed secrets storage.
+
+---
+
+## Backup and Restore
+
+### `sindri backup`
+
+```
+sindri backup [-o <path>] [--include-cache]
+```
+
+Creates a `tar.gz` archive of sindri state: project files (`sindri.yaml`, `sindri.policy.yaml`, all lockfiles), `~/.sindri/ledger.jsonl`, `~/.sindri/trust/`, `~/.sindri/plugins/`, `~/.sindri/history/`. The registry cache is excluded by default; add `--include-cache` to include it.
+
+The default filename is `sindri-backup-<timestamp>Z.tar.gz` in the current directory.
+
+**Examples**
+
+```bash
+sindri backup
+sindri backup -o /mnt/backups/ --include-cache
+```
+
+### `sindri restore`
+
+```
+sindri restore <archive> [--dry-run] [--force]
+```
+
+Extracts a backup archive. Refuses to overwrite existing files without `--force`. Rejects archives with absolute paths or `..` traversal entries. Project files restore to the current directory; `~/.sindri/` files restore to `$HOME/.sindri/`.
+
+**Examples**
+
+```bash
+sindri restore sindri-backup-20260427T120000Z.tar.gz --dry-run
+sindri restore sindri-backup-20260427T120000Z.tar.gz --force
+```

--- a/v4/docs/POLICY.md
+++ b/v4/docs/POLICY.md
@@ -1,0 +1,249 @@
+# Sindri v4 Policy Subsystem
+
+This document describes the install policy system: admission gates, license deduplication, capability execution controls, and the denylist/allowlist semantics. It is aimed at security engineers, platform teams, and developers who need to enforce compliance constraints on Sindri-managed environments.
+
+The design is documented in [ADR-008](architecture/adr/008-install-policy-subsystem.md). For a quick start, see [CLI.md — Policy Management](CLI.md#policy-management). The policy schema is at [`v4/schemas/policy.json`](../schemas/policy.json).
+
+---
+
+## Overview
+
+Sindri's policy subsystem is a first-class Rust crate (`sindri-policy`) that intercepts every `sindri resolve` and optionally every `sindri apply`. Policy is explicit, auditable, and version-controlled. There is no hidden enforcement; every denial produces a machine-readable code.
+
+The default preset (`default`) is fully permissive — suitable for personal or home-lab use. The `strict` preset enforces the security requirements expected of production or regulated environments.
+
+---
+
+## Policy File Hierarchy
+
+Policy is resolved by merging two files in order. Project-level settings override global defaults.
+
+```
+~/.sindri/policy.yaml           # user-global defaults
+./sindri.policy.yaml            # project-level overrides (merged on top)
+```
+
+Both files are optional. An absent file is treated as empty (all defaults apply).
+
+`sindri policy show` prints the effective merged policy with source annotations.
+
+### Example `sindri.policy.yaml`
+
+```yaml
+apiVersion: sindri.dev/v4
+kind: InstallPolicy
+
+preset: strict
+
+licenses:
+  allow:
+    - MIT
+    - Apache-2.0
+    - BSD-2-Clause
+    - BSD-3-Clause
+    - ISC
+    - MPL-2.0
+  deny:
+    - GPL-3.0-only
+    - AGPL-3.0-only
+    - BUSL-1.1
+  onUnknown: warn   # allow | warn | prompt | deny
+
+registries:
+  require_signed: true
+  trust:
+    - sindri/core
+    - acme/internal
+
+sources:
+  require_checksums: true
+  require_pinned_versions: true
+  allow_script_backend: prompt   # allow | warn | prompt | deny
+  allow_privileged: prompt
+
+network:
+  offline: false
+
+capabilities:
+  trust_sources:
+    collision_handling:
+      - sindri/core
+    project_init:
+      - sindri/core
+      - acme/internal
+    mcp_registration: "*"
+    shell_rc_edits:
+      - sindri/core
+      - acme/internal
+
+audit:
+  require_justification: false
+```
+
+---
+
+## The Four Admission Gates
+
+Every `sindri resolve` runs all four gates in order. A failure at any gate prevents the component (and any component that depends on it) from entering the lockfile.
+
+```mermaid
+flowchart TD
+    A[Component from registry] --> G1{Gate 1\nPlatform eligibility}
+    G1 -->|FAIL: ADM_PLATFORM_UNSUPPORTED| DENY[Denied — exit 2]
+    G1 -->|PASS| G2{Gate 2\nPolicy eligibility}
+    G2 -->|FAIL: ADM_LICENSE_DENIED\nADM_UNSIGNED_REGISTRY\nADM_PRIVILEGED_DENIED| DENY
+    G2 -->|PASS| G3{Gate 3\nDependency closure}
+    G3 -->|FAIL: transitive dependency denied| DENY
+    G3 -->|PASS| G4{Gate 4\nCapability trust}
+    G4 -->|FAIL: untrusted collision_handling\nor project_init source| DENY
+    G4 -->|PASS| ADMIT[Admitted — written to sindri.lock]
+```
+
+### Gate 1 — Platform Eligibility
+
+The component's `platforms:` list is intersected with the current `TargetProfile` (OS + architecture). If the current platform is not in the list, resolution fails with `ADM_PLATFORM_UNSUPPORTED`.
+
+This gate is always enforced regardless of policy preset.
+
+```
+DENIED (1)
+  apt:docker-ce  ADM_PLATFORM_UNSUPPORTED: no platform entry for macos-aarch64
+                 → add macos-aarch64 to apt:docker-ce platforms: or use an override
+```
+
+### Gate 2 — Policy Eligibility
+
+The resolved merged policy (global + project) is evaluated. Denial codes:
+
+| Code | Trigger |
+|------|---------|
+| `ADM_LICENSE_DENIED` | Component license is in `licenses.deny`, or strict mode and not in `licenses.allow` |
+| `ADM_LICENSE_UNKNOWN` | `metadata.license` is empty and `onUnknown: deny` |
+| `ADM_UNSIGNED_REGISTRY` | `registries.require_signed: true` and registry has no trusted key |
+| `ADM_PRIVILEGED_DENIED` | Component requires elevated privileges and `sources.allow_privileged: deny` |
+| `ADM_SCRIPT_DENIED` | Component uses `script` backend and `sources.allow_script_backend: deny` |
+| `ADM_CHECKSUM_MISSING` | `sources.require_checksums: true` and binary component has no checksums |
+
+### Gate 3 — Dependency Closure
+
+Every transitive dependency via `dependsOn` edges must pass gates 1 and 2. If any dependency in the closure is denied, the entire closure fails. `sindri resolve` shows the full dependency path:
+
+```
+DENIED (1)
+  collection:jvm  ADM_LICENSE_DENIED via transitive dependency:
+    collection:jvm → sdkman:groovy → license=Apache-2.0 ← allowed
+    collection:jvm → sdkman:java   → license=GPL-2.0-CE ← DENIED
+    → to allow: add GPL-2.0-CE to policy.licenses.allow
+```
+
+### Gate 4 — Capability Trust
+
+Components that declare `capabilities.collision_handling` or `capabilities.project_init` from third-party registries are checked against `policy.capabilities.trust_sources`. Untrusted sources are denied (or downgraded to a warning) per policy.
+
+**Collision handling path prefix rule:** `collision_handling.path_prefix` must start with `{component-name}/`. This prevents a component from claiming collision ownership over paths it does not own. Components in `sindri/core` may additionally use `:shared` for cross-component shared paths. See [ADR-008](architecture/adr/008-install-policy-subsystem.md) and the lint error `LINT_COLLISION_PREFIX`.
+
+---
+
+## License Deduplication
+
+When multiple components in the closure declare the same license, the policy engine deduplicates before evaluating `licenses.allow` / `licenses.deny`. A single allow-list entry covers every component with that license.
+
+`sindri resolve` prints a structured admission report:
+
+```
+ADMITTED (12)
+  mise:nodejs@22.0.0     license=MIT, signed by sindri/core
+  npm:claude-code@1.0.0  license=MIT, signed by sindri/core
+  binary:gh@2.67.0       license=MIT, signed by sindri/core
+  mise:python@3.14.0     license=PSF-2.0, signed by sindri/core
+  ...
+
+DENIED (2)
+  vendor/closed:foo@1.0.0  license=proprietary (policy: licenses.deny)
+                            → to allow: sindri policy allow-license proprietary
+                              or add to sindri.policy.yaml licenses.allow
+  apt:docker-ce            ADM_PLATFORM_UNSUPPORTED: macos-aarch64 not in platforms
+```
+
+---
+
+## Capability Execution Controls
+
+The `capabilities:` block in `sindri.policy.yaml` controls which registries are trusted to execute each capability type at apply time.
+
+| Capability | Default trusted sources | Description |
+|------------|-------------------------|-------------|
+| `collision_handling` | `sindri/core` | Registries trusted to declare path-prefix collision rules |
+| `project_init` | `sindri/core` | Registries trusted to run project-init steps post-install |
+| `mcp_registration` | `*` (any) | Registries trusted to register MCP servers |
+| `shell_rc_edits` | `sindri/core` | Registries trusted to edit shell RC files |
+
+Setting a source list to `"*"` (string) trusts any registry. Setting to an empty list `[]` denies all third-party sources for that capability.
+
+---
+
+## Denylist and Allowlist Semantics
+
+The evaluation order is:
+
+1. `licenses.deny` is checked first. An explicit deny always wins.
+2. In `strict` preset, `licenses.allow` is an allowlist — only listed licenses pass. Any unlisted license is denied with `ADM_LICENSE_DENIED`.
+3. In `default` preset, `licenses.allow` is a hint (not enforced). Any license not in `deny` passes.
+4. Unknown licenses (empty `metadata.license`) are handled by `onUnknown`: `allow`, `warn` (default), `prompt`, or `deny`.
+
+```bash
+# Add a license to the global allow list
+sindri policy allow-license BUSL-1.1 --reason "vendor contract SA-2342"
+
+# View effective policy
+sindri policy show
+```
+
+---
+
+## Policy Presets
+
+Three named presets are available:
+
+| Preset | Description |
+|--------|-------------|
+| `default` | Permissive. No license restrictions. `onUnknown: warn`. Signing not required. Suitable for personal use. |
+| `strict` | Pinned versions required. Registries must be signed. `onUnknown: deny`. Only allow-listed licenses pass. `allow_script_backend: prompt`. |
+| `offline` | All network access disabled (`network.offline: true`). Extends `strict`. |
+
+```bash
+sindri policy use strict    # sets ~/.sindri/policy.yaml preset: strict
+sindri policy use default   # reverts to permissive
+sindri init --policy strict # init with strict policy baked into the project
+```
+
+---
+
+## Forced Overrides and Audit Trail
+
+Policy overrides are allowed but every override is appended to the StatusLedger (`~/.sindri/ledger.jsonl`) with timestamp, user, and optional reason.
+
+When `policy.audit.require_justification: true`, the `--reason` flag is mandatory for overrides:
+
+```bash
+sindri resolve --allow-license proprietary --reason "vendor contract SA-2342"
+```
+
+Ledger entries are viewable with:
+
+```bash
+sindri log --json | jq '.[] | select(.event_type == "policy_override")'
+```
+
+---
+
+## Gate Implementation Status
+
+| Gate | Status | Reference |
+|------|--------|-----------|
+| Gate 1 — Platform eligibility | Implemented | [ADR-008](architecture/adr/008-install-policy-subsystem.md), [PR #205](https://github.com/pacphi/sindri/pull/205) |
+| Gate 2 — Policy eligibility | Implemented (license check in `sindri-policy::check`) | [ADR-008](architecture/adr/008-install-policy-subsystem.md) |
+| Gate 3 — Dependency closure | Implemented (topological DAG in resolver) | [ADR-008](architecture/adr/008-install-policy-subsystem.md) |
+| Gate 4 — Capability trust | Implemented (collision path prefix enforced in `registry lint`) | [ADR-008](architecture/adr/008-install-policy-subsystem.md) |
+
+Full script sandboxing (Landlock/Seatbelt/AppContainer) and SLSA L3+ attestation chains are deferred beyond v4.0.

--- a/v4/docs/REGISTRY.md
+++ b/v4/docs/REGISTRY.md
@@ -1,0 +1,280 @@
+# Sindri v4 Registry
+
+This document covers the OCI registry design, cosign verification flow, the publish workflow, and sequence diagrams for the two critical runtime operations: `resolve` and `apply`. It is aimed at registry maintainers and platform engineers who need to operate or mirror a Sindri registry. Component authors who only want to write manifests should start with [AUTHORING.md](AUTHORING.md).
+
+Design decisions are documented in [ADR-003](architecture/adr/003-oci-only-registry-distribution.md) (OCI-only transport), [ADR-014](architecture/adr/014-signed-registries-cosign.md) (cosign signing), and [ADR-016](architecture/adr/016-registry-tag-cadence.md) (tag cadence).
+
+---
+
+## Why OCI
+
+Sindri v4 uses OCI as the only production registry transport. The key properties that motivated this choice (over git) are:
+
+- **Content-addressability** — every artifact layer is identified by its SHA-256 digest. Two machines pulling the same digest get identical bits.
+- **Immutable tags** — monthly and patch tags are never re-pushed; OCI registries enforce this.
+- **Native signing** — cosign attaches signatures to the manifest digest; no GPG key management or webhook setup needed.
+- **Corporate mirrors** — any OCI-compliant registry (GHCR, ECR, Harbor, Artifactory) is a valid Sindri registry mirror.
+- **Offline support** — OCI layout spec (`oci://path/to/dir`) provides a standard local cache format.
+
+See [ADR-003](architecture/adr/003-oci-only-registry-distribution.md) for the full analysis.
+
+---
+
+## Artifact Structure
+
+The canonical registry is `oci://ghcr.io/sindri-dev/registry-core:<tag>`. Its OCI artifact contains a single tarball layer with the following layout:
+
+```
+registry-core:<tag>/
+├── manifest.json               (OCI artifact manifest)
+├── signatures/                 (cosign signature objects)
+└── layers/ (tarball):
+    ├── index.yaml              (lightweight catalog, one entry per component)
+    ├── components/             (atomic components — one directory per tool)
+    │   ├── nodejs/
+    │   │   └── component.yaml
+    │   ├── python/
+    │   │   └── component.yaml
+    │   └── gh/
+    │       └── component.yaml
+    ├── collections/            (meta-components, sibling of components/)
+    │   └── anthropic-dev/
+    │       └── component.yaml
+    └── checksums/
+        └── sha256sums
+```
+
+Component directories use the **simple name** from `metadata.name` — no backend prefix. The backend is encoded in the `install:` block of `component.yaml` and in the `backend` field of `index.yaml`.
+
+The disk layout mirrors this structure at [`v4/registry-core/`](../registry-core/).
+
+---
+
+## `index.yaml` Format
+
+`index.yaml` is the lightweight catalog that `sindri resolve` reads without unpacking individual component manifests. Each entry contains enough information for resolution and policy gate 1 (platform) and gate 2 (policy).
+
+```yaml
+apiVersion: sindri.dev/v4
+kind: RegistryIndex
+components:
+  - name: nodejs
+    backend: mise
+    latest: "22.0.0"
+    versions:
+      - "22.0.0"
+      - "20.17.0"
+    license: MIT
+    description: "Node.js JavaScript runtime via mise"
+    oci_ref: "ghcr.io/sindri-dev/registry-core/nodejs:22.0.0"
+    digest: "sha256:abc123..."
+    depends_on: []
+    tags:
+      - runtime
+      - javascript
+```
+
+The `digest` field is the SHA-256 of the `component.yaml` blob. `sindri resolve` verifies each blob against this digest before using it.
+
+---
+
+## Tag Semantics ([ADR-016](architecture/adr/016-registry-tag-cadence.md))
+
+| Tag pattern | Semantics | Mutable? |
+|-------------|-----------|----------|
+| `YYYY.MM` | Monthly tag (cut on the 1st) | **Immutable** — never re-pushed |
+| `YYYY.MM.N` | Patch tag for additions between monthlies | Immutable |
+| `:latest` | Rolling pointer — tracks newest immutable patch tag | Yes (pointer only) |
+| `:stable` | Rolling pointer — tracks blessed-stable | Yes (pointer only) |
+
+Users pin their registries to a tag in `sindri.yaml`:
+
+```yaml
+registries:
+  - name: core
+    url: oci://ghcr.io/sindri-dev/registry-core:2026.04
+```
+
+A pin to `:2026.04` resolves to the latest patch tag under that monthly (e.g., `:2026.04.3`) at resolve time. The resolved digest is captured in `sindri.lock` regardless of which pointer was used, guaranteeing reproducibility.
+
+---
+
+## Cosign Verification Flow ([ADR-014](architecture/adr/014-signed-registries-cosign.md))
+
+### Trust model
+
+| Source | Trust level |
+|--------|-------------|
+| `sindri/core` (published by sindri-dev) | Always trusted — hardcoded public key in the CLI binary |
+| User-added registries | Must explicitly `sindri registry trust <name> --signer cosign:key=<path>` |
+| Registries added with `--no-verify` | Added without signature; logged as unverified in the StatusLedger; surfaced as a warning at resolve time |
+
+Sindri enforces **three independent integrity checks**, each at a distinct layer boundary:
+
+1. `sindri registry refresh` — verifies the cosign signature on the OCI manifest before writing the index to cache. Failure aborts with the stale index left in place (fail-closed, not fail-open).
+2. `sindri resolve` — verifies each `component.yaml` blob's SHA-256 digest against the digest declared in `index.yaml`. Any mismatch is a hard error.
+3. `sindri apply` — verifies downloaded binary artifacts against the checksums declared in `component.yaml` before executing them.
+
+### Registering a trusted key
+
+```bash
+# Trust a cosign P-256 SPKI PEM public key for registry "acme"
+sindri registry trust acme --signer cosign:key=./acme-registry-signing.pub
+```
+
+The key is validated as a P-256 SPKI PEM and stored at `~/.sindri/trust/acme/cosign-<key-id>.pub`.
+
+### Keyless OIDC
+
+Keyless OIDC signing (Sigstore Fulcio + Rekor transparency log) is architecturally supported by the cosign integration but is **deferred** to a future wave. Today only key-based signing is active.
+
+---
+
+## Publish Workflow ([ADR-016](architecture/adr/016-registry-tag-cadence.md))
+
+The CI workflow at `.github/workflows/registry-core-publish.yml` (on `main` branch) drives the monthly and patch publish process. The pipeline steps are:
+
+1. Validate all `component.yaml` files with `sindri registry lint`.
+2. Build the tarball layer from `v4/registry-core/`.
+3. Push the OCI artifact with `oras push`.
+4. Sign the manifest digest with `cosign sign`.
+5. Update the rolling `:latest` and `:stable` pointers.
+6. Create a GitHub release entry for the new tag.
+
+Tag immutability is enforced by the workflow: it calls `oras manifest fetch` before push and fails if the tag already exists.
+
+---
+
+## Resolve Flow Sequence
+
+The following diagram shows what happens when a user runs `sindri resolve`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as sindri CLI
+    participant Cache as ~/.sindri/cache
+    participant Registry as OCI Registry (GHCR)
+
+    User->>CLI: sindri resolve
+    CLI->>Cache: check index.yaml TTL
+    alt cache stale or --refresh
+        CLI->>Registry: oras pull index.yaml layer
+        Registry-->>CLI: index.yaml + OCI manifest digest
+        CLI->>CLI: verify cosign signature on manifest digest
+        CLI->>Cache: write index.yaml (atomic rename)
+    end
+    CLI->>Cache: load index.yaml
+    CLI->>CLI: Gate 1 — platform eligibility check (platforms: vs TargetProfile)
+    CLI->>CLI: Gate 2 — policy check (license, signed, checksums)
+    CLI->>CLI: Gate 3 — build dependency closure (dependsOn DAG)
+    CLI->>CLI: Gate 4 — capability trust (collision_handling, project_init)
+    alt any gate fails
+        CLI-->>User: exit 2 (POLICY_DENIED) or exit 3 (RESOLUTION_CONFLICT)
+    else all gates pass
+        loop per component
+            CLI->>Cache: verify component.yaml blob vs declared digest
+        end
+        CLI->>CLI: write sindri.lock (JSON, per-target)
+        CLI-->>User: Resolved N component(s) → sindri.lock (exit 0)
+    end
+```
+
+---
+
+## Apply Flow Sequence
+
+The following diagram shows what happens when a user runs `sindri apply`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as sindri CLI
+    participant Target as Install Target (local/cloud)
+    participant Backends as Install Backends (mise/npm/binary/…)
+
+    User->>CLI: sindri apply
+    CLI->>CLI: load sindri.lock
+    CLI->>CLI: verify sindri.yaml hash matches lockfile (stale check)
+    CLI->>CLI: CollisionResolver.validate_and_resolve(closure)
+    alt collision validation fails
+        CLI-->>User: exit 3 (RESOLUTION_CONFLICT)
+    end
+    CLI-->>User: print plan, prompt [y/N]
+    User->>CLI: y
+    loop per component (in topological order)
+        CLI->>Target: run pre_install hook
+        CLI->>Backends: install component (mise install / npm install / binary download…)
+        Backends->>CLI: verify binary checksum
+        CLI->>Target: configure (environment variables, shell-rc edits)
+        CLI->>Target: validate (run validate.commands)
+        CLI->>Target: run post_install hook
+    end
+    loop per component with project_init (in priority order)
+        CLI->>Target: run pre_project_init hook
+        CLI->>Target: ProjectInitExecutor.run(steps)
+        CLI->>Target: run post_project_init hook
+    end
+    CLI->>CLI: append events to ~/.sindri/ledger.jsonl
+    CLI-->>User: Applied N component(s) successfully (exit 0)
+```
+
+---
+
+## Local Development Registry
+
+Component authors can work against a local registry without pushing to GHCR:
+
+```bash
+# In sindri.yaml, use the local protocol
+registries:
+  - name: dev
+    url: registry:local:./v4/registry-core
+
+# Refresh the local index into cache
+sindri registry refresh dev registry:local:./v4/registry-core
+
+# Resolve against the local registry
+sindri resolve
+```
+
+The `registry:local:<path>` loader reads `<path>/index.yaml` directly and skips cosign verification (no OCI manifest to sign). Lint validation still runs.
+
+---
+
+## Air-Gapped / Offline Mirroring
+
+Full air-gapped spec is deferred to v4.1, but the mechanism is standard OCI:
+
+```bash
+# Mirror from GHCR to a private registry
+skopeo copy \
+  oci://ghcr.io/sindri-dev/registry-core:2026.04 \
+  oci://my-host/sindri/registry-core:2026.04
+
+# Point your sindri.yaml at the mirror
+registries:
+  - name: core
+    url: oci://my-host/sindri/registry-core:2026.04
+```
+
+`sindri resolve --offline` uses the cached index and fails loudly if the cache is stale (exit code 5).
+
+---
+
+## Corporate / Private Registries
+
+OCI auth follows the standard Docker credential store (`~/.docker/config.json` or the platform keychain). No separate credential mechanism is needed:
+
+```bash
+# Authenticate with your OCI registry (e.g., GitHub PAT)
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u $GITHUB_USER --password-stdin
+
+# Add the private registry to sindri.yaml
+registries:
+  - name: acme-internal
+    url: oci://ghcr.io/acme-org/sindri-registry:stable
+
+# Trust the registry's signing key
+sindri registry trust acme-internal --signer cosign:key=./acme-public.pub
+```

--- a/v4/docs/TARGETS.md
+++ b/v4/docs/TARGETS.md
@@ -1,0 +1,299 @@
+# Sindri v4 Targets
+
+This document explains the target abstraction, describes each built-in target kind, covers the plugin protocol for extending Sindri with community targets, and lists all `sindri target` subverbs. It is aimed at developers who need to provision components on non-local environments and platform engineers who want to write custom target plugins.
+
+The target system is defined in [ADR-017](architecture/adr/017-rename-provider-to-target.md) (Provider → Target rename and `TargetProfile` trait), [ADR-018](architecture/adr/018-per-target-lockfiles.md) (per-target lockfiles), [ADR-019](architecture/adr/019-subprocess-json-target-plugins.md) (plugin protocol), and [ADR-023](architecture/adr/023-implicit-local-default-target.md) (local as the implicit default).
+
+---
+
+## What Is a Target?
+
+A target represents an execution environment where components are installed. Every Sindri operation that touches installed state — `apply`, `diff`, `doctor`, `status`, `shell` — addresses a named target.
+
+In v3, "where to install" was an implicit mode (local host) or a provider-specific concept. v4 makes targets explicit and first-class so that the same `sindri.yaml` and workflow applies identically regardless of where components end up.
+
+The `Target` trait (in `sindri-targets`) defines the runtime contract:
+
+```rust
+pub trait Target: Send + Sync {
+    fn name(&self) -> &str;
+    fn kind(&self) -> &str;
+    fn profile(&self) -> Result<TargetProfile, TargetError>;
+    fn exec(&self, cmd: &str, env: &[(&str, &str)]) -> Result<(String, String), TargetError>;
+    fn upload(&self, local: &Path, remote: &str) -> Result<(), TargetError>;
+    fn download(&self, remote: &str, local: &Path) -> Result<(), TargetError>;
+    fn create(&self) -> Result<(), TargetError>;
+    fn destroy(&self) -> Result<(), TargetError>;
+    fn check_prerequisites(&self) -> Vec<PrereqCheck>;
+}
+```
+
+`TargetProfile` carries the OS, architecture, and capabilities (system package manager, Docker availability, sudo, shell path) that the resolver uses to intersect with each component's `platforms:` list and to drive backend selection. Different targets from the same `sindri.yaml` produce different lockfiles ([ADR-018](architecture/adr/018-per-target-lockfiles.md)).
+
+---
+
+## The Three-Artifact Model Per Target
+
+```
+sindri.yaml  →  sindri.<target>.lock  →  installed state on <target>
+```
+
+For the `local` target, the lockfile is simply `sindri.lock`. For any other target `<name>`, it is `sindri.<name>.lock`. Both formats are identical JSON; only the filename differs.
+
+```bash
+sindri resolve --target e2b-sandbox   # writes sindri.e2b-sandbox.lock
+sindri apply --target e2b-sandbox     # reads sindri.e2b-sandbox.lock
+sindri diff --target e2b-sandbox
+```
+
+---
+
+## Built-In Target Kinds
+
+### `local`
+
+The host machine. Always present as the implicit default ([ADR-023](architecture/adr/023-implicit-local-default-target.md)). `sindri apply` without `--target` uses `local`.
+
+**Status:** Fully wired (Wave 2A). The complete apply pipeline including hooks, configure, validate, and project-init steps runs on `local`.
+
+**Prerequisites:** None beyond the host shell.
+
+```yaml
+# sindri.yaml (local is implicit; no targets: block needed)
+components:
+  mise:nodejs: "22.0.0"
+```
+
+```bash
+sindri apply
+sindri target status local
+sindri target doctor
+```
+
+---
+
+### `docker`
+
+A Docker container provisioned from a specified base image. Useful for isolated, reproducible environments that mirror a CI or production container.
+
+**Status:** Struct and trait scaffolding complete (Sprint 9/10). Full API integration is Sprint 10 hardening work.
+
+**Prerequisites:** `docker` binary on PATH.
+
+```yaml
+targets:
+  ci-container:
+    kind: docker
+    image: ubuntu:24.04
+```
+
+```bash
+sindri target add ci-container docker
+sindri target create ci-container   # starts container
+sindri apply --target ci-container
+sindri target shell ci-container    # opens bash inside container
+sindri target destroy ci-container  # removes container
+```
+
+---
+
+### `ssh`
+
+A remote host reachable over SSH. Sindri executes commands via `ssh` and transfers files with `scp`/`sftp`.
+
+**Status:** Struct scaffolded (Sprint 9). Full `exec` and `upload`/`download` wiring is Sprint 10.
+
+**Prerequisites:** `ssh` binary on PATH; an SSH key with access to the remote host.
+
+```yaml
+targets:
+  dev-server:
+    kind: ssh
+    host: dev.example.com
+    user: ubuntu
+    key: ~/.ssh/id_ed25519
+```
+
+```bash
+sindri target add dev-server ssh
+sindri apply --target dev-server
+sindri target shell dev-server
+```
+
+---
+
+### `e2b`
+
+An E2B cloud sandbox (ephemeral micro-VM). Commands are executed via the E2B CLI (`e2b sandbox exec`).
+
+**Status:** Struct and trait implementation complete (Sprint 10). HTTP API wiring (Wave 5B) will replace CLI delegation for sub-50ms exec round-trips.
+
+**Prerequisites:** `npm install -g @e2b/cli` and `e2b auth login`.
+
+**TargetProfile:** `linux/x86_64`, `apt-get` package manager, no Docker, sudo available.
+
+```yaml
+targets:
+  sandbox:
+    kind: e2b
+    template: base-ubuntu-24-04
+```
+
+```bash
+sindri target add sandbox e2b
+sindri target create sandbox
+sindri resolve --target sandbox
+sindri apply --target sandbox
+sindri target shell sandbox
+sindri target destroy sandbox
+```
+
+---
+
+### `fly`
+
+A Fly.io application. Commands are executed via `flyctl ssh console --app <name> --command`.
+
+**Status:** Struct and trait implementation complete (Sprint 10). HTTP wiring (Wave 5B) in flight.
+
+**Prerequisites:** `flyctl` on PATH and authenticated.
+
+**TargetProfile:** `linux/x86_64`, default Capabilities.
+
+```yaml
+targets:
+  fly-app:
+    kind: fly
+    app: my-sindri-app
+    region: lax
+```
+
+```bash
+sindri target add fly-app fly
+sindri target create fly-app   # creates the Fly app via flyctl
+sindri apply --target fly-app
+```
+
+---
+
+### `kubernetes`
+
+A Kubernetes pod reachable via `kubectl exec`. File transfers use `kubectl cp`.
+
+**Status:** Struct and trait implementation complete (Sprint 10). Namespace and pod-name wiring is configurable.
+
+**Prerequisites:** `kubectl` on PATH and configured with cluster access.
+
+**TargetProfile:** `linux/x86_64`, default Capabilities.
+
+```yaml
+targets:
+  k8s-pod:
+    kind: kubernetes
+    namespace: sindri
+    pod: sindri-worker-0
+```
+
+```bash
+sindri target add k8s-pod kubernetes
+sindri apply --target k8s-pod
+sindri target shell k8s-pod
+```
+
+---
+
+### `runpod` (Wave 5B — HTTP wiring in flight)
+
+A RunPod serverless GPU pod. The RunPod REST API is used for pod lifecycle; commands execute via the RunPod SSH relay.
+
+**Status:** Struct scaffolded. HTTP API wiring is tracked as Wave 5B work.
+
+---
+
+### `northflank` (Wave 5B — HTTP wiring in flight)
+
+A Northflank service or job. Commands delegate to the Northflank API.
+
+**Status:** Struct scaffolded. HTTP API wiring is tracked as Wave 5B work.
+
+---
+
+## Target Plugin Protocol ([ADR-019](architecture/adr/019-subprocess-json-target-plugins.md))
+
+Sindri supports community-authored target plugins using a subprocess-JSON protocol — the same pattern used by `terraform-provider-*`, `kubectl` plugins, and `gh` extensions.
+
+### Plugin binary convention
+
+A plugin is a binary named `sindri-target-<name>` on `$PATH`. Sindri discovers plugins at startup by searching `$PATH` for binaries matching `sindri-target-*`.
+
+### Protocol
+
+The CLI sends JSON requests to the plugin's stdin and reads JSON responses from its stdout.
+
+**Request examples:**
+
+```json
+{"method": "profile", "params": {}, "sindri_protocol_version": "v4"}
+{"method": "plan",   "params": {"lock": {"target": "modal", "components": [...]}}}
+{"method": "create", "params": {"infra": {"name": "my-pod"}}}
+{"method": "exec",   "params": {"cmd": "node --version", "cwd": "/workspace"}}
+```
+
+**Response examples:**
+
+```json
+{"result": {"os": "linux", "arch": "x86_64", "capabilities": {"system_package_manager": "apt-get", "has_docker": false}}}
+{"result": {"actions": [{"action": "install", "component": "mise:nodejs", "version": "22.0.0"}]}}
+{"result": {"status": "created", "details": {"pod_id": "abc123"}}}
+{"result": {"stdout": "v22.0.0", "stderr": "", "exit_code": 0}}
+{"error":  {"code": "PREREQ_MISSING", "message": "modal CLI not found on PATH"}}
+```
+
+The `"sindri_protocol_version": "v4"` field is included in every request. The CLI rejects plugins with incompatible protocol versions.
+
+### Installing a community plugin
+
+```bash
+sindri target plugin install oci://ghcr.io/myorg/sindri-target-modal:1.0
+# Downloads binary, places in ~/.sindri/bin/sindri-target-modal, adds to PATH
+
+sindri target plugin trust modal --signer cosign:key=./modal-signing.pub
+# Records the cosign signature; unsigned plugins require --no-verify (logged)
+```
+
+### Security model
+
+Plugins run as the user. There is no additional sandboxing in v4.0 (WASM isolation is deferred to v4.1). The subprocess protocol does not expose Sindri's internal state beyond what is passed in `params`.
+
+---
+
+## `sindri target` Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `target add <name> <kind>` | Register a named target in `sindri.yaml` |
+| `target ls` | List all configured targets |
+| `target status <name>` | Show platform and capabilities (from `TargetProfile`) |
+| `target create <name>` | Provision the target resource |
+| `target destroy <name>` | Tear down the target resource |
+| `target doctor [<name>]` | Run prerequisite checks (default: `local`) |
+| `target shell <name>` | Open an interactive shell on the target |
+
+See [CLI.md](CLI.md) for full option flags.
+
+---
+
+## Target Capability Matrix
+
+| Target | Platform | System PM | Docker | Sudo | Full apply | Wave |
+|--------|----------|-----------|--------|------|------------|------|
+| `local` | host | host | host | host | Yes | 2A |
+| `docker` | linux/x86_64 | apt | Yes | Yes | Partial | 3 |
+| `ssh` | configurable | configurable | configurable | configurable | Partial | 3 |
+| `e2b` | linux/x86_64 | apt-get | No | Yes | Partial | 5B |
+| `fly` | linux/x86_64 | default | default | default | Partial | 5B |
+| `kubernetes` | linux/x86_64 | default | default | default | Partial | 5B |
+| `runpod` | linux/x86_64 | apt | Yes | Yes | Scaffold | 5B |
+| `northflank` | linux/x86_64 | apt | No | No | Scaffold | 5B |
+
+"Partial" means struct and trait complete; full end-to-end HTTP or exec wiring is in progress.


### PR DESCRIPTION
## Summary

- Closes audit deferred item **D20** — the v4 documentation set was absent from the repository.
- Creates five new Markdown docs under `v4/docs/` derived entirely from the actual codebase (clap definitions, ADRs, Rust source) — no invented or training-data content.
- No Rust, workflow, schema, or extension files are touched.

## Documents Added

| File | Word Count | Description |
|------|-----------|-------------|
| `v4/docs/CLI.md` | ~2 826 | Full command reference for every verb and flag; exit code table; secrets + backup commands from Sprint 12 |
| `v4/docs/AUTHORING.md` | ~1 180 | Component manifest authoring guide with worked example and lint error table |
| `v4/docs/REGISTRY.md` | ~1 348 | OCI layout, cosign verification, tag cadence, publish workflow, resolve+apply mermaid sequence diagrams |
| `v4/docs/TARGETS.md` | ~1 363 | Target abstraction, per-target lockfiles, built-in kinds, plugin protocol, capability matrix |
| `v4/docs/POLICY.md` | ~1 202 | Four-gate admission flow (mermaid), license dedup, denylist/allowlist semantics, capability trust, gate status |
| **Total** | **~7 919** | |

## ADRs Cross-Linked

| ADR | Topic | Docs |
|-----|-------|------|
| ADR-002 | Atomic Component Unit | AUTHORING |
| ADR-003 | OCI-Only Registry Distribution | REGISTRY, AUTHORING |
| ADR-004 | Backend-Addressed Manifest Syntax | CLI, AUTHORING |
| ADR-008 | Install Policy Subsystem | CLI, AUTHORING, POLICY |
| ADR-009 | Cross-Platform Backend Coverage | AUTHORING |
| ADR-011 | Full Imperative Verb Set | CLI |
| ADR-012 | Exit-Code Contract | CLI |
| ADR-014 | Signed Registries (cosign) | REGISTRY, CLI |
| ADR-016 | Registry Tag Cadence | REGISTRY, AUTHORING |
| ADR-017 | Provider → Target Rename | TARGETS, CLI |
| ADR-018 | Per-Target Lockfiles | TARGETS, CLI |
| ADR-019 | Subprocess-JSON Target Plugins | TARGETS |
| ADR-023 | Implicit Local Default Target | TARGETS, CLI |
| ADR-024 | Script Component Lifecycle Contract | AUTHORING, CLI |

## Test Plan

- [ ] Verify all five docs render cleanly on GitHub (mermaid diagrams, tables, code blocks)
- [ ] Confirm every relative ADR link resolves correctly within the `v4/docs/` tree
- [ ] Confirm no Rust, workflow, schema, or extension files changed (`git diff --name-only HEAD~1`)
- [ ] Run `markdownlint v4/docs/*.md` if markdownlint is available in CI

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)