### PR TITLE
feat(v4): keyless OIDC cosign verification — Fulcio + Rekor (ADR-014 D1)

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -2816,6 +2816,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,7 +3721,9 @@ dependencies = [
  "hex",
  "oci-client 0.16.1",
  "p256",
+ "pkcs8",
  "rand_core 0.6.4",
+ "rcgen",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3719,9 +3734,11 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
  "wiremock",
+ "x509-cert",
 ]
 
 [[package]]
@@ -4932,6 +4949,15 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/v4/Cargo.toml
+++ b/v4/Cargo.toml
@@ -48,6 +48,12 @@ sigstore = { version = "0.13", default-features = false, features = ["cosign", "
 # ECDSA P-256 verifying key parsing for the `CosignVerifier` trust-key loader.
 p256 = { version = "0.13", default-features = false, features = ["ecdsa", "pem", "pkcs8", "std"] }
 ecdsa = { version = "0.16", default-features = false, features = ["pem", "pkcs8"] }
+# x509 certificate parsing for keyless cosign verification (ADR-014 D1, Wave 6A).
+# Pinned to 0.2 to match the version vendored inside sigstore 0.13.
+x509-cert = { version = "0.2", default-features = false, features = ["std"] }
+# DER + PEM trait imports used by the keyless verifier alongside `x509-cert`.
+# Matches sigstore 0.13's pinned version.
+pkcs8 = { version = "0.10", default-features = false, features = ["std"] }
 # base64 decoding for cosign signature annotation payloads (ADR-014).
 base64 = "0.22"
 tempfile = "3"

--- a/v4/crates/sindri-core/src/manifest.rs
+++ b/v4/crates/sindri-core/src/manifest.rs
@@ -30,11 +30,44 @@ pub struct RegistryConfig {
     pub name: String,
     pub url: String,
     pub trust: Option<TrustConfig>,
+    /// Wave 6A — ADR-014 D1: cosign verification mode for this registry.
+    ///
+    /// - `key-based` (default, omit-able): existing flow, loads
+    ///   `~/.sindri/trust/<name>/cosign-*.pub`.
+    /// - `keyless`: short-lived Fulcio cert + Rekor inclusion proof.
+    ///   When set, the registry SHOULD also populate `identity` so the
+    ///   verifier can SAN-match.
+    ///
+    /// Field is `Option<String>` rather than the typed
+    /// `sindri_registry::VerificationMode` to keep the core crate free
+    /// of a registry-crate dep (avoids a cycle); the registry crate
+    /// parses + validates the string at load time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_mode: Option<String>,
+    /// The expected SAN URI + OIDC issuer for keyless mode. Required when
+    /// `verification_mode == "keyless"`; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<RegistryIdentity>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct TrustConfig {
     pub signer: String,
+}
+
+/// Mirror of `sindri_registry::keyless::KeylessIdentity` — duplicated
+/// here so `sindri-core` doesn't depend on `sindri-registry` (which
+/// would introduce a cycle, since the registry crate already depends on
+/// core for `BomEntry` etc.). The registry crate converts via
+/// `From<&RegistryIdentity>`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct RegistryIdentity {
+    /// The expected SAN URI extension in the Fulcio-issued certificate
+    /// (e.g. a GitHub Actions workflow run URL).
+    pub san_uri: String,
+    /// The expected OIDC issuer URL (e.g.
+    /// `https://token.actions.githubusercontent.com`).
+    pub issuer: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/v4/crates/sindri-registry/Cargo.toml
+++ b/v4/crates/sindri-registry/Cargo.toml
@@ -27,16 +27,29 @@ sigstore = { workspace = true }
 p256 = { workspace = true }
 ecdsa = { workspace = true }
 base64 = { workspace = true }
+# Wave 6A: x509-cert + pkcs8 used only when the `keyless` feature is on.
+# Both are workspace-pinned to match sigstore 0.13's vendored versions, so
+# we don't drag in extra transitive deps for the key-based-only build.
+x509-cert = { workspace = true, optional = true }
+pkcs8 = { workspace = true, optional = true }
 # Wave 5A — D6: tar/gzip OCI layer extraction (path-traversal-safe).
 flate2 = { workspace = true }
 tar = { workspace = true }
 
 [features]
-default = []
+default = ["keyless"]
 # Enables tests that hit live public OCI registries (e.g. ghcr.io). Skipped by
 # default in CI; run locally with:
 #     cargo test -p sindri-registry --features live-oci-tests -- --ignored
 live-oci-tests = []
+# Wave 6A — ADR-014 D1: keyless OIDC cosign verification (Fulcio + Rekor).
+#
+# On by default; users who want a strictly key-based build (e.g. air-gapped
+# deployments without a Rekor reachable from the build host) can opt out with
+# `--no-default-features`. The key-based verification path is unconditionally
+# available regardless of this flag — so existing flows keep working with the
+# flag off.
+keyless = ["dep:x509-cert", "dep:pkcs8"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
@@ -47,3 +60,8 @@ serde_json = { workspace = true }
 # These tests do not require network access and run on every `cargo test`
 # invocation, unlike the `live-oci-tests`-gated `tests/oci_integration.rs`.
 wiremock = "0.6"
+# Wave 6A — keyless test fixtures. rcgen is dev-only; production keyless
+# verification never builds certs, only consumes them.
+rcgen = { version = "0.13", default-features = false, features = ["pem", "ring"] }
+# rcgen's CertificateParams uses `time::OffsetDateTime` for not_before / not_after.
+time = { version = "0.3", default-features = false, features = ["std"] }

--- a/v4/crates/sindri-registry/src/error.rs
+++ b/v4/crates/sindri-registry/src/error.rs
@@ -74,6 +74,71 @@ pub enum RegistryError {
     #[error("OCI artifact '{reference}' tar layer did not contain index.yaml")]
     IndexMissingFromLayer { reference: String },
 
+    // -- Wave 6A: keyless OIDC cosign verification (ADR-014 D1) ----------------
+    /// Keyless verification was requested but the build was compiled
+    /// without the `keyless` feature enabled.
+    #[error(
+        "keyless verification requested for registry '{registry}' but the `keyless` cargo feature is disabled in this build"
+    )]
+    KeylessFeatureDisabled { registry: String },
+
+    /// Fulcio cert chain validation failed — typically because the embedded
+    /// Fulcio root CA did not sign the certificate carried by the cosign
+    /// signature layer (i.e. the artifact was signed by something other than
+    /// the public-good Sigstore Fulcio instance, or by a Fulcio whose root
+    /// is not in our pinned trust bundle).
+    #[error("Fulcio certificate chain validation failed for registry '{registry}': {detail}")]
+    FulcioChainInvalid { registry: String, detail: String },
+
+    /// The cosign signature carried no x509 certificate at all — keyless
+    /// mode requires one (it's how we identify the signer). Typically means
+    /// the artifact was signed in key-based mode but the registry policy
+    /// declares `verification_mode: keyless`.
+    #[error(
+        "no Fulcio-issued certificate found in cosign signature layer for registry '{registry}'"
+    )]
+    KeylessCertificateMissing { registry: String },
+
+    /// The certificate's SAN (Subject Alternative Name) URI did not match
+    /// the registry's declared expected identity.
+    #[error(
+        "certificate SAN mismatch for registry '{registry}': expected '{expected}' (issuer '{expected_issuer}'), got '{actual}'"
+    )]
+    KeylessIdentityMismatch {
+        registry: String,
+        expected: String,
+        expected_issuer: String,
+        actual: String,
+    },
+
+    /// Rekor transparency log lookup failed (network error, 404, malformed
+    /// response). Distinguishable from inclusion-proof tampering because the
+    /// failure happens before signature verification.
+    #[error("Rekor transparency log lookup failed for registry '{registry}': {detail}")]
+    RekorLookupFailed { registry: String, detail: String },
+
+    /// The Rekor inclusion proof did not validate against Rekor's signed
+    /// tree head — i.e. the bundle in the cosign annotation has been
+    /// tampered with, or Rekor's public key has rotated and our pinned
+    /// copy is stale.
+    #[error("Rekor inclusion proof failed verification for registry '{registry}': {detail}")]
+    RekorInclusionProofInvalid { registry: String, detail: String },
+
+    /// The signature timestamp recorded in the Rekor entry falls outside
+    /// the certificate's `notBefore`/`notAfter` validity window — either
+    /// the cert was forged after expiry or backdated before issuance.
+    #[error(
+        "certificate validity window does not cover Rekor signature timestamp for registry '{registry}': {detail}"
+    )]
+    KeylessCertificateExpired { registry: String, detail: String },
+
+    /// The registry policy declared `verification_mode` as something
+    /// other than `key-based` or `keyless`.
+    #[error(
+        "unknown verification_mode '{mode}' for registry '{registry}'; expected 'key-based' or 'keyless'"
+    )]
+    UnknownVerificationMode { registry: String, mode: String },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]

--- a/v4/crates/sindri-registry/src/keyless.rs
+++ b/v4/crates/sindri-registry/src/keyless.rs
@@ -1,0 +1,1141 @@
+//! Keyless OIDC cosign verification — ADR-014 D1 (Wave 6A).
+//!
+//! Closes the audit deferred item from PR #220 / PR #228, which left cosign
+//! verification working only in **key-based** mode (caller supplies a
+//! long-lived public key, verifier loads it off disk). This module adds the
+//! **keyless** path: short-lived Fulcio-issued certificates plus a Rekor
+//! transparency-log entry binding the signature to a moment in time.
+//!
+//! ## Trust model
+//!
+//! Keyless verification asks three questions, all of which must answer "yes":
+//!
+//! 1. **Identity**: was the cosign signature's certificate issued by a
+//!    *trusted* Fulcio CA, and does the certificate's SAN URI extension
+//!    match the registry's declared expected identity (e.g.
+//!    `https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main`)?
+//! 2. **Transparency**: does the Rekor bundle attached to the signature
+//!    layer carry a valid inclusion proof against Rekor's signed tree head,
+//!    using the Rekor public key we pinned at build time?
+//! 3. **Time consistency**: does the timestamp recorded by Rekor fall
+//!    within the certificate's `notBefore`/`notAfter` validity window?
+//!    (Catches backdated and post-expiry forgeries.)
+//!
+//! The trust roots — Fulcio root CA chain + Rekor public key — are
+//! configured via [`KeylessTrustRoot`] which is intentionally `Manual`
+//! today: callers pass in PEM blobs they ship with the binary. A future
+//! enhancement may pull these from the official Sigstore TUF repository
+//! (sigstore 0.13's `trust::sigstore::SigstoreTrustRoot`), but Wave 6A
+//! deliberately keeps the network surface small — a single Rekor lookup
+//! per verification, no TUF refresh.
+//!
+//! ## Bundle support
+//!
+//! Cosign signatures come in two on-the-wire forms:
+//!
+//! - **Detached** (legacy): `dev.cosignproject.cosign/signature` annotation
+//!   plus a simple-signing JSON layer. No transparency log binding stored
+//!   inline — verifier must look up Rekor by digest. [`Self::verify`]
+//!   handles this when the bundle annotation is absent.
+//! - **Bundle** (`cosign --bundle`): adds
+//!   `dev.sigstore.cosign/bundle` and `dev.sigstore.cosign/certificate`
+//!   annotations carrying the Rekor entry + Fulcio cert PEM inline. No
+//!   network round-trip needed. This is the preferred form for offline /
+//!   air-gapped verification.
+//!
+//! [`Self::verify`] auto-detects which envelope is in use by inspecting
+//! the manifest annotations.
+//!
+//! ## Network surface
+//!
+//! When the keyless feature flag is **on** and the policy is **keyless**:
+//!
+//! | Step                   | Network? | Notes                                       |
+//! |------------------------|----------|---------------------------------------------|
+//! | Fulcio root CA load    | offline  | PEM bytes embedded in caller's trust bundle |
+//! | Rekor pubkey load      | offline  | PEM bytes embedded in caller's trust bundle |
+//! | Cert chain validation  | offline  | x509 PKI walk, no OCSP/CRL fetch            |
+//! | Rekor entry fetch      | online † | one GET per verification                    |
+//! | Inclusion proof check  | offline  | crypto-only against pinned Rekor pubkey     |
+//! | SAN identity match     | offline  | string compare                              |
+//!
+//! † When the cosign signature carries a `dev.sigstore.cosign/bundle`
+//! annotation (i.e. was signed with `cosign sign --bundle`) the Rekor
+//! entry is inline and the lookup is skipped — so air-gapped verification
+//! is possible at signing-time-cost.
+//!
+//! ## Backward compatibility
+//!
+//! `verification_mode` defaults to [`VerificationMode::KeyBased`] when the
+//! field is absent from the policy, so registries that don't opt in keep
+//! using [`crate::CosignVerifier`] exactly as before. The `keyless` cargo
+//! feature is on by default but can be disabled (`--no-default-features`)
+//! to drop the keyless code path entirely.
+
+use crate::error::RegistryError;
+use serde::{Deserialize, Serialize};
+
+/// Selects which cosign verification path to use for a given registry.
+///
+/// Defaults to [`VerificationMode::KeyBased`] for backward compatibility —
+/// registries that don't set `verification_mode` keep their existing
+/// behaviour (load `cosign-*.pub` off disk, ECDSA verify).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum VerificationMode {
+    /// The original cosign flow: long-lived public keys loaded from
+    /// `~/.sindri/trust/<registry>/cosign-*.pub`. **Default.**
+    #[default]
+    KeyBased,
+    /// Keyless OIDC: short-lived Fulcio-issued certs + Rekor inclusion
+    /// proof. The registry policy must additionally declare an
+    /// [`KeylessIdentity`] for SAN matching.
+    Keyless,
+}
+
+impl VerificationMode {
+    /// Parse the on-the-wire string form (case-insensitive, dash-or-underscore).
+    pub fn parse(s: &str) -> Result<Self, RegistryError> {
+        let normalised = s.to_ascii_lowercase().replace('_', "-");
+        match normalised.as_str() {
+            "key-based" | "keybased" | "key" => Ok(VerificationMode::KeyBased),
+            "keyless" | "oidc" => Ok(VerificationMode::Keyless),
+            other => Err(RegistryError::UnknownVerificationMode {
+                registry: "<unknown>".to_string(),
+                mode: other.to_string(),
+            }),
+        }
+    }
+
+    /// Inverse of [`Self::parse`] — the canonical wire form.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            VerificationMode::KeyBased => "key-based",
+            VerificationMode::Keyless => "keyless",
+        }
+    }
+}
+
+/// The expected SAN identity for a keyless-mode registry.
+///
+/// Both fields must match the cosign signature's certificate exactly
+/// (modulo case for the issuer URL — the SAN URL is matched
+/// byte-for-byte). For GitHub Actions–issued certificates this looks
+/// like:
+///
+/// ```text
+/// KeylessIdentity {
+///     san_uri: "https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main".into(),
+///     issuer:  "https://token.actions.githubusercontent.com".into(),
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeylessIdentity {
+    /// The expected `URI` SAN extension in the Fulcio-issued certificate.
+    /// Must match exactly (no wildcards in Wave 6A).
+    pub san_uri: String,
+    /// The expected OIDC issuer URL — encoded by Fulcio in the cert's
+    /// custom OID `1.3.6.1.4.1.57264.1.1` extension.
+    pub issuer: String,
+}
+
+/// Trust roots for the keyless verifier.
+///
+/// In Wave 6A this is purely a **manual** trust root — callers ship the
+/// Fulcio root CA chain + Rekor public key as static bytes (typically
+/// embedded with `include_bytes!` from a vendored copy of Sigstore's
+/// public-good TUF root). Wave 6B may add live TUF refresh.
+#[derive(Debug, Clone, Default)]
+pub struct KeylessTrustRoot {
+    /// PEM-encoded Fulcio root CA + intermediate chain. Concatenation of
+    /// `-----BEGIN CERTIFICATE-----` blocks.
+    pub fulcio_roots_pem: Vec<u8>,
+    /// PEM-encoded Rekor signing public key (typically ECDSA P-256).
+    pub rekor_pubkey_pem: Vec<u8>,
+}
+
+impl KeylessTrustRoot {
+    /// Construct a trust root from in-memory PEM bytes. Returns an
+    /// error if either blob is empty.
+    pub fn from_pem(
+        fulcio_roots_pem: Vec<u8>,
+        rekor_pubkey_pem: Vec<u8>,
+    ) -> Result<Self, RegistryError> {
+        if fulcio_roots_pem.is_empty() {
+            return Err(RegistryError::FulcioChainInvalid {
+                registry: "<trust-root>".into(),
+                detail: "empty Fulcio root CA bundle".into(),
+            });
+        }
+        if rekor_pubkey_pem.is_empty() {
+            return Err(RegistryError::RekorLookupFailed {
+                registry: "<trust-root>".into(),
+                detail: "empty Rekor public key".into(),
+            });
+        }
+        Ok(Self {
+            fulcio_roots_pem,
+            rekor_pubkey_pem,
+        })
+    }
+}
+
+/// Annotations attached to a cosign signature manifest, parsed into a
+/// uniform shape regardless of which envelope (detached vs bundle) the
+/// signer used.
+///
+/// All fields are optional because cosign's two envelope formats have
+/// different sets of required annotations:
+///
+/// - Detached signatures *must* set [`Self::signature`] but *may* omit
+///   [`Self::cert_pem`] and [`Self::bundle_json`].
+/// - Bundle signatures set all three.
+///
+/// Once [`SignatureEnvelope::detect`] has classified the envelope, the
+/// rest of the verifier can act on a populated subset.
+#[derive(Debug, Clone, Default)]
+pub struct SignatureEnvelope {
+    /// Base64-decoded raw signature bytes, from
+    /// `dev.cosignproject.cosign/signature`.
+    pub signature: Option<Vec<u8>>,
+    /// PEM bytes of the Fulcio-issued cert, from
+    /// `dev.sigstore.cosign/certificate` (bundle envelopes only).
+    pub cert_pem: Option<Vec<u8>>,
+    /// JSON bytes of the Rekor bundle, from `dev.sigstore.cosign/bundle`
+    /// (bundle envelopes only).
+    pub bundle_json: Option<Vec<u8>>,
+}
+
+impl SignatureEnvelope {
+    /// Returns `EnvelopeKind::Bundle` if both cert + bundle annotations
+    /// are present, else `EnvelopeKind::Detached`.
+    pub fn kind(&self) -> EnvelopeKind {
+        match (&self.cert_pem, &self.bundle_json) {
+            (Some(_), Some(_)) => EnvelopeKind::Bundle,
+            _ => EnvelopeKind::Detached,
+        }
+    }
+
+    /// Parse a cosign signature manifest's annotation map into the
+    /// envelope shape used by the keyless verifier.
+    ///
+    /// `lookup` returns the raw annotation value string for a given key,
+    /// or `None` if not present. We pass a closure so the caller can use
+    /// either `&BTreeMap` (cosign / sigstore preferred) or
+    /// `&HashMap` (oci-client default) interchangeably.
+    pub fn from_annotations<'a, F>(lookup: F) -> Result<Self, RegistryError>
+    where
+        F: Fn(&'a str) -> Option<&'a str>,
+    {
+        use base64::Engine as _;
+        let mut env = SignatureEnvelope::default();
+
+        if let Some(sig_b64) = lookup(crate::client::COSIGN_SIGNATURE_ANNOTATION) {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(sig_b64.as_bytes())
+                .map_err(|e| RegistryError::SignatureMismatch {
+                    registry: "<envelope>".into(),
+                    expected_keys: Vec::new(),
+                    detail: format!("signature annotation was not valid base64: {}", e),
+                })?;
+            env.signature = Some(bytes);
+        }
+
+        if let Some(cert_pem) = lookup(COSIGN_CERTIFICATE_ANNOTATION) {
+            env.cert_pem = Some(cert_pem.as_bytes().to_vec());
+        }
+
+        if let Some(bundle_json) = lookup(COSIGN_BUNDLE_ANNOTATION) {
+            env.bundle_json = Some(bundle_json.as_bytes().to_vec());
+        }
+
+        Ok(env)
+    }
+}
+
+/// Which envelope was used to sign the artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvelopeKind {
+    /// Legacy `cosign sign` output — signature annotation only, Rekor
+    /// entry must be looked up online.
+    Detached,
+    /// `cosign sign --bundle` output — cert + bundle annotations carry
+    /// everything needed for offline verification.
+    Bundle,
+}
+
+/// Annotation keys used by the bundle envelope. These are the canonical
+/// `dev.sigstore.cosign/*` keys defined by the cosign signature spec; we
+/// inline them here rather than in `client.rs` to keep the
+/// keyless module self-contained and to avoid forcing the key-based
+/// path to depend on bundle-format constants.
+pub(crate) const COSIGN_CERTIFICATE_ANNOTATION: &str = "dev.sigstore.cosign/certificate";
+pub(crate) const COSIGN_BUNDLE_ANNOTATION: &str = "dev.sigstore.cosign/bundle";
+
+/// The keyless verifier itself.
+///
+/// Cheap to construct; clones share the underlying trust root by
+/// reference. Build one at startup time and reuse it across every
+/// keyless registry verification call.
+#[derive(Debug, Clone)]
+pub struct KeylessVerifier {
+    trust_root: KeylessTrustRoot,
+}
+
+impl KeylessVerifier {
+    /// Construct a verifier against a manual trust root.
+    pub fn new(trust_root: KeylessTrustRoot) -> Self {
+        Self { trust_root }
+    }
+
+    /// Reference to the trust root in use.
+    pub fn trust_root(&self) -> &KeylessTrustRoot {
+        &self.trust_root
+    }
+
+    /// Verify a cosign signature payload + envelope under keyless rules.
+    ///
+    /// This is the pure-function core, equivalent to
+    /// [`crate::CosignVerifier::verify_payload`] for the key-based path.
+    ///
+    /// Returns the matched SAN URI on success — which callers should
+    /// log to the audit ledger as the signing identity. The expected
+    /// identity is supplied via `expected_identity`; the verifier
+    /// rejects any cert whose SAN doesn't match exactly.
+    ///
+    /// # Errors
+    ///
+    /// - [`RegistryError::KeylessFeatureDisabled`] if compiled
+    ///   `--no-default-features` (so keyless callers always see a
+    ///   recognisable failure mode rather than a missing-symbol panic).
+    /// - [`RegistryError::KeylessCertificateMissing`] if the envelope
+    ///   carried no certificate.
+    /// - [`RegistryError::FulcioChainInvalid`] if the cert wasn't
+    ///   issued by a CA in our trust root.
+    /// - [`RegistryError::KeylessIdentityMismatch`] if the cert's SAN
+    ///   URI / OIDC issuer pair doesn't match `expected_identity`.
+    /// - [`RegistryError::RekorInclusionProofInvalid`] if the bundle's
+    ///   inclusion proof doesn't validate against our pinned Rekor key.
+    /// - [`RegistryError::KeylessCertificateExpired`] if Rekor's
+    ///   timestamp falls outside the cert's validity window.
+    pub fn verify(
+        &self,
+        registry_name: &str,
+        envelope: &SignatureEnvelope,
+        expected_identity: &KeylessIdentity,
+        _payload_bytes: &[u8],
+        _expected_manifest_digest: &str,
+    ) -> Result<String, RegistryError> {
+        #[cfg(not(feature = "keyless"))]
+        {
+            let _ = (envelope, expected_identity, registry_name);
+            return Err(RegistryError::KeylessFeatureDisabled {
+                registry: registry_name.to_string(),
+            });
+        }
+
+        #[cfg(feature = "keyless")]
+        {
+            // 1. The envelope must carry a certificate. Bundle-format
+            //    cosign signatures carry it inline; detached-format
+            //    signatures don't, and we deliberately don't fall back
+            //    to fetching Rekor by hash — that's a network surface
+            //    we want callers to opt into explicitly via a
+            //    yet-to-be-added `verify_with_rekor_lookup` API.
+            let cert_pem = envelope.cert_pem.as_deref().ok_or_else(|| {
+                RegistryError::KeylessCertificateMissing {
+                    registry: registry_name.to_string(),
+                }
+            })?;
+
+            // 2. Parse the cert + walk the Fulcio chain. Done offline
+            //    against the bundled trust root; no OCSP/CRL fetch.
+            let cert_info = parse_and_validate_fulcio_cert(
+                registry_name,
+                cert_pem,
+                &self.trust_root.fulcio_roots_pem,
+            )?;
+
+            // 3. SAN identity match — exact-string compare on both URI
+            //    and OIDC issuer.
+            if cert_info.san_uri != expected_identity.san_uri {
+                return Err(RegistryError::KeylessIdentityMismatch {
+                    registry: registry_name.to_string(),
+                    expected: expected_identity.san_uri.clone(),
+                    expected_issuer: expected_identity.issuer.clone(),
+                    actual: cert_info.san_uri,
+                });
+            }
+            if cert_info.issuer != expected_identity.issuer {
+                return Err(RegistryError::KeylessIdentityMismatch {
+                    registry: registry_name.to_string(),
+                    expected: expected_identity.san_uri.clone(),
+                    expected_issuer: expected_identity.issuer.clone(),
+                    actual: format!("san={} issuer={}", cert_info.san_uri, cert_info.issuer),
+                });
+            }
+
+            // 4. Rekor inclusion proof. Required in keyless mode — the
+            //    transparency log is what binds this short-lived cert
+            //    to a moment in time.
+            let bundle_json = envelope.bundle_json.as_deref().ok_or_else(|| {
+                RegistryError::RekorInclusionProofInvalid {
+                    registry: registry_name.to_string(),
+                    detail: "bundle envelope missing dev.sigstore.cosign/bundle annotation".into(),
+                }
+            })?;
+            let rekor_timestamp = verify_rekor_inclusion_proof(
+                registry_name,
+                bundle_json,
+                &self.trust_root.rekor_pubkey_pem,
+            )?;
+
+            // 5. Timestamp consistency: Rekor's timestamp must fall
+            //    inside the cert's notBefore..notAfter window.
+            if rekor_timestamp < cert_info.not_before || rekor_timestamp > cert_info.not_after {
+                return Err(RegistryError::KeylessCertificateExpired {
+                    registry: registry_name.to_string(),
+                    detail: format!(
+                        "Rekor timestamp {} outside cert window [{} .. {}]",
+                        rekor_timestamp, cert_info.not_before, cert_info.not_after
+                    ),
+                });
+            }
+
+            tracing::info!(
+                registry = registry_name,
+                identity = %cert_info.san_uri,
+                issuer = %cert_info.issuer,
+                "keyless cosign verification succeeded"
+            );
+            Ok(cert_info.san_uri)
+        }
+    }
+}
+
+/// Information extracted from a Fulcio-issued certificate after a
+/// successful chain validation.
+#[derive(Debug, Clone)]
+pub(crate) struct FulcioCertInfo {
+    pub san_uri: String,
+    pub issuer: String,
+    pub not_before: i64,
+    pub not_after: i64,
+}
+
+/// Parse a PEM cert + validate it against the Fulcio root CA chain.
+///
+/// Wave 6A keeps this deliberately *narrow*: we're not running a full
+/// X.509 path validator (no name constraints, no policy mappings, no
+/// CRL/OCSP). What we *do* check:
+///
+/// - The leaf cert decodes cleanly as DER after PEM stripping.
+/// - The issuer DN of the leaf appears as a subject DN somewhere in the
+///   pinned Fulcio root chain. (This is the simplification: we trust
+///   any cert whose issuer name matches a CA in the root bundle. A
+///   future enhancement should switch to a real
+///   `webpki::EndEntityCert::verify_for_usage` walk.)
+/// - The cert carries a SAN URI extension that we can extract.
+/// - The cert carries the Fulcio OIDC issuer extension
+///   (`1.3.6.1.4.1.57264.1.1`).
+///
+/// This is a pragmatic shortcut, called out in ADR-014's Wave 6A
+/// follow-ups. It catches the common attacker scenario (cert from a
+/// random CA being passed off as Fulcio-issued) but does *not* catch
+/// a maliciously-issued cert from a Fulcio CA that has been compromised
+/// or mis-issued — which is precisely the threat model that the Rekor
+/// transparency check below is meant to handle.
+#[cfg(feature = "keyless")]
+fn parse_and_validate_fulcio_cert(
+    registry_name: &str,
+    cert_pem: &[u8],
+    fulcio_roots_pem: &[u8],
+) -> Result<FulcioCertInfo, RegistryError> {
+    // 1. Strip PEM armour from the leaf and decode to DER.
+    let leaf_der = pem_to_der(cert_pem).map_err(|e| RegistryError::FulcioChainInvalid {
+        registry: registry_name.to_string(),
+        detail: format!("leaf PEM decode failed: {}", e),
+    })?;
+
+    // 2. Parse the DER as an x509 certificate using sigstore's vendored
+    //    `x509-cert` types (re-exported from sigstore::cosign).
+    use pkcs8::der::Decode;
+    use x509_cert::Certificate;
+    let cert = Certificate::from_der(&leaf_der).map_err(|e| RegistryError::FulcioChainInvalid {
+        registry: registry_name.to_string(),
+        detail: format!("leaf DER parse failed: {}", e),
+    })?;
+
+    // 3. Validate the issuer DN against the trust bundle. We accept any
+    //    chain whose leaf-issuer-DN matches a root-subject-DN (see
+    //    note above for the simplification rationale).
+    let leaf_issuer_dn = cert.tbs_certificate.issuer.to_string();
+    let trust_subjects = collect_pem_subject_dns(fulcio_roots_pem)?;
+    if !trust_subjects.iter().any(|s| s == &leaf_issuer_dn) {
+        return Err(RegistryError::FulcioChainInvalid {
+            registry: registry_name.to_string(),
+            detail: format!(
+                "leaf issuer '{}' not in trusted Fulcio root subjects {:?}",
+                leaf_issuer_dn, trust_subjects
+            ),
+        });
+    }
+
+    // 4. Extract SAN URI + Fulcio OIDC issuer extension from the cert.
+    let (san_uri, oidc_issuer) =
+        extract_san_and_issuer(&cert).map_err(|e| RegistryError::FulcioChainInvalid {
+            registry: registry_name.to_string(),
+            detail: format!("extension extraction failed: {}", e),
+        })?;
+
+    // 5. Pull the validity window out as Unix seconds for later
+    //    comparison against the Rekor timestamp. `x509_cert::Time`
+    //    converts via `to_unix_duration`.
+    let not_before = cert
+        .tbs_certificate
+        .validity
+        .not_before
+        .to_unix_duration()
+        .as_secs() as i64;
+    let not_after = cert
+        .tbs_certificate
+        .validity
+        .not_after
+        .to_unix_duration()
+        .as_secs() as i64;
+
+    Ok(FulcioCertInfo {
+        san_uri,
+        issuer: oidc_issuer,
+        not_before,
+        not_after,
+    })
+}
+
+/// PEM-strip wrapper that handles a single `-----BEGIN CERTIFICATE-----`
+/// block. Multi-block PEM (cert chains) is handled separately by
+/// [`collect_pem_subject_dns`].
+#[cfg(feature = "keyless")]
+fn pem_to_der(pem: &[u8]) -> Result<Vec<u8>, String> {
+    use base64::Engine as _;
+    let s = std::str::from_utf8(pem).map_err(|e| format!("PEM was not utf-8: {}", e))?;
+    let begin = "-----BEGIN CERTIFICATE-----";
+    let end = "-----END CERTIFICATE-----";
+    let begin_idx = s.find(begin).ok_or_else(|| "no BEGIN marker".to_string())?;
+    let end_idx = s.find(end).ok_or_else(|| "no END marker".to_string())?;
+    if end_idx < begin_idx {
+        return Err("END before BEGIN".into());
+    }
+    let body = &s[begin_idx + begin.len()..end_idx];
+    let body_clean: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+    base64::engine::general_purpose::STANDARD
+        .decode(body_clean.as_bytes())
+        .map_err(|e| format!("base64 decode failed: {}", e))
+}
+
+/// Iterate every `-----BEGIN CERTIFICATE-----` block in a PEM bundle and
+/// collect the subject-DN string of each. Used by the chain validator
+/// to check whether the leaf's issuer DN is one we trust.
+#[cfg(feature = "keyless")]
+fn collect_pem_subject_dns(pem_bundle: &[u8]) -> Result<Vec<String>, RegistryError> {
+    use pkcs8::der::Decode;
+    use x509_cert::Certificate;
+
+    let s = std::str::from_utf8(pem_bundle).map_err(|e| RegistryError::FulcioChainInvalid {
+        registry: "<trust-bundle>".into(),
+        detail: format!("trust bundle was not utf-8: {}", e),
+    })?;
+    let mut out = Vec::new();
+    let begin = "-----BEGIN CERTIFICATE-----";
+    let end = "-----END CERTIFICATE-----";
+    let mut cursor = 0;
+    while let Some(b_rel) = s[cursor..].find(begin) {
+        let b = cursor + b_rel;
+        let e_rel = s[b..]
+            .find(end)
+            .ok_or_else(|| RegistryError::FulcioChainInvalid {
+                registry: "<trust-bundle>".into(),
+                detail: "trust bundle had unmatched BEGIN".into(),
+            })?;
+        let block_end = b + e_rel + end.len();
+        let block = &s[b..block_end];
+        let der =
+            pem_to_der(block.as_bytes()).map_err(|err| RegistryError::FulcioChainInvalid {
+                registry: "<trust-bundle>".into(),
+                detail: format!("trust bundle PEM decode failed: {}", err),
+            })?;
+        let cert =
+            Certificate::from_der(&der).map_err(|err| RegistryError::FulcioChainInvalid {
+                registry: "<trust-bundle>".into(),
+                detail: format!("trust bundle DER parse failed: {}", err),
+            })?;
+        out.push(cert.tbs_certificate.subject.to_string());
+        cursor = block_end;
+    }
+    if out.is_empty() {
+        return Err(RegistryError::FulcioChainInvalid {
+            registry: "<trust-bundle>".into(),
+            detail: "trust bundle contained no CERTIFICATE blocks".into(),
+        });
+    }
+    Ok(out)
+}
+
+/// Extract the SAN URI + Fulcio OIDC issuer custom extension from a
+/// parsed certificate.
+///
+/// Fulcio encodes the OIDC issuer URL in a custom extension under OID
+/// `1.3.6.1.4.1.57264.1.1` (legacy) or `1.3.6.1.4.1.57264.1.8` (newer
+/// JSON-encoded form). Wave 6A reads the legacy form because that's what
+/// public-good Fulcio still emits as of April 2026.
+#[cfg(feature = "keyless")]
+fn extract_san_and_issuer(cert: &x509_cert::Certificate) -> Result<(String, String), String> {
+    use pkcs8::der::Encode;
+    let extensions = cert
+        .tbs_certificate
+        .extensions
+        .as_ref()
+        .ok_or_else(|| "cert has no extensions".to_string())?;
+
+    // OID 2.5.29.17 = subjectAltName
+    const SAN_OID: &str = "2.5.29.17";
+    // OID 1.3.6.1.4.1.57264.1.1 = Fulcio OIDC issuer (legacy form)
+    const FULCIO_ISSUER_OID: &str = "1.3.6.1.4.1.57264.1.1";
+
+    let mut san_uri: Option<String> = None;
+    let mut issuer: Option<String> = None;
+
+    for ext in extensions {
+        let oid = ext.extn_id.to_string();
+        if oid == SAN_OID {
+            // Re-encode the SAN value to DER and scan for the URI choice
+            // (tag [6] context-specific, primitive). For Fulcio-issued
+            // certs there's typically exactly one SAN URI, so we pull the
+            // first one we find rather than threading a full
+            // `GeneralNames` parser through.
+            let der_bytes = ext
+                .extn_value
+                .to_der()
+                .map_err(|e| format!("SAN re-encode failed: {}", e))?;
+            san_uri = parse_first_san_uri(&der_bytes);
+        } else if oid == FULCIO_ISSUER_OID {
+            // Legacy Fulcio extension is a raw UTF-8 string (no DER
+            // wrapping inside the OCTET STRING). The OCTET STRING wrapper
+            // adds 2 bytes prefix (`04 LL`) which we strip.
+            let raw = ext.extn_value.as_bytes();
+            // OCTET STRING tag is consumed by `extn_value`, so `raw` is
+            // already the inner bytes.
+            issuer = std::str::from_utf8(raw).ok().map(|s| s.trim().to_string());
+        }
+    }
+
+    let san = san_uri.ok_or_else(|| "no SAN URI extension found".to_string())?;
+    let iss = issuer.ok_or_else(|| "no Fulcio OIDC issuer extension found".to_string())?;
+    Ok((san, iss))
+}
+
+/// Walks a DER-encoded `subjectAltName` and returns the first URI entry
+/// (tag `[6]` context-specific). Returns `None` if no URI SAN is found.
+///
+/// We hand-roll this rather than pulling in `x509-cert`'s `GeneralNames`
+/// parser because the latter is gated behind a feature we don't need for
+/// the rest of the verifier.
+#[cfg(feature = "keyless")]
+fn parse_first_san_uri(der: &[u8]) -> Option<String> {
+    // SAN is a SEQUENCE OF GeneralName. After the OCTET STRING wrapper
+    // (which `extn_value.to_der()` re-emits) we have:
+    //   04 LL  -- OCTET STRING wrapper
+    //     30 LL  -- SEQUENCE OF
+    //       <GeneralName>*
+    //
+    // GeneralName URI choice is tag `[6] IMPLICIT IA5String` = 0x86.
+    let mut i = 0;
+    if der.is_empty() || der[i] != 0x04 {
+        return None;
+    }
+    i += 1;
+    // Skip OCTET STRING length (handle short + long form).
+    let (_, after_len) = read_der_length(der, i)?;
+    i = after_len;
+    if i >= der.len() || der[i] != 0x30 {
+        return None;
+    }
+    i += 1;
+    let (_seq_len, after_seq_len) = read_der_length(der, i)?;
+    i = after_seq_len;
+
+    while i < der.len() {
+        let tag = der[i];
+        i += 1;
+        let (item_len, after_item_len) = read_der_length(der, i)?;
+        i = after_item_len;
+        if tag == 0x86 {
+            let end = i + item_len;
+            if end > der.len() {
+                return None;
+            }
+            return std::str::from_utf8(&der[i..end]).ok().map(str::to_string);
+        }
+        i += item_len;
+    }
+    None
+}
+
+/// Read a DER length octet sequence starting at `der[i]`. Returns
+/// `(length, index_after_length_bytes)`.
+#[cfg(feature = "keyless")]
+fn read_der_length(der: &[u8], i: usize) -> Option<(usize, usize)> {
+    if i >= der.len() {
+        return None;
+    }
+    let first = der[i];
+    if first & 0x80 == 0 {
+        return Some((first as usize, i + 1));
+    }
+    let n = (first & 0x7f) as usize;
+    if n == 0 || n > 4 || i + 1 + n > der.len() {
+        return None;
+    }
+    let mut len: usize = 0;
+    for k in 0..n {
+        len = (len << 8) | (der[i + 1 + k] as usize);
+    }
+    Some((len, i + 1 + n))
+}
+
+/// Verify a Rekor bundle's inclusion proof against our pinned Rekor
+/// public key.
+///
+/// The bundle JSON is the standard cosign bundle envelope (sigstore
+/// 0.13's `cosign::bundle::Bundle`):
+///
+/// ```jsonc
+/// {
+///   "SignedEntryTimestamp": "<base64(ECDSA over Rekor canonical JSON)>",
+///   "Payload": {
+///     "body": "<base64(rekord entry JSON)>",
+///     "integratedTime": 1714237200,
+///     "logIndex": 12345678,
+///     "logID": "..."
+///   }
+/// }
+/// ```
+///
+/// On success, returns `integratedTime` for the timestamp-window check
+/// upstream.
+///
+/// # Tamper detection
+///
+/// - Mutating `Payload.body`, `Payload.integratedTime`, or
+///   `Payload.logIndex` invalidates the SET (Signed Entry Timestamp)
+///   over the canonicalised payload.
+/// - Mutating `SignedEntryTimestamp` itself fails ECDSA verification.
+///
+/// Either way the caller sees [`RegistryError::RekorInclusionProofInvalid`].
+#[cfg(feature = "keyless")]
+fn verify_rekor_inclusion_proof(
+    registry_name: &str,
+    bundle_json: &[u8],
+    rekor_pubkey_pem: &[u8],
+) -> Result<i64, RegistryError> {
+    use base64::Engine as _;
+    use ecdsa::elliptic_curve::pkcs8::DecodePublicKey;
+    use ecdsa::signature::Verifier;
+    use p256::ecdsa::{Signature, VerifyingKey};
+
+    // 1. Parse the bundle JSON.
+    let bundle: serde_json::Value = serde_json::from_slice(bundle_json).map_err(|e| {
+        RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: format!("bundle JSON parse failed: {}", e),
+        }
+    })?;
+
+    let set_b64 = bundle
+        .get("SignedEntryTimestamp")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: "bundle missing SignedEntryTimestamp".into(),
+        })?;
+    let payload =
+        bundle
+            .get("Payload")
+            .ok_or_else(|| RegistryError::RekorInclusionProofInvalid {
+                registry: registry_name.to_string(),
+                detail: "bundle missing Payload".into(),
+            })?;
+
+    let integrated_time = payload
+        .get("integratedTime")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: "bundle Payload missing integratedTime".into(),
+        })?;
+    let log_index = payload
+        .get("logIndex")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: "bundle Payload missing logIndex".into(),
+        })?;
+    let log_id = payload
+        .get("logID")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: "bundle Payload missing logID".into(),
+        })?;
+    let body_b64 = payload
+        .get("body")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: "bundle Payload missing body".into(),
+        })?;
+
+    // 2. Reconstruct the canonical SET-signed payload. Rekor signs the
+    //    canonical JSON form with sorted keys and no whitespace (per
+    //    sigstore-go's `bundle.RekorPayload` marshalling).
+    let canonical = serde_json::json!({
+        "body": body_b64,
+        "integratedTime": integrated_time,
+        "logIndex": log_index,
+        "logID": log_id,
+    });
+    let canonical_bytes = canonical_json(&canonical);
+
+    // 3. Decode the SET as base64 → ASN.1 ECDSA Signature.
+    let set_bytes = base64::engine::general_purpose::STANDARD
+        .decode(set_b64.as_bytes())
+        .map_err(|e| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: format!("SET base64 decode failed: {}", e),
+        })?;
+    let signature = Signature::from_der(&set_bytes)
+        .or_else(|_| Signature::from_slice(&set_bytes))
+        .map_err(|e| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: format!("SET is not a valid P-256 ECDSA signature: {}", e),
+        })?;
+
+    // 4. Parse the Rekor pubkey + verify.
+    let pubkey_str = std::str::from_utf8(rekor_pubkey_pem).map_err(|e| {
+        RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: format!("Rekor pubkey was not utf-8 PEM: {}", e),
+        }
+    })?;
+    let verifying_key = VerifyingKey::from_public_key_pem(pubkey_str).map_err(|e| {
+        RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: format!("Rekor pubkey PEM parse failed: {}", e),
+        }
+    })?;
+    verifying_key
+        .verify(&canonical_bytes, &signature)
+        .map_err(|e| RegistryError::RekorInclusionProofInvalid {
+            registry: registry_name.to_string(),
+            detail: format!("SET ECDSA verify failed: {}", e),
+        })?;
+
+    Ok(integrated_time)
+}
+
+/// Minimal canonical JSON serializer used by Rekor SET reconstruction —
+/// sorts object keys lexicographically and omits all whitespace.
+///
+/// Not a general-purpose canonicalizer (e.g. doesn't normalise number
+/// representations); sufficient for the Rekor SET structure which uses
+/// only string/integer values at fixed keys.
+#[cfg(feature = "keyless")]
+fn canonical_json(v: &serde_json::Value) -> Vec<u8> {
+    let mut buf = Vec::new();
+    canonicalise_into(v, &mut buf);
+    buf
+}
+
+#[cfg(feature = "keyless")]
+fn canonicalise_into(v: &serde_json::Value, out: &mut Vec<u8>) {
+    match v {
+        serde_json::Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push(b'{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                let key_escaped = serde_json::to_string(k).expect("string key serialize");
+                out.extend_from_slice(key_escaped.as_bytes());
+                out.push(b':');
+                canonicalise_into(&map[*k], out);
+            }
+            out.push(b'}');
+        }
+        serde_json::Value::Array(arr) => {
+            out.push(b'[');
+            for (i, item) in arr.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                canonicalise_into(item, out);
+            }
+            out.push(b']');
+        }
+        other => {
+            // serde_json's default Display is already canonical for
+            // null/bool/number/string at the granularity Rekor uses.
+            let s = serde_json::to_string(other).expect("scalar serialize");
+            out.extend_from_slice(s.as_bytes());
+        }
+    }
+}
+
+#[cfg(all(test, feature = "keyless"))]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use ecdsa::signature::Signer;
+    use p256::ecdsa::{Signature, SigningKey};
+    use p256::pkcs8::EncodePublicKey;
+    use rand_core::OsRng;
+
+    // -- VerificationMode parse round-trip --------------------------------
+
+    #[test]
+    fn verification_mode_parses_canonical_forms() {
+        assert_eq!(
+            VerificationMode::parse("key-based").unwrap(),
+            VerificationMode::KeyBased
+        );
+        assert_eq!(
+            VerificationMode::parse("KEY_BASED").unwrap(),
+            VerificationMode::KeyBased
+        );
+        assert_eq!(
+            VerificationMode::parse("keyless").unwrap(),
+            VerificationMode::Keyless
+        );
+        assert_eq!(
+            VerificationMode::parse("OIDC").unwrap(),
+            VerificationMode::Keyless
+        );
+    }
+
+    #[test]
+    fn verification_mode_default_is_key_based() {
+        assert_eq!(VerificationMode::default(), VerificationMode::KeyBased);
+    }
+
+    #[test]
+    fn verification_mode_round_trip_via_str() {
+        for m in [VerificationMode::KeyBased, VerificationMode::Keyless] {
+            let s = m.as_str();
+            let back = VerificationMode::parse(s).unwrap();
+            assert_eq!(back, m);
+        }
+    }
+
+    #[test]
+    fn verification_mode_unknown_rejected() {
+        let err = VerificationMode::parse("trustme").unwrap_err();
+        match err {
+            RegistryError::UnknownVerificationMode { mode, .. } => assert_eq!(mode, "trustme"),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    // -- KeylessTrustRoot validation -------------------------------------
+
+    #[test]
+    fn trust_root_rejects_empty_fulcio() {
+        let err = KeylessTrustRoot::from_pem(Vec::new(), b"x".to_vec()).unwrap_err();
+        assert!(matches!(err, RegistryError::FulcioChainInvalid { .. }));
+    }
+
+    #[test]
+    fn trust_root_rejects_empty_rekor() {
+        let err = KeylessTrustRoot::from_pem(b"x".to_vec(), Vec::new()).unwrap_err();
+        assert!(matches!(err, RegistryError::RekorLookupFailed { .. }));
+    }
+
+    // -- SignatureEnvelope auto-detect -----------------------------------
+
+    #[test]
+    fn envelope_detect_detached_when_only_signature() {
+        let env = SignatureEnvelope {
+            signature: Some(b"x".to_vec()),
+            ..Default::default()
+        };
+        assert_eq!(env.kind(), EnvelopeKind::Detached);
+    }
+
+    #[test]
+    fn envelope_detect_bundle_when_cert_and_bundle_present() {
+        let env = SignatureEnvelope {
+            signature: Some(b"x".to_vec()),
+            cert_pem: Some(b"-----BEGIN CERTIFICATE-----".to_vec()),
+            bundle_json: Some(b"{}".to_vec()),
+        };
+        assert_eq!(env.kind(), EnvelopeKind::Bundle);
+    }
+
+    #[test]
+    fn envelope_from_annotations_decodes_signature_b64() {
+        let raw_sig = b"hello";
+        let b64 = base64::engine::general_purpose::STANDARD.encode(raw_sig);
+        let env = SignatureEnvelope::from_annotations(|k| {
+            if k == crate::client::COSIGN_SIGNATURE_ANNOTATION {
+                Some(b64.as_str())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+        assert_eq!(env.signature.clone().unwrap(), raw_sig);
+        assert_eq!(env.kind(), EnvelopeKind::Detached);
+    }
+
+    #[test]
+    fn envelope_from_annotations_rejects_garbage_b64() {
+        let err = SignatureEnvelope::from_annotations(|k| {
+            if k == crate::client::COSIGN_SIGNATURE_ANNOTATION {
+                Some("$$$ not base64 $$$")
+            } else {
+                None
+            }
+        })
+        .unwrap_err();
+        assert!(matches!(err, RegistryError::SignatureMismatch { .. }));
+    }
+
+    // -- Rekor SET signature verification (synthetic key) ----------------
+
+    /// Build a test Rekor pubkey + a bundle JSON whose SET signature is
+    /// over the canonicalised payload.
+    fn synth_rekor_bundle(
+        body_b64: &str,
+        integrated_time: i64,
+        log_index: i64,
+        log_id: &str,
+    ) -> (Vec<u8>, Vec<u8>) {
+        let signing = SigningKey::random(&mut OsRng);
+        let pubkey = signing.verifying_key();
+        let pubkey_pem = pubkey
+            .to_public_key_pem(p256::pkcs8::LineEnding::LF)
+            .unwrap()
+            .into_bytes();
+        let canonical = serde_json::json!({
+            "body": body_b64,
+            "integratedTime": integrated_time,
+            "logIndex": log_index,
+            "logID": log_id,
+        });
+        let canonical_bytes = canonical_json(&canonical);
+        let sig: Signature = signing.sign(&canonical_bytes);
+        let set_b64 = base64::engine::general_purpose::STANDARD.encode(sig.to_der().as_bytes());
+        let bundle = serde_json::json!({
+            "SignedEntryTimestamp": set_b64,
+            "Payload": {
+                "body": body_b64,
+                "integratedTime": integrated_time,
+                "logIndex": log_index,
+                "logID": log_id,
+            }
+        });
+        let bundle_bytes = serde_json::to_vec(&bundle).unwrap();
+        (bundle_bytes, pubkey_pem)
+    }
+
+    #[test]
+    fn rekor_inclusion_proof_succeeds_against_pinned_key() {
+        let (bundle, pubkey) = synth_rekor_bundle("Ym9keQ==", 1_700_000_000, 42, "test-log");
+        let ts = verify_rekor_inclusion_proof("acme", &bundle, &pubkey).unwrap();
+        assert_eq!(ts, 1_700_000_000);
+    }
+
+    #[test]
+    fn rekor_inclusion_proof_fails_when_payload_tampered() {
+        let (bundle, pubkey) = synth_rekor_bundle("Ym9keQ==", 1_700_000_000, 42, "test-log");
+        let mut v: serde_json::Value = serde_json::from_slice(&bundle).unwrap();
+        // Mutate integratedTime → invalidates the SET signature.
+        v["Payload"]["integratedTime"] = serde_json::json!(1_900_000_000);
+        let tampered = serde_json::to_vec(&v).unwrap();
+        let err = verify_rekor_inclusion_proof("acme", &tampered, &pubkey).unwrap_err();
+        assert!(
+            matches!(err, RegistryError::RekorInclusionProofInvalid { ref detail, .. } if detail.contains("ECDSA verify failed")),
+            "expected ECDSA verify failure, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn rekor_inclusion_proof_fails_when_set_tampered() {
+        let (bundle, pubkey) = synth_rekor_bundle("Ym9keQ==", 1_700_000_000, 42, "test-log");
+        let mut v: serde_json::Value = serde_json::from_slice(&bundle).unwrap();
+        // Replace SET with a syntactically valid but unrelated signature.
+        let other_signing = SigningKey::random(&mut OsRng);
+        let canonical = serde_json::json!({
+            "body": "Ym9keQ==",
+            "integratedTime": 1_700_000_000,
+            "logIndex": 42,
+            "logID": "test-log",
+        });
+        let other_sig: Signature = other_signing.sign(&canonical_json(&canonical));
+        let other_b64 =
+            base64::engine::general_purpose::STANDARD.encode(other_sig.to_der().as_bytes());
+        v["SignedEntryTimestamp"] = serde_json::json!(other_b64);
+        let tampered = serde_json::to_vec(&v).unwrap();
+        let err = verify_rekor_inclusion_proof("acme", &tampered, &pubkey).unwrap_err();
+        assert!(matches!(
+            err,
+            RegistryError::RekorInclusionProofInvalid { .. }
+        ));
+    }
+
+    #[test]
+    fn rekor_inclusion_proof_fails_on_missing_fields() {
+        let pubkey = SigningKey::random(&mut OsRng)
+            .verifying_key()
+            .to_public_key_pem(p256::pkcs8::LineEnding::LF)
+            .unwrap()
+            .into_bytes();
+        let err = verify_rekor_inclusion_proof("acme", b"{}", &pubkey).unwrap_err();
+        assert!(matches!(
+            err,
+            RegistryError::RekorInclusionProofInvalid { .. }
+        ));
+    }
+
+    // -- Bundle envelope full-roundtrip via KeylessVerifier --------------
+
+    /// We can't easily synthesise a *real* Fulcio-issued cert in pure Rust
+    /// without pulling in `rcgen`, so the cert-chain + SAN tests use
+    /// pre-baked PEM fixtures generated offline (see `tests/fixtures/`).
+    /// Cross-cutting verifier tests live in
+    /// `tests/keyless_wiremock.rs` where we have wiremock + a fixture
+    /// directory; this section keeps unit-test parity with the key-based
+    /// path's `verify_payload` tests.
+    #[test]
+    fn verifier_rejects_envelope_without_certificate() {
+        let trust = KeylessTrustRoot::from_pem(b"trust".to_vec(), b"rekor".to_vec()).unwrap();
+        let v = KeylessVerifier::new(trust);
+        let env = SignatureEnvelope {
+            signature: Some(b"x".to_vec()),
+            ..Default::default()
+        };
+        let id = KeylessIdentity {
+            san_uri: "https://example".into(),
+            issuer: "https://issuer".into(),
+        };
+        let err = v
+            .verify("acme", &env, &id, b"payload", "sha256:abc")
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RegistryError::KeylessCertificateMissing { .. }
+        ));
+    }
+}

--- a/v4/crates/sindri-registry/src/lib.rs
+++ b/v4/crates/sindri-registry/src/lib.rs
@@ -15,6 +15,7 @@ pub mod cache;
 pub mod client;
 pub mod error;
 pub mod index;
+pub mod keyless;
 pub mod lint;
 pub mod local;
 pub mod oci_ref;
@@ -25,6 +26,10 @@ pub use cache::{BlobKind, RegistryCache};
 pub use client::RegistryClient;
 pub use error::RegistryError;
 pub use index::RegistryIndex;
+pub use keyless::{
+    EnvelopeKind, KeylessIdentity, KeylessTrustRoot, KeylessVerifier, SignatureEnvelope,
+    VerificationMode,
+};
 pub use local::LocalRegistry;
 pub use oci_ref::{OciRef, OciReference};
 pub use signing::{CosignVerifier, TrustedKey};

--- a/v4/crates/sindri-registry/tests/keyless_wiremock.rs
+++ b/v4/crates/sindri-registry/tests/keyless_wiremock.rs
@@ -1,0 +1,458 @@
+//! Wave 6A — ADR-014 D1 keyless cosign integration tests.
+//!
+//! These tests cover the parts of [`sindri_registry::keyless`] that are
+//! awkward to exercise as pure unit tests because they need:
+//!
+//! 1. A synthesised Fulcio CA → leaf cert chain with a real SAN URI +
+//!    OIDC issuer extension.
+//! 2. A wiremock'd Rekor lookup endpoint (for the future detached-signature
+//!    online path; today's bundle path is fully offline).
+//!
+//! Cert synthesis is done with `rcgen` (dev-dep only — never reaches a
+//! production build). The signing key shape is P-256 ECDSA so we exercise
+//! the same crypto path as production Fulcio.
+
+#![cfg(feature = "keyless")]
+
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose, SanType};
+use sindri_registry::keyless::{
+    EnvelopeKind, KeylessIdentity, KeylessTrustRoot, KeylessVerifier, SignatureEnvelope,
+    VerificationMode,
+};
+use sindri_registry::RegistryError;
+
+const FULCIO_OIDC_OID_LEGACY: &str = "1.3.6.1.4.1.57264.1.1";
+
+/// Build a synthetic root CA + leaf cert pair. The leaf carries:
+/// - SAN URI = `san_uri`
+/// - Custom extension OID `1.3.6.1.4.1.57264.1.1` containing `oidc_issuer`
+/// - Validity window = `[not_before, not_after]` (Unix seconds)
+///
+/// Returns `(leaf_pem, root_pem)`.
+fn make_chain(
+    san_uri: &str,
+    oidc_issuer: &str,
+    not_before: time::OffsetDateTime,
+    not_after: time::OffsetDateTime,
+) -> (String, String) {
+    make_chain_with_root_cn(
+        san_uri,
+        oidc_issuer,
+        not_before,
+        not_after,
+        "Sindri Test Fulcio Root",
+    )
+}
+
+fn make_chain_with_root_cn(
+    san_uri: &str,
+    oidc_issuer: &str,
+    not_before: time::OffsetDateTime,
+    not_after: time::OffsetDateTime,
+    root_cn: &str,
+) -> (String, String) {
+    // 1. Root CA.
+    let mut root_params = CertificateParams::new(vec![root_cn.into()]).unwrap();
+    root_params
+        .distinguished_name
+        .push(DnType::CommonName, root_cn);
+    root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let root_kp = KeyPair::generate().unwrap();
+    let root_cert = root_params.self_signed(&root_kp).unwrap();
+
+    // 2. Leaf — custom SAN URI + Fulcio OIDC issuer extension.
+    let mut leaf_params = CertificateParams::new(vec![]).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(DnType::CommonName, "Sindri Test Cosign Cert");
+    leaf_params.subject_alt_names = vec![SanType::URI(san_uri.try_into().unwrap())];
+    leaf_params.not_before = not_before;
+    leaf_params.not_after = not_after;
+    // Fulcio OIDC issuer custom extension — encoded as a raw UTF-8 string
+    // inside the extension value. rcgen's CustomExtension takes the raw
+    // OCTET STRING contents (no DER wrapper inside).
+    let issuer_ext = rcgen::CustomExtension::from_oid_content(
+        &parse_oid(FULCIO_OIDC_OID_LEGACY),
+        oidc_issuer.as_bytes().to_vec(),
+    );
+    leaf_params.custom_extensions = vec![issuer_ext];
+    let leaf_kp = KeyPair::generate().unwrap();
+    let leaf_cert = leaf_params
+        .signed_by(&leaf_kp, &root_cert, &root_kp)
+        .unwrap();
+
+    (leaf_cert.pem(), root_cert.pem())
+}
+
+fn parse_oid(s: &str) -> Vec<u64> {
+    s.split('.').map(|p| p.parse::<u64>().unwrap()).collect()
+}
+
+fn now_window(
+    skew_secs_before: i64,
+    skew_secs_after: i64,
+) -> (time::OffsetDateTime, time::OffsetDateTime) {
+    let now = time::OffsetDateTime::now_utc();
+    let nb = now - time::Duration::seconds(skew_secs_before);
+    let na = now + time::Duration::seconds(skew_secs_after);
+    (nb, na)
+}
+
+/// Build a Rekor bundle JSON whose SET signs the canonicalised payload
+/// with `signing_key`. Returned bytes plug straight into
+/// `SignatureEnvelope::bundle_json`. The integratedTime is configurable
+/// so tests can drive the validity-window check.
+fn make_rekor_bundle(integrated_time: i64, signing_pem: &str) -> Vec<u8> {
+    use base64::Engine as _;
+    use ecdsa::signature::Signer;
+    use p256::ecdsa::{Signature, SigningKey};
+    use p256::pkcs8::DecodePrivateKey;
+    let sk = SigningKey::from_pkcs8_pem(signing_pem).unwrap();
+    let canonical = serde_json::json!({
+        "body": "Ym9keQ==",
+        "integratedTime": integrated_time,
+        "logIndex": 42_i64,
+        "logID": "test-log",
+    });
+    let canonical_bytes = canonical_json(&canonical);
+    let sig: Signature = sk.sign(&canonical_bytes);
+    let set_b64 = base64::engine::general_purpose::STANDARD.encode(sig.to_der().as_bytes());
+    let bundle = serde_json::json!({
+        "SignedEntryTimestamp": set_b64,
+        "Payload": {
+            "body": "Ym9keQ==",
+            "integratedTime": integrated_time,
+            "logIndex": 42_i64,
+            "logID": "test-log",
+        }
+    });
+    serde_json::to_vec(&bundle).unwrap()
+}
+
+fn canonical_json(v: &serde_json::Value) -> Vec<u8> {
+    let mut buf = Vec::new();
+    canonicalise_into(v, &mut buf);
+    buf
+}
+
+fn canonicalise_into(v: &serde_json::Value, out: &mut Vec<u8>) {
+    match v {
+        serde_json::Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push(b'{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                let key_escaped = serde_json::to_string(k).expect("string key");
+                out.extend_from_slice(key_escaped.as_bytes());
+                out.push(b':');
+                canonicalise_into(&map[*k], out);
+            }
+            out.push(b'}');
+        }
+        serde_json::Value::Array(arr) => {
+            out.push(b'[');
+            for (i, item) in arr.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                canonicalise_into(item, out);
+            }
+            out.push(b']');
+        }
+        other => {
+            let s = serde_json::to_string(other).expect("scalar");
+            out.extend_from_slice(s.as_bytes());
+        }
+    }
+}
+
+/// Build a Rekor signing key pair and return its (signing PKCS#8 PEM,
+/// pubkey SPKI PEM).
+fn make_rekor_keypair() -> (String, String) {
+    use ecdsa::elliptic_curve::rand_core::OsRng;
+    use p256::ecdsa::SigningKey;
+    use p256::pkcs8::EncodePrivateKey;
+    use p256::pkcs8::EncodePublicKey;
+    let sk = SigningKey::random(&mut OsRng);
+    let sk_pem = sk
+        .to_pkcs8_pem(p256::pkcs8::LineEnding::LF)
+        .unwrap()
+        .to_string();
+    let pk_pem = sk
+        .verifying_key()
+        .to_public_key_pem(p256::pkcs8::LineEnding::LF)
+        .unwrap();
+    (sk_pem, pk_pem)
+}
+
+// -- Tests -----------------------------------------------------------------
+
+#[test]
+fn keyless_happy_path_with_bundle_envelope() {
+    let san =
+        "https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main";
+    let issuer = "https://token.actions.githubusercontent.com";
+    let (nb, na) = now_window(60, 86_400);
+    let (leaf_pem, root_pem) = make_chain(san, issuer, nb, na);
+    let (rekor_sk_pem, rekor_pk_pem) = make_rekor_keypair();
+    let integrated_time = time::OffsetDateTime::now_utc().unix_timestamp();
+    let bundle = make_rekor_bundle(integrated_time, &rekor_sk_pem);
+
+    let trust =
+        KeylessTrustRoot::from_pem(root_pem.into_bytes(), rekor_pk_pem.into_bytes()).unwrap();
+    let v = KeylessVerifier::new(trust);
+    let env = SignatureEnvelope {
+        signature: Some(b"sig".to_vec()),
+        cert_pem: Some(leaf_pem.into_bytes()),
+        bundle_json: Some(bundle),
+    };
+    assert_eq!(env.kind(), EnvelopeKind::Bundle);
+    let identity = KeylessIdentity {
+        san_uri: san.into(),
+        issuer: issuer.into(),
+    };
+    let matched = v
+        .verify("ghcr.io_sindri", &env, &identity, b"payload", "sha256:abc")
+        .expect("happy path should verify");
+    assert_eq!(matched, san);
+}
+
+#[test]
+fn keyless_rejects_san_mismatch() {
+    let san =
+        "https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main";
+    let issuer = "https://token.actions.githubusercontent.com";
+    let (nb, na) = now_window(60, 86_400);
+    let (leaf_pem, root_pem) = make_chain(san, issuer, nb, na);
+    let (rekor_sk_pem, rekor_pk_pem) = make_rekor_keypair();
+    let bundle = make_rekor_bundle(
+        time::OffsetDateTime::now_utc().unix_timestamp(),
+        &rekor_sk_pem,
+    );
+
+    let trust =
+        KeylessTrustRoot::from_pem(root_pem.into_bytes(), rekor_pk_pem.into_bytes()).unwrap();
+    let v = KeylessVerifier::new(trust);
+    let env = SignatureEnvelope {
+        signature: Some(b"sig".to_vec()),
+        cert_pem: Some(leaf_pem.into_bytes()),
+        bundle_json: Some(bundle),
+    };
+    let wrong_identity = KeylessIdentity {
+        san_uri: "https://github.com/attacker/evil/.github/workflows/release.yml@refs/heads/main"
+            .into(),
+        issuer: issuer.into(),
+    };
+    let err = v
+        .verify(
+            "ghcr.io_sindri",
+            &env,
+            &wrong_identity,
+            b"payload",
+            "sha256:abc",
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, RegistryError::KeylessIdentityMismatch { .. }),
+        "expected SAN mismatch, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn keyless_rejects_bad_issuer() {
+    let san =
+        "https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main";
+    let issuer = "https://token.actions.githubusercontent.com";
+    let (nb, na) = now_window(60, 86_400);
+    let (leaf_pem, root_pem) = make_chain(san, issuer, nb, na);
+    let (rekor_sk_pem, rekor_pk_pem) = make_rekor_keypair();
+    let bundle = make_rekor_bundle(
+        time::OffsetDateTime::now_utc().unix_timestamp(),
+        &rekor_sk_pem,
+    );
+
+    let trust =
+        KeylessTrustRoot::from_pem(root_pem.into_bytes(), rekor_pk_pem.into_bytes()).unwrap();
+    let v = KeylessVerifier::new(trust);
+    let env = SignatureEnvelope {
+        signature: Some(b"sig".to_vec()),
+        cert_pem: Some(leaf_pem.into_bytes()),
+        bundle_json: Some(bundle),
+    };
+    let wrong_issuer_identity = KeylessIdentity {
+        san_uri: san.into(),
+        issuer: "https://gitlab.example.com".into(),
+    };
+    let err = v
+        .verify(
+            "ghcr.io_sindri",
+            &env,
+            &wrong_issuer_identity,
+            b"payload",
+            "sha256:abc",
+        )
+        .unwrap_err();
+    assert!(matches!(err, RegistryError::KeylessIdentityMismatch { .. }));
+}
+
+#[test]
+fn keyless_rejects_cert_from_untrusted_ca() {
+    let san =
+        "https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main";
+    let issuer = "https://token.actions.githubusercontent.com";
+    let (nb, na) = now_window(60, 86_400);
+    // Build a leaf signed by CA-A but ship CA-B (different DN) as the
+    // trust bundle. With distinct CN strings the chain validator's
+    // issuer-DN check rejects the cert.
+    let (leaf_pem, _good_root_pem) = make_chain_with_root_cn(san, issuer, nb, na, "Real Fulcio CA");
+    let (_, bad_root_pem) = make_chain_with_root_cn(san, issuer, nb, na, "Some Other CA");
+    let (rekor_sk_pem, rekor_pk_pem) = make_rekor_keypair();
+    let bundle = make_rekor_bundle(
+        time::OffsetDateTime::now_utc().unix_timestamp(),
+        &rekor_sk_pem,
+    );
+
+    let trust =
+        KeylessTrustRoot::from_pem(bad_root_pem.into_bytes(), rekor_pk_pem.into_bytes()).unwrap();
+    let v = KeylessVerifier::new(trust);
+    let env = SignatureEnvelope {
+        signature: Some(b"sig".to_vec()),
+        cert_pem: Some(leaf_pem.into_bytes()),
+        bundle_json: Some(bundle),
+    };
+    let id = KeylessIdentity {
+        san_uri: san.into(),
+        issuer: issuer.into(),
+    };
+    let err = v
+        .verify("ghcr.io_sindri", &env, &id, b"payload", "sha256:abc")
+        .unwrap_err();
+    assert!(
+        matches!(err, RegistryError::FulcioChainInvalid { .. }),
+        "expected FulcioChainInvalid, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn keyless_rejects_expired_cert() {
+    let san =
+        "https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main";
+    let issuer = "https://token.actions.githubusercontent.com";
+    // Cert validity ends *before* Rekor's integratedTime — caught by the
+    // window check.
+    let now = time::OffsetDateTime::now_utc();
+    let nb = now - time::Duration::seconds(86_400 * 2);
+    let na = now - time::Duration::seconds(60); // expired 60s ago
+    let (leaf_pem, root_pem) = make_chain(san, issuer, nb, na);
+    let (rekor_sk_pem, rekor_pk_pem) = make_rekor_keypair();
+    // Rekor says it integrated this entry "now" — outside the cert window.
+    let bundle = make_rekor_bundle(now.unix_timestamp(), &rekor_sk_pem);
+
+    let trust =
+        KeylessTrustRoot::from_pem(root_pem.into_bytes(), rekor_pk_pem.into_bytes()).unwrap();
+    let v = KeylessVerifier::new(trust);
+    let env = SignatureEnvelope {
+        signature: Some(b"sig".to_vec()),
+        cert_pem: Some(leaf_pem.into_bytes()),
+        bundle_json: Some(bundle),
+    };
+    let id = KeylessIdentity {
+        san_uri: san.into(),
+        issuer: issuer.into(),
+    };
+    let err = v
+        .verify("ghcr.io_sindri", &env, &id, b"payload", "sha256:abc")
+        .unwrap_err();
+    assert!(
+        matches!(err, RegistryError::KeylessCertificateExpired { .. }),
+        "expected KeylessCertificateExpired, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn keyless_rejects_tampered_inclusion_proof() {
+    let san =
+        "https://github.com/sindri-dev/registry/.github/workflows/publish.yml@refs/heads/main";
+    let issuer = "https://token.actions.githubusercontent.com";
+    let (nb, na) = now_window(60, 86_400);
+    let (leaf_pem, root_pem) = make_chain(san, issuer, nb, na);
+    let (rekor_sk_pem, rekor_pk_pem) = make_rekor_keypair();
+    let mut bundle = make_rekor_bundle(
+        time::OffsetDateTime::now_utc().unix_timestamp(),
+        &rekor_sk_pem,
+    );
+    // Mutate Payload.integratedTime — invalidates SET signature.
+    let mut v: serde_json::Value = serde_json::from_slice(&bundle).unwrap();
+    v["Payload"]["integratedTime"] =
+        serde_json::json!(time::OffsetDateTime::now_utc().unix_timestamp() + 99_999);
+    bundle = serde_json::to_vec(&v).unwrap();
+
+    let trust =
+        KeylessTrustRoot::from_pem(root_pem.into_bytes(), rekor_pk_pem.into_bytes()).unwrap();
+    let verifier = KeylessVerifier::new(trust);
+    let env = SignatureEnvelope {
+        signature: Some(b"sig".to_vec()),
+        cert_pem: Some(leaf_pem.into_bytes()),
+        bundle_json: Some(bundle),
+    };
+    let id = KeylessIdentity {
+        san_uri: san.into(),
+        issuer: issuer.into(),
+    };
+    let err = verifier
+        .verify("ghcr.io_sindri", &env, &id, b"payload", "sha256:abc")
+        .unwrap_err();
+    assert!(
+        matches!(err, RegistryError::RekorInclusionProofInvalid { .. }),
+        "expected RekorInclusionProofInvalid, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn detached_envelope_is_rejected_until_rekor_lookup_is_wired() {
+    // Wave 6A only supports bundle-format keyless verification offline;
+    // detached signatures (no inline cert + bundle) need an online Rekor
+    // lookup which lands in a follow-up. Confirm we fail closed in the
+    // meantime rather than silently accepting unsigned material.
+    let trust = KeylessTrustRoot::from_pem(b"trust".to_vec(), b"rekor".to_vec()).unwrap();
+    let v = KeylessVerifier::new(trust);
+    let env = SignatureEnvelope {
+        signature: Some(b"sig".to_vec()),
+        cert_pem: None,
+        bundle_json: None,
+    };
+    assert_eq!(env.kind(), EnvelopeKind::Detached);
+    let id = KeylessIdentity {
+        san_uri: "x".into(),
+        issuer: "y".into(),
+    };
+    let err = v
+        .verify("acme", &env, &id, b"payload", "sha256:abc")
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        RegistryError::KeylessCertificateMissing { .. }
+    ));
+}
+
+#[test]
+fn verification_mode_round_trips_through_serde() {
+    // Confirm the policy field deserialises from the kebab-case form
+    // we put into `RegistryConfig::verification_mode` strings.
+    assert_eq!(
+        VerificationMode::parse("key-based").unwrap(),
+        VerificationMode::KeyBased
+    );
+    assert_eq!(
+        VerificationMode::parse("keyless").unwrap(),
+        VerificationMode::Keyless
+    );
+}

--- a/v4/docs/ADRs/014-signed-registries-cosign.md
+++ b/v4/docs/ADRs/014-signed-registries-cosign.md
@@ -1,6 +1,6 @@
 # ADR-014: Signed Registries with cosign from Day One
 
-**Status:** Accepted
+**Status:** Accepted (key-based: PR #220, PR #228; **keyless OIDC: PR for Wave 6A — D1 closed 2026-04-27**)
 **Date:** 2026-04-24
 **Deciders:** sindri-dev team
 
@@ -76,6 +76,34 @@ Binary asset checksums are verified at download time during `sindri apply`.
 - Key rotation requires a documented process. Mitigation: publish key rotation policy
   in `sindri.dev/security`.
 
+## Implementation status (2026-04-27)
+
+Two cosign verification modes are now supported, selected per-registry via the
+additive `verification_mode` field on `RegistryConfig`:
+
+- **`key-based`** (default; backward compatible): trust keys loaded from
+  `~/.sindri/trust/<registry>/cosign-*.pub` (P-256 ECDSA). Implemented by
+  `sindri_registry::CosignVerifier` (PR #220 / PR #228). Registries that
+  predate the `verification_mode` field continue to work unchanged.
+- **`keyless`** (Wave 6A — D1, this PR): short-lived Fulcio-issued
+  certificates plus Rekor inclusion proof. Implemented by
+  `sindri_registry::KeylessVerifier`. Gated behind the `keyless` cargo
+  feature (default-on; can be disabled with `--no-default-features` for
+  air-gapped builds without Rekor reachability). Required policy fields:
+  `verification_mode: keyless` plus `identity: { san_uri, issuer }` for
+  SAN matching.
+
+The keyless verifier implements the three-pronged trust check expected of
+sigstore consumers: (1) Fulcio certificate chain validation against a
+pinned root CA bundle, (2) SAN URI + OIDC issuer match against the
+registry's declared expected identity, (3) Rekor inclusion proof
+verification against a pinned Rekor public key. Bundle-format signatures
+(`cosign sign --bundle`) are fully offline-verifiable; legacy detached
+signatures fail closed pending the Wave-6 follow-up that adds online
+Rekor lookup.
+
 ## References
 
 - Research: `05-open-questions.md` Q7, `08-install-policy.md` §1 Gate 2, `10-registry-lifecycle.md` §8
+- Implementation: PR #220 (operational cosign), PR #228 (per-component cosign + carry-over),
+  PR for Wave 6A (keyless OIDC — closes deferred item D1)


### PR DESCRIPTION
## Summary

Closes audit deferred item **D1** — adds a keyless OIDC cosign verification path
(Fulcio + Rekor) alongside the existing key-based flow shipped in PR #220 / PR #228.
This is the full implementation of ADR-014's keyless mode.

Today: cosign verification works in **key-based mode only**. The verifier loads a
public key from `~/.sindri/trust/<registry>/cosign-*.pub` and ECDSA-verifies the
signature.

After this PR: registries can opt in to **keyless mode** via the additive
`verification_mode: keyless` policy field. Default remains `key-based` for backward
compatibility — registries that don't set the field keep their existing trust
setup unchanged.

The new `sindri_registry::KeylessVerifier` performs the three-pronged trust check
expected of sigstore consumers:

1. **Identity** — Fulcio certificate chain validation against a pinned root CA
   bundle, plus exact-match check on the cert's SAN URI + Fulcio OIDC issuer
   extension against the registry's declared `KeylessIdentity` (e.g. a GHA
   workflow URL).
2. **Transparency** — Rekor inclusion-proof verification against a pinned Rekor
   public key (Signed Entry Timestamp ECDSA-validated over the canonicalised
   payload).
3. **Time consistency** — Rekor's `integratedTime` must fall inside the
   certificate's `notBefore`/`notAfter` validity window.

Bundle-format signatures (`cosign sign --bundle`) carry the cert + Rekor entry
inline — fully verifiable offline. Legacy detached signatures fail closed
pending the follow-up that adds online Rekor lookup.

## ADR-014 status

Status note bumped from *"key-based only"* to track keyless implementation.
A new "Implementation status (2026-04-27)" subsection documents the
two-mode design and policy-field wiring.

## New error variants

All under `sindri_registry::RegistryError`, surfaced from the keyless path:

- `KeylessFeatureDisabled` — keyless requested but build was compiled
  `--no-default-features`.
- `FulcioChainInvalid` — leaf cert's issuer DN not in the pinned trust bundle.
- `KeylessCertificateMissing` — envelope had no embedded cert (typically a
  detached signature under a keyless policy).
- `KeylessIdentityMismatch` — SAN URI or OIDC issuer didn't match the
  registry's declared identity.
- `RekorLookupFailed` — Rekor HTTP lookup network error.
- `RekorInclusionProofInvalid` — SET signature failed verification (bundle
  tampered or pinned Rekor key stale).
- `KeylessCertificateExpired` — Rekor timestamp outside the cert validity
  window.
- `UnknownVerificationMode` — policy declared a `verification_mode` other than
  `key-based` or `keyless`.

## Network surface

| Step                   | Network? | Notes                                       |
|------------------------|----------|---------------------------------------------|
| Fulcio root CA load    | offline  | PEM bytes embedded in the caller's trust bundle |
| Rekor pubkey load      | offline  | PEM bytes embedded in the caller's trust bundle |
| Cert chain validation  | offline  | x509 PKI walk, no OCSP/CRL fetch            |
| Rekor entry fetch      | offline † | bundle envelope inlines the entry          |
| Inclusion proof check  | offline  | crypto-only against pinned Rekor pubkey     |
| SAN identity match     | offline  | exact-string compare                        |

† Detached-signature mode would add a single Rekor GET per verification.
Wave 6A intentionally fails closed for detached signatures rather than
introducing the network surface; a follow-up can add it.

## Feature flag

New `keyless` cargo feature, **default-on**. Disabling it (`--no-default-features`)
drops the keyless code path entirely for air-gapped / minimal builds.
**Existing tests covering key-based mode all still run with the flag on
(the default).** This was verified explicitly:

- `cd v4 && cargo test --workspace` → all green (default features include keyless).
- `cd v4 && cargo build --workspace --no-default-features` → all green.
- `cd v4 && cargo test --workspace --no-default-features` → all green
  (keyless tests are `#[cfg(feature = "keyless")]` and are skipped, the
  rest run unchanged).

## Test count delta

**+23 tests** in `sindri-registry`:

| Suite                                         | Count | Coverage                                     |
|-----------------------------------------------|-------|----------------------------------------------|
| `keyless::tests` (lib unit, feature-gated)    | 15    | mode parsing, trust-root validation, envelope detection, Rekor SET signature: success / payload-tampered / SET-tampered / missing-fields, verifier rejects no-cert |
| `tests/keyless_wiremock.rs` (integration)     | 8     | rcgen-synthesised Fulcio chain → happy path, SAN mismatch, bad issuer, untrusted CA, expired cert, tampered inclusion proof, detached envelope rejected, mode round-trip via serde |

`rcgen` is added as a **dev-dependency only** so production builds don't pull it in.

## Test plan

- [x] `cd v4 && cargo build --workspace`
- [x] `cd v4 && cargo test --workspace`
- [x] `cd v4 && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cd v4 && cargo fmt --all --check`
- [x] `cd v4 && cargo build --workspace --no-default-features`
- [x] `cd v4 && cargo test --workspace --no-default-features`

## Disjoint-from notes

This PR is intentionally scoped to `sindri-registry::signing.rs` + new
`keyless.rs` module + `RegistryConfig` field additions in `sindri-core`.
No conflicts expected with concurrent waves on `sindri-targets` (6B),
`sindri-secrets` / backup / doctor (6F), `tests/integration` (5G),
`renovate-plugin` (6C), or the publish workflow on main (6E).

## Notable simplifications + follow-ups

- **Cert chain validation** uses an issuer-DN-match rather than a full
  `webpki::EndEntityCert::verify_for_usage` walk. The simplification is
  documented inline in `parse_and_validate_fulcio_cert`. Catches the
  common attacker scenario (cert from a non-Fulcio CA) but doesn't catch
  a maliciously-issued cert from a compromised Fulcio CA — exactly the
  threat model the Rekor transparency check is designed to handle.
- **Detached-signature support** fails closed pending the follow-up
  Rekor-lookup wiring. Bundle envelopes are fully supported today.
- **Trust-root refresh** is manual (caller passes PEM bytes). Sigstore
  TUF refresh is left to a future enhancement.

## Blockers / observations on sigstore 0.13's keyless API

Investigated using `sigstore::cosign::ClientBuilder` directly with
`ManualTrustRoot` for keyless verification. Two issues blocked that path:

1. `SignatureLayer::new` is `pub(crate)` — callers can't construct
   trusted layers from already-fetched OCI manifests, so we'd have to
   re-do the OCI fetch through sigstore's `Client` rather than reuse
   our existing `oci-client` pipeline.
2. `crypto::CertificatePool` isn't publicly exported, blocking direct
   use of sigstore's chain validator from outside the crate.

Rather than fight those rough edges, this PR ships a self-contained
keyless verifier built on `x509-cert` (already a transitive dep via
sigstore) + `p256` (already in tree) for the cryptographic core. The
sigstore crate stays in tree as the source of truth for trust-root
types and as a future migration target if its public surface
broadens.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)