### PR TITLE
feat(v4): per-target lockfile + component_digest population (Wave 5F — D18, D5)

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -3730,6 +3730,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hex",
+ "oci-client 0.16.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3737,8 +3738,11 @@ dependencies = [
  "sindri-core",
  "sindri-policy",
  "sindri-registry",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/v4/crates/sindri-registry/src/client.rs
+++ b/v4/crates/sindri-registry/src/client.rs
@@ -284,6 +284,65 @@ impl RegistryClient {
         Ok((index, Some(digest)))
     }
 
+    /// Fetch the SHA-256 digest of a *component's* primary OCI layer.
+    ///
+    /// Wave 5F — D5 (carry-over from PR #228): the resolver populates the
+    /// per-component `component_digest` lockfile field via this helper so
+    /// that `sindri apply`'s cosign pre-flight (added in #228) can verify a
+    /// per-component signature before the install backend runs.
+    ///
+    /// Returns the layer descriptor digest (e.g. `"sha256:…"`) of the
+    /// manifest's first layer. Unlike [`Self::fetch_index`], this does *not*
+    /// pull the layer blob — only the manifest — because the layer
+    /// descriptor digest is what cosign needs and the apply pipeline does
+    /// the full layer pull lazily.
+    ///
+    /// `oci_ref_str` accepts the same forms as [`OciRef::parse`]. Anonymous
+    /// auth is used unless `~/.docker/config.json` provides credentials, in
+    /// which case the bearer-token flow is delegated to `oci-client`.
+    pub async fn fetch_component_layer_digest(
+        &self,
+        oci_ref_str: &str,
+    ) -> Result<String, RegistryError> {
+        let oci_ref = OciRef::parse(oci_ref_str)?;
+        let reference = oci_reference_for(&oci_ref);
+        let auth = docker_config_auth(&oci_ref.registry).unwrap_or(RegistryAuth::Anonymous);
+
+        tracing::debug!(
+            "fetching component manifest {} for layer digest (Wave 5F D5)",
+            oci_ref.to_canonical()
+        );
+
+        let (manifest, _manifest_digest) = self
+            .oci
+            .pull_manifest(&reference, &auth)
+            .await
+            .map_err(|e| RegistryError::OciFetch {
+                reference: oci_ref.to_canonical(),
+                detail: e.to_string(),
+            })?;
+
+        let image_manifest = match manifest {
+            OciManifest::Image(m) => m,
+            OciManifest::ImageIndex(_) => {
+                return Err(RegistryError::OciFetch {
+                    reference: oci_ref.to_canonical(),
+                    detail: "expected image manifest, got image index".into(),
+                });
+            }
+        };
+
+        let layer = image_manifest
+            .layers
+            .first()
+            .ok_or_else(|| RegistryError::OciFetch {
+                reference: oci_ref.to_canonical(),
+                detail: "manifest has no layers".into(),
+            })?;
+
+        Ok(layer.digest.clone())
+    }
+
     // ------------------------------------------------------------------
     // internals
     // ------------------------------------------------------------------

--- a/v4/crates/sindri-registry/tests/oci_wiremock.rs
+++ b/v4/crates/sindri-registry/tests/oci_wiremock.rs
@@ -346,6 +346,75 @@ async fn manifest_404_maps_to_oci_fetch_error() {
 }
 
 #[tokio::test]
+async fn fetch_component_layer_digest_returns_descriptor_digest() {
+    // Wave 5F — D5: the resolver pre-fetches per-component layer digests
+    // and writes them into the lockfile. This test exercises the manifest-
+    // only fetch path (no blob pull).
+    let server = MockServer::start().await;
+    let layer = b"opaque-component-payload";
+    let layer_digest = format!("sha256:{}", sha256_hex(layer));
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "size": 0
+        },
+        "layers": [{
+            "mediaType": OCI_TAR_GZIP_MEDIA_TYPE,
+            "digest": layer_digest,
+            "size": layer.len()
+        }]
+    })
+    .to_string();
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/{}/manifests/{}", REPO, TAG)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+                .set_body_string(manifest),
+        )
+        .mount(&server)
+        .await;
+
+    let (_endpoint, registry_url) = registry_url_for(&server);
+    let oci = http_oci_client();
+    let (_t, client) = temp_client(oci);
+    let returned = client
+        .fetch_component_layer_digest(&registry_url)
+        .await
+        .expect("manifest-only fetch should succeed");
+    assert_eq!(returned, layer_digest);
+}
+
+#[tokio::test]
+async fn fetch_component_layer_digest_404_surfaces_oci_fetch_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/v2/.*/manifests/.*$"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    let (_endpoint, registry_url) = registry_url_for(&server);
+    let oci = http_oci_client();
+    let (_t, client) = temp_client(oci);
+    let err = client
+        .fetch_component_layer_digest(&registry_url)
+        .await
+        .expect_err("404 must surface");
+    let msg = format!("{}", err).to_ascii_lowercase();
+    assert!(
+        msg.contains("404") || msg.contains("not found") || msg.contains("oci fetch"),
+        "expected fetch error, got: {}",
+        msg
+    );
+}
+
+const OCI_TAR_GZIP_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+
+#[tokio::test]
 async fn manifest_500_maps_to_oci_fetch_error() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/v4/crates/sindri-resolver/Cargo.toml
+++ b/v4/crates/sindri-resolver/Cargo.toml
@@ -19,3 +19,12 @@ serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true }
+wiremock = "0.6"
+oci-client = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+serde_json = { workspace = true }

--- a/v4/crates/sindri-resolver/src/backend_choice.rs
+++ b/v4/crates/sindri-resolver/src/backend_choice.rs
@@ -91,6 +91,86 @@ pub fn explain_choice(entry: &ComponentEntry, platform: &Platform) -> String {
     lines.join("\n")
 }
 
+/// Target-kind-aware backend preference chain (Wave 5F — D18).
+///
+/// Different deployment targets have different "native" backends. A `local`
+/// target uses the host package managers (`brew`/`apt`/`mise`); a `docker` or
+/// `kubernetes` target prefers container-image / binary backends because the
+/// host's brew/apt isn't reachable from inside the container; an `ssh` target
+/// behaves like a remote `local` (we'll still use brew/apt on the remote box,
+/// the `mise` chain works there too).
+///
+/// The chain returned here is *additive on top of the platform default*: if
+/// the target kind doesn't override, callers fall back to
+/// [`default_preference`]. Returning `None` means "use the platform default."
+pub fn target_kind_preference(target_kind: &str, platform: &Platform) -> Option<Vec<Backend>> {
+    match target_kind {
+        // Local target: identical to platform default.
+        "local" => None,
+
+        // Container-style targets — the user-installed package managers on
+        // the host are not reachable inside the container, so we prefer
+        // tarball / static-binary backends. `mise` is preserved because it
+        // installs into `$XDG_DATA_HOME` and works inside containers when
+        // available.
+        "docker" | "kubernetes" | "k8s" | "fly" | "e2b" | "runpod" | "northflank" => Some(vec![
+            Backend::Mise,
+            Backend::Binary,
+            Backend::Cargo,
+            Backend::GoInstall,
+            Backend::Npm,
+            Backend::Pipx,
+            Backend::Script,
+        ]),
+
+        // Remote shell targets: same as local default — the remote host has
+        // its own package managers. The CLI is responsible for setting
+        // `platform` to the remote's platform when the target probes its
+        // profile; if it can't, we fall through to the host's defaults.
+        "ssh"
+        | "wsl"
+        | "devpod-aws"
+        | "devpod-gcp"
+        | "devpod-azure"
+        | "devpod-digitalocean"
+        | "devpod-k8s"
+        | "devpod-ssh"
+        | "devpod-docker" => None,
+
+        // Unknown kind (likely a plugin target): be conservative and let the
+        // platform default apply. This keeps plugin targets working before
+        // they declare their own preference chain.
+        _ => {
+            tracing::debug!(
+                "target kind '{}' has no built-in backend preference; \
+                 falling back to platform default for {}",
+                target_kind,
+                platform.triple()
+            );
+            None
+        }
+    }
+}
+
+/// Choose the best backend for a component, taking the target's *kind* into
+/// account (Wave 5F — D18).
+///
+/// Wraps [`choose_backend`] but consults [`target_kind_preference`] first.
+/// User-supplied preferences (`user_prefs`) still win — both over the target
+/// chain and the platform chain — to preserve the override hook.
+pub fn choose_backend_for_target(
+    entry: &ComponentEntry,
+    platform: &Platform,
+    target_kind: Option<&str>,
+    user_prefs: Option<&[Backend]>,
+) -> Backend {
+    if user_prefs.is_some() {
+        return choose_backend(entry, platform, user_prefs);
+    }
+    let target_chain = target_kind.and_then(|k| target_kind_preference(k, platform));
+    choose_backend(entry, platform, target_chain.as_deref())
+}
+
 // Helper: parse the backend string from a registry entry
 struct BackendStr(String);
 
@@ -108,5 +188,139 @@ impl std::str::FromStr for BackendStr {
         } else {
             Err(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::platform::{Arch, Os, Platform};
+    use sindri_core::registry::{ComponentEntry, ComponentKind};
+
+    fn linux_platform() -> Platform {
+        Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        }
+    }
+
+    fn macos_platform() -> Platform {
+        Platform {
+            os: Os::Macos,
+            arch: Arch::Aarch64,
+        }
+    }
+
+    fn entry_no_explicit_backend(name: &str) -> ComponentEntry {
+        ComponentEntry {
+            name: name.into(),
+            // Empty backend means "no explicit annotation"; the chooser will
+            // fall through to the preference chain.
+            backend: "".into(),
+            latest: "1.0.0".into(),
+            versions: vec!["1.0.0".into()],
+            description: "test".into(),
+            kind: ComponentKind::Component,
+            oci_ref: format!("ghcr.io/sindri-dev/registry-core/{}:1.0.0", name),
+            license: "MIT".into(),
+            depends_on: vec![],
+        }
+    }
+
+    #[test]
+    fn target_kind_local_falls_back_to_platform_default() {
+        // Wave 5F — D18: a `local` target uses the platform default chain.
+        let pf = macos_platform();
+        assert!(target_kind_preference("local", &pf).is_none());
+        let chosen = choose_backend_for_target(
+            &entry_no_explicit_backend("nodejs"),
+            &pf,
+            Some("local"),
+            None,
+        );
+        // macOS default chain heads with brew.
+        assert_eq!(chosen, Backend::Brew);
+    }
+
+    #[test]
+    fn target_kind_kubernetes_prefers_container_friendly_backends() {
+        // Wave 5F — D18: a `k8s` target should NOT pick brew (host-only),
+        // even on macOS. Mise is the first container-friendly backend.
+        let pf = macos_platform();
+        let chain = target_kind_preference("k8s", &pf).expect("k8s overrides default");
+        assert!(!chain.contains(&Backend::Brew));
+        assert!(!chain.contains(&Backend::Apt));
+        assert_eq!(chain.first(), Some(&Backend::Mise));
+        let chosen = choose_backend_for_target(
+            &entry_no_explicit_backend("kubectl"),
+            &pf,
+            Some("k8s"),
+            None,
+        );
+        assert_eq!(chosen, Backend::Mise);
+    }
+
+    #[test]
+    fn target_kind_docker_omits_host_package_managers() {
+        // Wave 5F — D18: docker shares the same chain as k8s.
+        let pf = linux_platform();
+        let chain = target_kind_preference("docker", &pf).expect("docker overrides default");
+        for forbidden in [
+            Backend::Brew,
+            Backend::Apt,
+            Backend::Dnf,
+            Backend::Pacman,
+            Backend::Apk,
+            Backend::Zypper,
+        ] {
+            assert!(
+                !chain.contains(&forbidden),
+                "docker chain leaked host package manager: {:?}",
+                forbidden
+            );
+        }
+    }
+
+    #[test]
+    fn target_kind_ssh_inherits_platform_default() {
+        // SSH installs onto a remote host that has its own package
+        // managers — preserve the platform default.
+        let pf = linux_platform();
+        assert!(target_kind_preference("ssh", &pf).is_none());
+        assert!(target_kind_preference("wsl", &pf).is_none());
+    }
+
+    #[test]
+    fn target_kind_unknown_falls_back_silently() {
+        // Plugin / unknown kinds should not error — they fall back to the
+        // platform default. (Plugins can override later via per-target prefs.)
+        let pf = linux_platform();
+        assert!(target_kind_preference("modal", &pf).is_none());
+        assert!(target_kind_preference("lambda-labs", &pf).is_none());
+    }
+
+    #[test]
+    fn user_prefs_win_over_target_kind() {
+        // Even with a docker target, an explicit user preference list wins.
+        let pf = macos_platform();
+        let prefs = [Backend::Brew, Backend::Script];
+        let chosen = choose_backend_for_target(
+            &entry_no_explicit_backend("nodejs"),
+            &pf,
+            Some("docker"),
+            Some(&prefs),
+        );
+        assert_eq!(chosen, Backend::Brew);
+    }
+
+    #[test]
+    fn explicit_entry_backend_still_honoured_under_target_kind() {
+        // If the registry entry pins `backend: "mise"`, that wins regardless
+        // of the target chain.
+        let pf = macos_platform();
+        let mut e = entry_no_explicit_backend("nodejs");
+        e.backend = "mise".into();
+        let chosen = choose_backend_for_target(&e, &pf, Some("k8s"), None);
+        assert_eq!(chosen, Backend::Mise);
     }
 }

--- a/v4/crates/sindri-resolver/src/lib.rs
+++ b/v4/crates/sindri-resolver/src/lib.rs
@@ -31,6 +31,34 @@ pub struct ResolveOptions {
     /// entries omit `manifest_digest`. ADR-003 audit-delta tracks moving
     /// this from registry-scoped to per-component when SBOM (Wave 5) lands.
     pub registry_manifest_digest: Option<String>,
+    /// Target *kind* (e.g. `local`, `docker`, `k8s`). Drives the per-target
+    /// backend preference chain (Wave 5F — D18, ADR-018). Defaults to
+    /// `"local"` when unset, preserving pre-5F behaviour.
+    #[doc(hidden)]
+    pub target_kind: Option<String>,
+    /// Pre-fetched per-component OCI layer digests, keyed by component
+    /// address (e.g. `mise:nodejs`). Populated by the CLI's resolve command
+    /// for OCI-backed components (Wave 5F — D5 carry-over from PR #228).
+    /// Components without an entry here serialize `component_digest: None`
+    /// (acceptable for local file / git / http tarball sources).
+    #[doc(hidden)]
+    pub component_digests: HashMap<String, String>,
+}
+
+impl Default for ResolveOptions {
+    fn default() -> Self {
+        Self {
+            manifest_path: PathBuf::new(),
+            lockfile_path: PathBuf::new(),
+            target_name: "local".to_string(),
+            offline: false,
+            strict: false,
+            explain: None,
+            registry_manifest_digest: None,
+            target_kind: None,
+            component_digests: HashMap::new(),
+        }
+    }
 }
 
 /// Main resolution pipeline: manifest → registry → closure → gates → backend → lockfile
@@ -71,6 +99,7 @@ pub fn resolve(
     let bom_hash = lockfile_writer::compute_bom_hash(&bom_content);
     let mut lockfile = Lockfile::new(bom_hash, opts.target_name.clone());
 
+    let target_kind = opts.target_kind.as_deref();
     for node in &closure_nodes {
         // Handle explain flag
         if let Some(ref exp) = opts.explain {
@@ -81,12 +110,16 @@ pub fn resolve(
             }
         }
 
-        let chosen = backend_choice::choose_backend(&node.entry, platform, None);
+        let chosen =
+            backend_choice::choose_backend_for_target(&node.entry, platform, target_kind, None);
+        let address = node.id.to_address();
+        let component_digest = opts.component_digests.get(&address).cloned();
         let resolved = lockfile_writer::resolved_from_entry(
             &node.entry,
             chosen,
-            &node.id.to_address(),
+            &address,
             opts.registry_manifest_digest.as_deref(),
+            component_digest.as_deref(),
         );
         lockfile.components.push(resolved);
     }

--- a/v4/crates/sindri-resolver/src/lockfile_writer.rs
+++ b/v4/crates/sindri-resolver/src/lockfile_writer.rs
@@ -24,6 +24,36 @@ pub fn write_lockfile(path: &Path, lockfile: &Lockfile) -> Result<(), ResolverEr
     Ok(())
 }
 
+/// Returns `true` when `oci_ref_str` looks like an OCI reference (registry
+/// host plus `:tag` or `@sha256:...`). Returns `false` for non-OCI sources
+/// (`registry:local:...`, `file://`, `git://`, `https://` tarballs, empty
+/// strings). Wave 5F — D5 uses this to decide whether the resolver should
+/// attempt a per-component digest fetch.
+pub fn is_oci_source(oci_ref_str: &str) -> bool {
+    let trimmed = oci_ref_str.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    for prefix in [
+        "registry:local:",
+        "file://",
+        "file:",
+        "git://",
+        "git+",
+        "git@",
+        "http://",
+        "https://",
+        "ssh://",
+    ] {
+        if trimmed.starts_with(prefix) {
+            return false;
+        }
+    }
+    // OCI refs may be bare ("ghcr.io/...") or prefixed with `oci://`. Both
+    // parse via OciRef::parse; we use that as the canonical recogniser.
+    sindri_registry::OciRef::parse(trimmed).is_ok()
+}
+
 /// Read and parse an existing lockfile
 pub fn read_lockfile(path: &Path) -> Result<Lockfile, ResolverError> {
     if !path.exists() {
@@ -40,16 +70,23 @@ pub fn read_lockfile(path: &Path) -> Result<Lockfile, ResolverError> {
 /// 3A.2). When `None` (e.g. local-protocol fixtures, offline mode), the
 /// lockfile entry omits `manifest_digest` for backwards compatibility.
 ///
-/// Per ADR-003 audit-delta (Wave 3A.2): per-component manifest digests
-/// (each component carrying its own OCI digest) are deferred to the SBOM
-/// work in Wave 5. This field carries the *registry-level* artifact digest
-/// — an integrity tie-in for "this lockfile was resolved against this
-/// exact `index.yaml` snapshot."
+/// `component_digest` is the SHA-256 digest of the component's primary OCI
+/// layer, pre-fetched by the CLI for OCI-backed components (Wave 5F — D5
+/// carry-over from PR #228). Components sourced from non-OCI locations
+/// (local file, git URL, raw HTTP tarball) leave this `None`; under
+/// `policy.require_signed_registries=true`, apply will fail closed for
+/// components missing this field.
+///
+/// Per ADR-003 audit-delta (Wave 3A.2): the registry-level `manifest_digest`
+/// remains as an integrity tie-in for "this lockfile was resolved against
+/// this exact `index.yaml` snapshot." The new `component_digest` is the
+/// per-component analogue used by the cosign pre-flight in apply.
 pub fn resolved_from_entry(
     entry: &ComponentEntry,
     chosen_backend: Backend,
     _bom_address: &str,
     registry_manifest_digest: Option<&str>,
+    component_digest: Option<&str>,
 ) -> ResolvedComponent {
     let id = ComponentId {
         backend: chosen_backend.clone(),
@@ -67,10 +104,64 @@ pub fn resolved_from_entry(
         // pipeline degrades to install + hooks only when manifest is None.
         manifest: None,
         manifest_digest: registry_manifest_digest.map(|s| s.to_string()),
-        // Wave 5A — D5: per-component digest is populated by the OCI fetch
-        // path that lands alongside per-component cosign verification. Until
-        // the resolver has a layer-fetch step, emit `None` (apply tolerates
-        // this under permissive policy; strict policy requires it).
-        component_digest: None,
+        component_digest: component_digest.map(|s| s.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::registry::ComponentKind;
+
+    fn entry(name: &str, oci_ref: &str) -> ComponentEntry {
+        ComponentEntry {
+            name: name.into(),
+            backend: "binary".into(),
+            latest: "1.0.0".into(),
+            versions: vec!["1.0.0".into()],
+            description: "test".into(),
+            kind: ComponentKind::Component,
+            oci_ref: oci_ref.into(),
+            license: "MIT".into(),
+            depends_on: vec![],
+        }
+    }
+
+    #[test]
+    fn oci_source_detection() {
+        // Wave 5F — D5: classify a ref as OCI vs non-OCI.
+        assert!(is_oci_source(
+            "ghcr.io/sindri-dev/registry-core/nodejs:22.0.0"
+        ));
+        assert!(is_oci_source(
+            "oci://ghcr.io/sindri-dev/registry-core/nodejs:22.0.0"
+        ));
+        assert!(is_oci_source(
+            "registry.example.com/foo/bar@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
+
+        assert!(!is_oci_source("registry:local:/tmp/fixtures/registry"));
+        assert!(!is_oci_source("file:///tmp/foo.tar.gz"));
+        assert!(!is_oci_source("https://example.com/foo.tar.gz"));
+        assert!(!is_oci_source("git+https://github.com/foo/bar.git"));
+        assert!(!is_oci_source(""));
+    }
+
+    #[test]
+    fn resolved_component_omits_digest_for_non_oci_source() {
+        // Wave 5F — D5: a component sourced from a local registry (or any
+        // non-OCI location) MUST leave `component_digest` as None. The
+        // contract is documented on `resolved_from_entry`.
+        let e = entry("local-tool", "registry:local:/tmp/fixtures/registry");
+        let resolved = resolved_from_entry(&e, Backend::Binary, "binary:local-tool", None, None);
+        assert!(resolved.component_digest.is_none());
+    }
+
+    #[test]
+    fn resolved_component_carries_digest_when_provided() {
+        let e = entry("nodejs", "ghcr.io/sindri-dev/registry-core/nodejs:22.0.0");
+        let digest = "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let resolved = resolved_from_entry(&e, Backend::Mise, "mise:nodejs", None, Some(digest));
+        assert_eq!(resolved.component_digest.as_deref(), Some(digest));
     }
 }

--- a/v4/crates/sindri-resolver/tests/per_target_lockfile.rs
+++ b/v4/crates/sindri-resolver/tests/per_target_lockfile.rs
@@ -1,0 +1,267 @@
+//! Wave 5F — D18: per-target lockfile integration test.
+//!
+//! Drives [`sindri_resolver::resolve`] end-to-end with two `ResolveOptions`
+//! variants — one defaulted (`target_name = "local"`) and one with a
+//! container-style target_kind — and asserts:
+//!
+//! * the default mode picks brew/mise (platform default chain on macOS, or
+//!   mise/apt on Linux) just as it always has;
+//! * the `k8s` mode picks `mise` (the first container-friendly backend) and
+//!   never `brew`, even on macOS;
+//! * round-trip: the lockfile written to disk parses back to a `Lockfile`
+//!   that round-trips the chosen backends.
+
+use sindri_core::component::Backend;
+use sindri_core::platform::{Arch, Os, Platform};
+use sindri_core::policy::{InstallPolicy, PolicyPreset};
+use sindri_core::registry::{ComponentEntry, ComponentKind, RegistryIndex};
+use sindri_resolver::{lockfile_writer, resolve, ResolveOptions};
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+fn macos_platform() -> Platform {
+    Platform {
+        os: Os::Macos,
+        arch: Arch::Aarch64,
+    }
+}
+
+fn permissive_policy() -> InstallPolicy {
+    InstallPolicy {
+        preset: PolicyPreset::Default,
+        allowed_licenses: Vec::new(),
+        denied_licenses: Vec::new(),
+        on_unknown_license: None,
+        require_signed_registries: None,
+        require_checksums: None,
+        offline: Some(true),
+        audit: None,
+    }
+}
+
+fn registry() -> HashMap<String, ComponentEntry> {
+    let entries = vec![
+        ComponentEntry {
+            name: "nodejs".into(),
+            backend: "".into(), // empty -> follow preference chain
+            latest: "22.0.0".into(),
+            versions: vec!["22.0.0".into()],
+            description: "node".into(),
+            kind: ComponentKind::Component,
+            oci_ref: "ghcr.io/sindri-dev/registry-core/nodejs:22.0.0".into(),
+            license: "MIT".into(),
+            depends_on: vec![],
+        },
+        ComponentEntry {
+            name: "kubectl".into(),
+            backend: "".into(),
+            latest: "1.35.4".into(),
+            versions: vec!["1.35.4".into()],
+            description: "kubectl".into(),
+            kind: ComponentKind::Component,
+            oci_ref: "ghcr.io/sindri-dev/registry-core/kubectl:1.35.4".into(),
+            license: "Apache-2.0".into(),
+            depends_on: vec![],
+        },
+    ];
+    let _index_for_serialisation_check = RegistryIndex {
+        version: 1,
+        registry: "test/core".into(),
+        components: entries.clone(),
+    };
+    let mut map = HashMap::new();
+    for e in entries {
+        map.insert(format!("{}:{}", "mise", e.name), e.clone());
+        map.insert(format!("{}:{}", "binary", e.name), e);
+    }
+    map
+}
+
+fn write_bom(dir: &std::path::Path) -> std::path::PathBuf {
+    let bom = r#"
+name: integration-fixture
+components:
+  - address: "mise:nodejs"
+  - address: "mise:kubectl"
+"#;
+    let path = dir.join("sindri.yaml");
+    std::fs::write(&path, bom).unwrap();
+    path
+}
+
+#[test]
+fn default_mode_writes_sindri_lock_with_platform_default_backends() {
+    let tmp = TempDir::new().unwrap();
+    let manifest = write_bom(tmp.path());
+    let lockfile_path = tmp.path().join("sindri.lock");
+
+    let opts = ResolveOptions {
+        manifest_path: manifest.clone(),
+        lockfile_path: lockfile_path.clone(),
+        target_name: "local".into(),
+        offline: true,
+        strict: false,
+        explain: None,
+        registry_manifest_digest: None,
+        target_kind: Some("local".into()),
+        component_digests: HashMap::new(),
+    };
+
+    let lock = resolve(&opts, &registry(), &permissive_policy(), &macos_platform())
+        .expect("resolve should succeed");
+    assert_eq!(lock.target, "local");
+    assert!(lockfile_path.exists());
+
+    // macOS default chain heads with brew.
+    let nodejs = lock
+        .components
+        .iter()
+        .find(|c| c.id.name == "nodejs")
+        .unwrap();
+    assert_eq!(nodejs.backend, Backend::Brew);
+
+    // Round-trip via the writer's reader.
+    let reread = lockfile_writer::read_lockfile(&lockfile_path).unwrap();
+    assert_eq!(reread.components.len(), lock.components.len());
+}
+
+#[test]
+fn target_mode_writes_sindri_target_lock_with_container_friendly_backends() {
+    let tmp = TempDir::new().unwrap();
+    let manifest = write_bom(tmp.path());
+    // Wave 5F — D18: per-target lockfile naming pattern is
+    // `sindri.<target>.lock`.
+    let lockfile_path = tmp.path().join("sindri.k8s.lock");
+
+    let opts = ResolveOptions {
+        manifest_path: manifest.clone(),
+        lockfile_path: lockfile_path.clone(),
+        target_name: "k8s".into(),
+        offline: true,
+        strict: false,
+        explain: None,
+        registry_manifest_digest: None,
+        target_kind: Some("k8s".into()),
+        component_digests: HashMap::new(),
+    };
+
+    let lock = resolve(&opts, &registry(), &permissive_policy(), &macos_platform())
+        .expect("resolve should succeed under k8s target");
+    assert_eq!(lock.target, "k8s");
+    assert!(lockfile_path.exists());
+
+    let nodejs = lock
+        .components
+        .iter()
+        .find(|c| c.id.name == "nodejs")
+        .unwrap();
+    // The k8s chain MUST NOT pick brew (host-only manager).
+    assert_ne!(nodejs.backend, Backend::Brew);
+    assert_eq!(nodejs.backend, Backend::Mise);
+
+    // Round-trip
+    let reread = lockfile_writer::read_lockfile(&lockfile_path).unwrap();
+    assert_eq!(reread.target, "k8s");
+}
+
+#[test]
+fn default_and_target_lockfiles_coexist() {
+    // Both modes can be invoked in the same project directory and produce
+    // distinct files — this is the contract apply.rs depends on.
+    let tmp = TempDir::new().unwrap();
+    let manifest = write_bom(tmp.path());
+
+    let local_lock = tmp.path().join("sindri.lock");
+    let k8s_lock = tmp.path().join("sindri.k8s.lock");
+
+    resolve(
+        &ResolveOptions {
+            manifest_path: manifest.clone(),
+            lockfile_path: local_lock.clone(),
+            target_name: "local".into(),
+            offline: true,
+            strict: false,
+            explain: None,
+            registry_manifest_digest: None,
+            target_kind: Some("local".into()),
+            component_digests: HashMap::new(),
+        },
+        &registry(),
+        &permissive_policy(),
+        &macos_platform(),
+    )
+    .unwrap();
+
+    resolve(
+        &ResolveOptions {
+            manifest_path: manifest.clone(),
+            lockfile_path: k8s_lock.clone(),
+            target_name: "k8s".into(),
+            offline: true,
+            strict: false,
+            explain: None,
+            registry_manifest_digest: None,
+            target_kind: Some("k8s".into()),
+            component_digests: HashMap::new(),
+        },
+        &registry(),
+        &permissive_policy(),
+        &macos_platform(),
+    )
+    .unwrap();
+
+    assert!(local_lock.exists());
+    assert!(k8s_lock.exists());
+
+    let l = lockfile_writer::read_lockfile(&local_lock).unwrap();
+    let k = lockfile_writer::read_lockfile(&k8s_lock).unwrap();
+
+    let l_node = l.components.iter().find(|c| c.id.name == "nodejs").unwrap();
+    let k_node = k.components.iter().find(|c| c.id.name == "nodejs").unwrap();
+    // Distinct backend choices per target on the same platform.
+    assert_ne!(l_node.backend, k_node.backend);
+}
+
+#[test]
+fn component_digests_propagate_into_lockfile() {
+    let tmp = TempDir::new().unwrap();
+    let manifest = write_bom(tmp.path());
+    let lockfile_path = tmp.path().join("sindri.lock");
+
+    let mut digests = HashMap::new();
+    digests.insert(
+        "mise:nodejs".to_string(),
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+    );
+
+    let opts = ResolveOptions {
+        manifest_path: manifest,
+        lockfile_path: lockfile_path.clone(),
+        target_name: "local".into(),
+        offline: true,
+        strict: false,
+        explain: None,
+        registry_manifest_digest: None,
+        target_kind: Some("local".into()),
+        component_digests: digests,
+    };
+
+    let lock = resolve(&opts, &registry(), &permissive_policy(), &macos_platform()).unwrap();
+    let nodejs = lock
+        .components
+        .iter()
+        .find(|c| c.id.name == "nodejs")
+        .unwrap();
+    assert!(
+        nodejs.component_digest.is_some(),
+        "nodejs digest threaded through"
+    );
+
+    // kubectl had no entry in the digest map — must remain None.
+    let kubectl = lock
+        .components
+        .iter()
+        .find(|c| c.id.name == "kubectl")
+        .unwrap();
+    assert!(kubectl.component_digest.is_none());
+}

--- a/v4/crates/sindri/src/commands/resolve.rs
+++ b/v4/crates/sindri/src/commands/resolve.rs
@@ -1,7 +1,9 @@
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use sindri_core::manifest::BomManifest;
 use sindri_core::platform::Platform;
 use sindri_core::policy::InstallPolicy;
 use sindri_core::registry::ComponentEntry;
+use sindri_resolver::lockfile_writer::is_oci_source;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -74,6 +76,22 @@ pub fn run(args: ResolveArgs) -> i32 {
         .ok()
         .and_then(|c| c.any_digest_for_registry(sindri_core::registry::CORE_REGISTRY_NAME));
 
+    // Wave 5F — D18: extract the per-target kind from the BOM so the
+    // resolver can pick a target-appropriate backend chain. We don't
+    // hard-fail on a missing target entry — the resolver falls back to the
+    // platform default for unknown / undeclared kinds.
+    let target_kind = read_target_kind(&manifest_path, &args.target);
+
+    // Wave 5F — D5 (carry-over from PR #228): pre-fetch per-component OCI
+    // layer digests so the lockfile carries `component_digest` for OCI-backed
+    // components. Components with non-OCI sources (local file, git, http)
+    // are skipped by design and serialize `component_digest: None`.
+    let component_digests = if args.offline {
+        HashMap::new()
+    } else {
+        prefetch_component_digests(&manifest_path, &registry)
+    };
+
     let opts = sindri_resolver::ResolveOptions {
         manifest_path: manifest_path.clone(),
         lockfile_path: lockfile_path.clone(),
@@ -82,6 +100,8 @@ pub fn run(args: ResolveArgs) -> i32 {
         strict: args.strict,
         explain: args.explain.clone(),
         registry_manifest_digest,
+        target_kind,
+        component_digests,
     };
 
     match sindri_resolver::resolve(&opts, &registry, &policy, &platform) {
@@ -119,6 +139,107 @@ pub fn run(args: ResolveArgs) -> i32 {
             code
         }
     }
+}
+
+/// Read the `kind` of the requested target from the BOM. Returns `None` if
+/// the BOM cannot be parsed, the target isn't declared, or the kind field
+/// is empty — in all of those cases the resolver falls back to the platform
+/// default chain. Wave 5F — D18.
+fn read_target_kind(manifest_path: &Path, target_name: &str) -> Option<String> {
+    let content = std::fs::read_to_string(manifest_path).ok()?;
+    let bom: BomManifest = serde_yaml::from_str(&content).ok()?;
+    bom.targets
+        .get(target_name)
+        .map(|t| t.kind.clone())
+        .filter(|k| !k.is_empty())
+        // The CLI's `--target local` default is the universal fallback even
+        // when the BOM doesn't declare a `targets.local` entry.
+        .or_else(|| {
+            if target_name == "local" {
+                Some("local".to_string())
+            } else {
+                None
+            }
+        })
+}
+
+/// Pre-fetch the SHA-256 digest of each OCI-backed component's primary
+/// layer. Returns a map keyed by component address (e.g. `"mise:nodejs"`).
+/// Best-effort: any failure for a single component is logged and skipped —
+/// the resolver tolerates missing entries (apply will fail closed under
+/// `policy.require_signed_registries=true` only). Wave 5F — D5.
+fn prefetch_component_digests(
+    manifest_path: &Path,
+    registry: &HashMap<String, ComponentEntry>,
+) -> HashMap<String, String> {
+    let content = match std::fs::read_to_string(manifest_path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    let bom: BomManifest = match serde_yaml::from_str(&content) {
+        Ok(b) => b,
+        Err(_) => return HashMap::new(),
+    };
+
+    // Collect the (address, oci_ref) pairs we want to fetch. Skip non-OCI
+    // sources up front to avoid pointless network attempts.
+    let mut targets: Vec<(String, String)> = Vec::new();
+    for entry in &bom.components {
+        if let Some(reg_entry) = registry.get(&entry.address) {
+            if is_oci_source(&reg_entry.oci_ref) {
+                targets.push((entry.address.clone(), reg_entry.oci_ref.clone()));
+            }
+        }
+    }
+    if targets.is_empty() {
+        return HashMap::new();
+    }
+
+    // Spin up a small runtime — the resolver itself is sync. Failures here
+    // are non-fatal: apply tolerates missing component_digest under
+    // permissive policy.
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!("could not start tokio runtime for digest pre-fetch: {}", e);
+            return HashMap::new();
+        }
+    };
+
+    let client = match sindri_registry::RegistryClient::new() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(
+                "could not construct RegistryClient for digest pre-fetch: {}",
+                e
+            );
+            return HashMap::new();
+        }
+    };
+
+    let mut out: HashMap<String, String> = HashMap::new();
+    runtime.block_on(async {
+        for (addr, oci_ref) in &targets {
+            match client.fetch_component_layer_digest(oci_ref).await {
+                Ok(d) => {
+                    tracing::debug!("component_digest({}) = {}", addr, d);
+                    out.insert(addr.clone(), d);
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "skipping component_digest for {} ({}): {}",
+                        addr,
+                        oci_ref,
+                        e
+                    );
+                }
+            }
+        }
+    });
+    out
 }
 
 fn load_registry_from_cache() -> HashMap<String, ComponentEntry> {


### PR DESCRIPTION
## Summary

- Closes audit-deferred **D18** (per-target lockfile writer with target-kind-aware backend selection) and finishes the **D5** carry-over from PR #228 (`component_digest` population in the resolver).
- Default `sindri resolve` still writes `sindri.lock` with the platform-default chain — `--target <name>` is purely additive.
- No lockfile schema changes — additive use of the existing `component_digest` field that PR #228 introduced with `#[serde(default, skip_serializing_if = ...)]`.

## What changed

**Per-target lockfile writer (D18):**
- Resolver consults `targets.<name>.kind` from the BOM and picks a target-appropriate backend chain. Container-style targets (`docker`, `kubernetes`/`k8s`, `fly`, `e2b`, `runpod`, `northflank`) skip host-only managers (`brew`, `apt`, `dnf`, ...) and prefer `mise` → `binary` → `cargo` → `go-install` → `npm` → `pipx` → `script`. `ssh` / `wsl` / `devpod-*` targets inherit the platform default.
- `ResolveOptions` gains additive `target_kind` and `component_digests` fields with `Default` impl for backwards compatibility.
- The CLI's `--target` flag (already wired in `main.rs`) drives this end-to-end. Apply already reads `sindri.<target>.lock` per `apply.rs:63-68`.

**`component_digest` population (D5 carry-over from #228):**
- New `RegistryClient::fetch_component_layer_digest()` performs a manifest-only OCI fetch and returns the layer descriptor digest. Reuses the existing `pull_manifest` path (no duplication of `pull_blob` / streaming verification).
- The CLI's `resolve.rs` runs an async pre-pass over OCI-backed components and threads digests into `ResolveOptions.component_digests`. Skipped under `--offline`. Per-component failures are non-fatal — apply still fails closed under `policy.require_signed_registries=true`.
- New helper `lockfile_writer::is_oci_source()` documents the contract: components from local-file / git / http-tarball sources legitimately leave `component_digest = None`.

## Schema diff

No schema changes — additive use of the existing `component_digest` field added in PR #228. Pre-Wave-5A lockfiles continue to deserialize via `#[serde(default)]`.

## Test count delta: +16 (248 → 264)

- **7** unit tests in `resolver::backend_choice` covering `local` / `k8s` / `docker` / `ssh` / `wsl` / unknown target kinds, plus user-pref + entry-pinned-backend override.
- **3** unit tests in `resolver::lockfile_writer` for OCI-source classification and digest propagation through `ResolvedComponent`.
- **4** integration tests in `tests/per_target_lockfile.rs` (new file) covering the default vs `--target k8s` write paths, distinct file names coexisting, full round-trip via `read_lockfile`.
- **2** wiremock tests in `sindri-registry::tests::oci_wiremock` for successful manifest-only digest fetch and 404 mapping.

## Sample invocation

```console
$ sindri resolve --manifest sindri.yaml
Resolved 2 component(s) → ./sindri.lock
  mise:nodejs 22.0.0 (brew)        # macOS host
  mise:kubectl 1.35.4 (brew)       # macOS host

$ sindri resolve --manifest sindri.yaml --target k8s
Resolved 2 component(s) → ./sindri.k8s.lock
  mise:nodejs 22.0.0 (mise)        # k8s chain — no brew
  mise:kubectl 1.35.4 (mise)
```

Both lockfiles coexist; `sindri apply --target k8s` (Wave 5H) reads the per-target lockfile.

## ADRs

- ADR-002 (atomic component)
- ADR-014 (cosign — pairs with per-component digest population)

## Test plan

- [x] `cd v4 && cargo build --workspace`
- [x] `cd v4 && cargo test --workspace` — 264/264 passing
- [x] `cd v4 && cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cd v4 && cargo fmt --all --check` — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)