### PR TITLE
docs(v4): auth-aware components & targets — ADR-026/027, DDD-07, plan

### DIFF
--- a/v4/docs/ADRs/026-auth-aware-components.md
+++ b/v4/docs/ADRs/026-auth-aware-components.md
@@ -1,0 +1,229 @@
+# ADR-026: Auth-Aware Components
+
+**Status:** Proposed
+**Date:** 2026-04-28
+**Deciders:** sindri-dev team
+
+## Context
+
+`ComponentManifest` (`v4/crates/sindri-core/src/component.rs`) describes how a
+component *installs* (a backend block), how it *configures itself*
+(`ConfigureConfig`), how it *validates* (`ValidateConfig`), and how it
+*removes* (`RemoveConfig`). It does **not** describe whether the component
+needs a credential to function, even though, per the
+[2026-04-28 survey](../research/auth-aware-survey-2026-04-28.md#11-components-in-v4registry-coreconponents),
+roughly a third of the 97 v4 components are silently inert without one
+(every cloud CLI, every AI assistant, every MCP server, every GitHub-asset
+download tool above the anonymous rate limit, every private package registry
+client).
+
+Today the only structured auth surface that touches a component is the
+`BomManifest.secrets: HashMap<String, String>` map (`manifest.rs:19-25`) —
+*declared by the user, not by the component.* The user has to know that
+`claude-code` wants `ANTHROPIC_API_KEY`, that `gh` wants `GITHUB_TOKEN`, and
+that `linear-mcp` wants its own token, because no manifest tells anyone. This
+is the v3 "set TOKEN before installing" pattern, formalised only in READMEs.
+
+Comparable systems — Renovate `hostRules`, Helm `values.schema.json`, Terraform
+`sensitive = true`, K8s `valueFrom.secretKeyRef`, AWS SDK provider chains — all
+do better than this. See the [survey Part 2](../research/auth-aware-survey-2026-04-28.md#part-2--web-research-how-comparable-tools-handle-this).
+
+This ADR adds the **declaration** half of the design. The fulfillment side is
+[ADR-027](027-target-auth-injection.md); lifecycle/rotation is folded into this
+ADR per the survey synthesis (no ADR-028 unless rotation surfaces real
+complexity in implementation).
+
+## Decision
+
+Extend `ComponentManifest` with an additive, default-empty `auth` block of type
+`AuthRequirements`. Existing components deserialize unchanged; the field is
+opt-in.
+
+### Schema
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthRequirements {
+    /// API tokens / static bearer secrets (anything that lives as a single string).
+    #[serde(default)] pub tokens: Vec<TokenRequirement>,
+    /// OAuth-flow credentials (RFC 8628 device flow today; auth-code in future).
+    #[serde(default)] pub oauth:  Vec<OAuthRequirement>,
+    /// X.509 / PEM materials.
+    #[serde(default)] pub certs:  Vec<CertRequirement>,
+    /// SSH key material (private + optional passphrase).
+    #[serde(default)] pub ssh:    Vec<SshKeyRequirement>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct TokenRequirement {
+    /// Stable id, unique within the component (e.g. "github_token").
+    pub name: String,
+    /// One-line human description shown by `sindri doctor` and `sindri auth show`.
+    pub description: String,
+    /// When the credential is needed.
+    #[serde(default)] pub scope: AuthScope,
+    /// If true, install proceeds when no source binds (degraded mode).
+    #[serde(default)] pub optional: bool,
+    /// Logical resource the token is intended for. RFC-9068 audience claim
+    /// when the token is a JWT; otherwise a free-form URL or vendor URN
+    /// (e.g. "https://api.github.com", "urn:anthropic:api").
+    pub audience: String,
+    /// How the component wants to *receive* the resolved value at apply time.
+    #[serde(default)] pub redemption: Redemption,
+    /// Hints the resolver uses to find a source automatically. ADR-027.
+    #[serde(default)] pub discovery: DiscoveryHints,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuthScope {
+    /// Needed only while install/configure scripts run.
+    Install,
+    /// Needed when the installed tool is invoked by the user.
+    Runtime,
+    /// Both phases.
+    #[default] Both,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum Redemption {
+    /// Inject as `<env_name>=<value>` into Target::exec env.
+    EnvVar { env_name: String },
+    /// Write to `<path>` (mode 0600, deleted post-apply unless `persist: true`).
+    File   { path: String, mode: Option<u32>, persist: bool },
+    /// Both: env-var pointing at file (e.g. GOOGLE_APPLICATION_CREDENTIALS).
+    EnvFile{ env_name: String, path: String },
+}
+
+impl Default for Redemption {
+    fn default() -> Self { Redemption::EnvVar { env_name: String::new() } }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct DiscoveryHints {
+    /// Env-var names to probe (e.g. ["ANTHROPIC_API_KEY","CLAUDE_API_KEY"]).
+    #[serde(default)] pub env_aliases: Vec<String>,
+    /// `cli:` invocations that produce the token (e.g. ["gh auth token"]).
+    #[serde(default)] pub cli_aliases: Vec<String>,
+    /// OAuth provider id this requirement maps to (matches OAuthProvider.id).
+    pub oauth_provider: Option<String>,
+}
+
+// (OAuthRequirement, CertRequirement, SshKeyRequirement follow the same pattern;
+//  see DDD-07 for full structures.)
+```
+
+### YAML example — `claude-code` after migration
+
+```yaml
+metadata: { name: claude-code, version: "1.0.0", … }
+install: { npm: { package: "@anthropic-ai/claude-code", global: true } }
+
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by the Claude Code CLI."
+      scope: runtime
+      optional: false
+      audience: "urn:anthropic:api"
+      redemption:
+        env-var: { env-name: ANTHROPIC_API_KEY }
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]
+        cli-aliases: ["sindri-anthropic-cli token"]
+```
+
+### Defaults / backwards compatibility
+
+- `auth` is `#[serde(default)]`. All 97 existing manifests deserialize as
+  `AuthRequirements::default()` (every list empty), and `existing_registry_components_still_deserialize` (the test added in PR #214) is extended to assert `m.auth.tokens.is_empty()` to lock that in.
+- Components with implicit auth needs are migrated to declared form in **Phase 3** of the [implementation plan](../plans/auth-aware-implementation-plan-2026-04-28.md), not in this ADR's PR.
+
+### Audience binding (the security invariant we cash in)
+
+The resolver MUST refuse to bind a `TokenRequirement` with audience `A` to an
+`AuthCapability` with audience `B` unless `A == B`. This propagates RFC-9068's
+audience constraint ([survey §2.6](../research/auth-aware-survey-2026-04-28.md#26-oauth-20--rfc-8628-device-flow--rfc-9068-audience-binding)) into the
+sindri domain and prevents the "OAuth-token-meant-for-X-fulfills-component-Y"
+confused-deputy class. Audience strings are matched as exact, lowercased,
+URL-form-canonical strings; no glob.
+
+### Optional vs required & the failure mode
+
+- `optional: false` (the default): if the resolver cannot bind a source,
+  `sindri apply` fails admission Gate 5 (ADR-027 §"Gate 5: auth-resolvable").
+  Exit code is `EXIT_POLICY_DENIED` (already defined). Error message names
+  the requirement, the candidate sources tried, and the precise remediation
+  (e.g. "set env var ANTHROPIC_API_KEY, or `sindri secrets set
+  anthropic_api_key`, or `sindri target auth ... --bind anthropic_api_key`").
+- `optional: true`: install proceeds with the binding unfilled, the lockfile
+  records `binding: none`, and a `WARN` line goes to the ledger
+  (`AuthBindingDeferred`).
+
+### Lifecycle, rotation, TTL (folded in)
+
+We deliberately keep this lightweight in v4.0:
+
+- A `TokenRequirement` does not declare its own TTL. The *source* (e.g. an
+  OAuth access token with `expires_in`) carries TTL metadata.
+- Per-source rotation is the source's job: `sindri-secrets`'s Vault client
+  already supports re-reads; OAuth tokens are re-fetched via the device flow
+  on `expired_token`.
+- Sindri's binding records *which source bound*, not *the value*. Re-running
+  `sindri apply` re-resolves and re-redeems — that *is* rotation. A future
+  `sindri auth refresh` verb (Phase 5) makes this a first-class operation.
+- A separate ADR-028 will be opened **only if** Phase 4 surfaces use-cases the
+  source-driven model cannot handle (e.g. STS-style scoped one-shot
+  credentials with explicit binding lifetimes).
+
+## Consequences
+
+**Positive**
+
+- Components self-describe. `sindri doctor --components` (PR #235 D13) can list
+  every unfulfilled credential before the user hits an opaque install failure.
+- The ledger (PR #217) gains structured `AuthRequirementDeclared` events
+  alongside the existing install events, giving auditors a complete picture.
+- Audience binding gives us RFC-9068-grade isolation at zero extra runtime
+  cost (validation is O(n) string compare at admission).
+- The migration of implicit → declared in Phase 3 is mechanical: components
+  that work today via "set this env var" become components with one
+  `TokenRequirement` whose `discovery.env_aliases` lists the same name.
+
+**Negative / risks**
+
+- 97 components × ~1-2 requirements each = ~100 small follow-up edits in
+  Phase 3. Mitigated by the migration table in the implementation plan §3
+  and a `--lint` rule that flags unmigrated cloud/AI components.
+- A poorly-chosen `audience` string fragments the ecosystem. We pin the
+  recommended audience strings for first-party components in
+  `v4/docs/AUTHORING.md` (Phase 0 task).
+- Schema growth: `bom.json` / `component.json` get larger. Acceptable —
+  schema-gen (PR #224) already handles arbitrary additive growth.
+
+**Alternatives rejected**
+
+- **Free-form `requirements:` block (Helm-values-schema-style).** Rejected:
+  unstructured fields make it impossible for `sindri doctor` to enumerate
+  unfulfilled creds, and audience binding can't be enforced.
+- **Encoding requirements in `Options` (DDD-01).** Rejected: options are
+  user-facing tunables; conflating them with credentials muddies the
+  redaction story (sensitivity propagation per Terraform [t1]).
+- **Reuse `BomManifest.secrets` as the declaration site.** Rejected: that map
+  is *user-supplied*, not *component-declared*. Different ownership boundary,
+  per DDD-07 §"Bounded contexts."
+
+## References
+
+- [Survey](../research/auth-aware-survey-2026-04-28.md) — the empirical case
+- [ADR-027](027-target-auth-injection.md) — the fulfillment half
+- [DDD-07](../DDDs/07-auth-bindings-domain.md) — domain model
+- [Implementation plan](../plans/auth-aware-implementation-plan-2026-04-28.md)
+- ADR-008 (admission gates), ADR-014 (registry trust — distinct concern),
+  ADR-019 (plugin protocol — extended in ADR-027), ADR-020 (`AuthValue`
+  resolver — the plumbing layer), ADR-024 (lifecycle hooks — redemption
+  point), ADR-025 (`sindri-secrets` — fulfillment backend).

--- a/v4/docs/ADRs/027-target-auth-injection.md
+++ b/v4/docs/ADRs/027-target-auth-injection.md
@@ -1,0 +1,261 @@
+# ADR-027: Target → Component Auth Injection
+
+**Status:** Proposed
+**Date:** 2026-04-28
+**Deciders:** sindri-dev team
+
+## Context
+
+[ADR-026](026-auth-aware-components.md) gives a component the ability to *declare*
+what credentials it needs. This ADR closes the loop: how does a target *fulfill*
+those needs, and what algorithm reconciles the two?
+
+The 2026-04-28 [survey](../research/auth-aware-survey-2026-04-28.md#12-targets-in-v4cratessindri-targets)
+shows that every existing target authenticates *itself* upstream (PR #236, Wave
+6B) but has no contract for satisfying a *child workload's* credential need. The
+`Target` trait (`v4/crates/sindri-targets/src/traits.rs:19-76`) is silent on
+auth-as-a-capability.
+
+The lessons from prior art ([survey §2](../research/auth-aware-survey-2026-04-28.md#part-2--web-research-how-comparable-tools-handle-this))
+converge on a single shape: a target advertises an ordered list of credential
+sources it can produce; a resolver walks that list per requirement, first match
+wins, value never persisted.
+
+## Decision
+
+### 1. `Target::auth_capabilities()` — capability advertisement
+
+Add a default-impl method to the `Target` trait:
+
+```rust
+pub trait Target: Send + Sync {
+    // ... existing methods ...
+
+    /// Describe the credential slots this target can fulfill.
+    /// Default: empty — targets opt in.
+    fn auth_capabilities(&self) -> Vec<AuthCapability> { vec![] }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AuthCapability {
+    /// Capability id (e.g. "github_token", "anthropic_api_key", "aws_sso").
+    pub id: String,
+    /// Audience the produced credential is valid for. Must match a
+    /// requirement's audience (ADR-026 §"Audience binding") to bind.
+    pub audience: String,
+    /// Where this credential physically comes from when redeemed.
+    pub source: AuthSource,
+    /// Priority for resolver tie-breaking (higher = preferred). Default 0.
+    #[serde(default)] pub priority: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum AuthSource {
+    /// Resolve via `sindri-secrets` (Vault, S3, KV).
+    FromSecretsStore { backend: String, path: String },
+    /// Resolve from environment variable on the target.
+    FromEnv { var: String },
+    /// Resolve from a file readable on the target.
+    FromFile { path: String, mode: Option<u32> },
+    /// Delegate to an installed CLI (mirrors `cli:` of ADR-020).
+    FromCli { command: String },
+    /// Reuse the target's own upstream auth (e.g. fly.io session token
+    /// serves as the GitHub token for fly's GitHub-actions audience).
+    FromUpstreamCredentials,
+    /// Run an OAuth device flow (ADR-026 → DiscoveryHints.oauth_provider).
+    FromOAuth { provider: String },
+    /// Interactive prompt (TTY only; rejected in `--ci` mode by Gate 5).
+    Prompt,
+}
+```
+
+### 2. Per-target manifest extension
+
+`TargetConfig` (`v4/crates/sindri-core/src/manifest.rs:73-78`) gains an optional
+`provides:` block listing user-visible overrides of (or additions to) the
+target's intrinsic capabilities:
+
+```yaml
+targets:
+  my-fly:
+    kind: fly
+    auth: { token: "secret:vault/fly/team-prod" }
+    provides:
+      - id: github_token
+        audience: "https://api.github.com"
+        source: { kind: from-secrets-store, backend: vault, path: "secrets/github/team" }
+        priority: 100
+```
+
+### 3. Binding algorithm — `sindri-resolver` § new module
+
+For each `AuthRequirement` declared by each component slated to be applied to
+each target:
+
+```text
+fn bind(req: AuthRequirement, target: &Target) -> Option<AuthBinding>:
+    candidates = target.auth_capabilities()           // intrinsic
+              ++ target.config.provides              // user overrides
+              ++ secrets_store.match(req.discovery)  // sindri-secrets fallback
+              ++ env.match(req.discovery.env_aliases)
+              ++ cli.match(req.discovery.cli_aliases)
+              ++ oauth.match(req.discovery.oauth_provider)
+
+    for cap in candidates.sorted_by(priority desc):
+        if cap.audience != req.audience:           # ADR-026 audience invariant
+            continue
+        if cap.source matches req.scope:
+            return Some(AuthBinding { req, source: cap.source, target_id, priority: cap.priority })
+    None
+```
+
+Key properties:
+- **Stable order.** Candidates are deduplicated by `(target_id, source.kind,
+  source.params)` and sorted by priority desc, then by source kind
+  (`FromSecretsStore` > `FromEnv` > `FromFile` > `FromCli` >
+  `FromUpstreamCredentials` > `FromOAuth` > `Prompt`). Determinism so the
+  lockfile is reproducible.
+- **First-match-wins**, but every skipped candidate is recorded as a
+  *considered-but-rejected* note in the ledger (with the reason —
+  `audience-mismatch`, `scope-mismatch`, etc.) for `sindri auth show`.
+- **No values are read.** Binding is a pure dataflow operation; sources are
+  *located* but not *opened* until apply-time redemption.
+
+### 4. Lockfile recording (per-target lockfile, PR #231)
+
+Each per-target `sindri.<target>.lock` gains an `auth_bindings:` array. Per
+ADR-026, the binding records *references only*:
+
+```yaml
+auth_bindings:
+  - component: "npm:claude-code"
+    requirement: anthropic_api_key
+    source:
+      kind: from-secrets-store
+      backend: vault
+      path: "secrets/anthropic/prod"
+    audience: "urn:anthropic:api"
+    bound_at: "2026-04-28T15:00:00Z"
+```
+
+No resolved value is ever written. The audit ledger gets an
+`AuthBindingResolved` event mirroring the lockfile entry.
+
+### 5. New admission gate — Gate 5 in `sindri-policy`
+
+ADR-008 enumerates four gates today (license / signature / pinned / privilege).
+This ADR adds **Gate 5: auth-resolvable**.
+
+> For each non-`optional` `AuthRequirement` declared by every component in
+> the resolved set, there must exist exactly one binding produced by the
+> binding algorithm. Otherwise apply is denied with
+> `EXIT_POLICY_DENIED`.
+
+Configurable in `sindri.policy.yaml`:
+
+```yaml
+auth:
+  on_unresolved_required: deny      # deny | warn | prompt
+  on_unresolved_optional: warn      # deny | warn | ignore
+  forbid_prompt_in_ci: true         # if --ci, reject Prompt-bound bindings
+  forbid_plain_audience_mismatch: true   # never let audience be globbed
+```
+
+### 6. Apply-time redemption (ADR-024 hooks)
+
+Redemption happens **immediately before `pre_install`** for `scope: install`
+or `both`, and **after `post_install`** as a configure-time step for
+`scope: runtime`. Both follow the same recipe:
+
+1. Resolve the binding's source by re-using the existing `AuthValue` (ADR-020)
+   plumbing — extended in Phase 0 to add `AuthValue::Secret(path)` for the
+   `secret:` prefix that ADR-020 spec'd but never wired.
+2. Apply the requirement's `Redemption`:
+   - `EnvVar { env_name }`: pass into `Target::exec(cmd, env)`.
+   - `File { path, mode, persist }`: write file via `Target::upload`,
+     `chmod`, register a deletion hook in the apply-state for `persist=false`.
+   - `EnvFile { env_name, path }`: both of the above.
+3. Emit `AuthRedeemed` ledger event (value redacted; only the binding ref).
+4. After the lifecycle phase that consumed it, zeroise in-memory copies and
+   delete non-persistent files.
+
+### 7. Plugin protocol extension (ADR-019)
+
+`sindri-target-<name>` plugins gain one new method:
+
+```json
+// CLI → plugin
+{"method": "auth_capabilities", "params": {}}
+// plugin → CLI
+{"result": {"capabilities": [ … AuthCapability JSON … ]}}
+```
+
+Plugins that don't implement the verb return `{"error": {"code": "method-not-supported"}}`,
+which the CLI treats as `vec![]` — same as the trait default.
+
+## Consequences
+
+**Positive**
+
+- The "implicit env var" footgun (mise's GitHub-token rate-limit cliff,
+  AI-CLI-runs-without-key silent inertness) becomes fail-fast at admission.
+- Three-deep audit trail per credential: declared (component) → bound
+  (resolver) → redeemed (apply hook). Each step is a ledger event,
+  values redacted.
+- Targets can be specialised: an `acme-corp-laptop` plugin can advertise
+  `cli:gh auth token` as a `github_token` source; a CI runner advertises
+  `from-env { var: GITHUB_TOKEN }`. Same component, two valid paths.
+- The deterministic candidate order makes lockfiles stable across machines —
+  preventing the "works on my laptop" class of binding drift.
+
+**Negative / risks**
+
+- The binding algorithm has to handle multi-target apply (when a `BomManifest`
+  applies the same component to two targets, two distinct bindings are
+  produced — one per per-target lockfile). Specified above; needs careful
+  test coverage.
+- A maliciously-crafted target plugin could advertise capabilities matching a
+  high-value audience (`urn:anthropic:api`) and harvest the resulting
+  redemption attempt. Mitigation: ADR-014 trust scope already gates plugin
+  install; document that plugin trust extends to auth claims.
+- Prompt-mode is incompatible with non-interactive runs. We default
+  `forbid_prompt_in_ci = true` and require `sindri --ci` to set the env var
+  `SINDRI_CI=1` (or detect via `CI=true`).
+
+**Alternatives rejected**
+
+- **Per-target hard-coded fulfillment table.** The v3-style "fly knows
+  GitHub-token, k8s knows kube-config" lookup. Rejected: doesn't compose with
+  community plugins (ADR-019), and breaks the audience invariant from
+  ADR-026.
+- **Component reaches into secrets store directly.** Rejected: violates
+  bounded-context separation (DDD-07 §"Bounded contexts"), and loses the
+  audit ledger trail because no domain event would mark the access.
+- **Defer Gate 5 to runtime.** Rejected: a fail-fast admission gate is the
+  whole point of the ADR-008 system. Failing at runtime, halfway through an
+  apply, is exactly what users hate about v3 today.
+
+## Open questions (punted to user)
+
+1. **Should `FromUpstreamCredentials` be allowed by default?** It's the
+   simplest path (e.g. fly's session token doubles as a GitHub token for
+   fly-published actions) but it weakens audience binding. Default-deny and
+   require an explicit `provides:` allowlist, or default-allow with a
+   `policy.auth.allow_upstream_reuse: false` opt-out?
+2. **Where should `Prompt` source actually prompt — the controlling CLI's
+   TTY or the target's stdin?** Today's `sindri target auth …` interactive
+   wizard runs locally; redemption-time prompts on a remote target (ssh,
+   e2b) need a tunneled prompt or a hard `Prompt` denial.
+
+## References
+
+- [Survey](../research/auth-aware-survey-2026-04-28.md)
+- [ADR-026](026-auth-aware-components.md) — the declaration half
+- [DDD-07](../DDDs/07-auth-bindings-domain.md) — domain model
+- [Implementation plan](../plans/auth-aware-implementation-plan-2026-04-28.md)
+- ADR-008 (admission gates), ADR-019 (plugin protocol — extended here),
+  ADR-020 (`AuthValue` plumbing — extended with `Secret` variant in Phase 0),
+  ADR-024 (lifecycle hooks — redemption is a `pre_install` extension),
+  ADR-025 (`sindri-secrets` — `FromSecretsStore` fulfillment backend),
+  per-target lockfile (PR #231 — `auth_bindings` writer).

--- a/v4/docs/ADRs/README.md
+++ b/v4/docs/ADRs/README.md
@@ -60,6 +60,8 @@ Each ADR states what was decided, why, and what is explicitly rejected.
 | [018](018-per-target-lockfiles.md)           | Per-target lockfiles                        | Accepted |
 | [019](019-subprocess-json-target-plugins.md) | Subprocess-JSON target plugin protocol      | Accepted |
 | [020](020-unified-auth-prefixed-values.md)   | Unified auth prefixed-value model           | Accepted |
+| [026](026-auth-aware-components.md)          | Auth-aware components                       | Proposed |
+| [027](027-target-auth-injection.md)          | Target → component auth injection           | Proposed |
 
 ### Product Scope
 

--- a/v4/docs/DDDs/07-auth-bindings-domain.md
+++ b/v4/docs/DDDs/07-auth-bindings-domain.md
@@ -1,0 +1,233 @@
+# DDD-07: Auth-Bindings Domain
+
+**Status:** Proposed (paired with [ADR-026](../ADRs/026-auth-aware-components.md) and [ADR-027](../ADRs/027-target-auth-injection.md))
+**Date:** 2026-04-28
+
+## Bounded Context
+
+The Auth-Bindings domain is a **thin orchestration context** sitting above
+three existing bounded contexts (Component, Target, Secrets/Policy). It owns
+exactly one new aggregate — `AuthBinding` — and a vocabulary that lets the
+existing aggregates talk about credentials without leaking each other's
+internals.
+
+```
+┌────────────────────┐  declares  ┌────────────────────────┐  fulfills   ┌────────────────────────┐
+│   Component (DDD-01)├──────────▶│ AuthRequirement (VO)    │◀────────────│ Target (DDD-04)         │
+└────────────────────┘             └─────────────┬──────────┘              └─────────────────────┬──┘
+                                                 │                                                │
+                                                 ▼ binds                                          │
+                                        ┌────────────────────┐  references                       │
+                                        │  AuthBinding (AR)   │──────────────────────────────────▶│
+                                        └─────────┬──────────┘                                    │
+                                                  │ references                                    │
+                                                  ▼                                                │
+                                        ┌────────────────────┐                                    │
+                                        │ AuthSource (VO)     │◀──────────── Secrets / Env / OAuth / CLI / File providers
+                                        └────────────────────┘
+```
+
+### Crate ownership
+
+| Crate              | Owns                                                                                      |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| `sindri-core`      | Schema types: `AuthRequirement`, `AuthCapability`, `AuthBinding`, `AuthSource`, `Audience`. |
+| `sindri-resolver`  | The binding algorithm; lockfile (de)serialisation of `auth_bindings`.                     |
+| `sindri-policy`    | Gate 5 evaluator; `AuthPolicy` config block.                                              |
+| `sindri-targets`   | `Target::auth_capabilities()` default + per-kind overrides; OAuth integration.            |
+| `sindri-extensions` | Apply-time redemption (hook into `pre_install`/`post_install` of ADR-024).               |
+| `sindri-secrets`   | `FromSecretsStore` resolution backend (existing).                                         |
+| `sindri` (CLI)     | `auth show / auth refresh / doctor --auth` verbs (Phase 5).                               |
+
+## Core Aggregate: `AuthBinding`
+
+```
+AuthBinding (aggregate root)
+├── id              (deterministic: hash(component_id, requirement.name, target_id))
+├── component_id    (ComponentId — DDD-01)
+├── requirement     (AuthRequirement — VO, copied from component manifest)
+├── target_id       (target name as string)
+├── source          (AuthSource — VO, the bound source)
+├── audience        (Audience — VO, must equal req.audience and source.audience)
+├── bound_at        (UTC timestamp)
+├── considered      (Vec<RejectedCandidate> — for `auth show` introspection)
+└── status          (Bound | Deferred | Failed)
+```
+
+`AuthBinding` is computed at *resolve time* and persisted in the per-target
+lockfile (PR #231). It is the only aggregate in this domain. `AuthRequirement`,
+`AuthCapability`, `AuthSource`, and `Audience` are all value objects.
+
+### Invariants enforced on construction
+
+1. **Audience match.** `binding.audience == req.audience == source.audience`,
+   matched as canonicalised, lower-cased strings. Constructor returns
+   `Err(AudienceMismatch)` otherwise.
+2. **Scope alignment.** `req.scope` must be representable by `source.kind` —
+   e.g. `Prompt` cannot satisfy `scope: install` in a `--ci` context (Gate 5
+   policy enforces this; the constructor records but does not block).
+3. **No value capture.** `AuthBinding` has no field that contains the
+   resolved credential. It is impossible at the type level (the `source`
+   variant carries only path/key references).
+4. **Determinism.** Given identical input (manifest + lockfile + target
+   capabilities), the produced binding's `id`, `source`, and `priority` are
+   identical across hosts. Lockfile diffs reflect intent changes only.
+
+### Lifecycle states
+
+```
+   ┌──────────┐  bind() ok    ┌────────┐  redeem() ok  ┌──────────┐
+   │ Pending  │──────────────▶│ Bound  │──────────────▶│ Redeemed │ (transient — not persisted)
+   └──────────┘               └───┬────┘               └──────────┘
+        │                         │ no source / required
+        │                         ▼
+        │                  ┌─────────┐
+        ├──optional? ─────▶│ Deferred │  (warn, install proceeds)
+        │                  └─────────┘
+        │ required, no src
+        ▼
+    ┌────────┐
+    │ Failed │  → admission Gate 5 denial
+    └────────┘
+```
+
+`Redeemed` is intentionally not persisted — it's a momentary state during
+apply, mirrored only as the `AuthRedeemed` domain event.
+
+## Ubiquitous Language
+
+| Term                  | Definition                                                                                                                                                                          |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **AuthRequirement**   | A component-declared statement "I need a credential of kind K, with audience A, optional or not, redeemed in form R." Lives in `ComponentManifest.auth.*`.                          |
+| **AuthCapability**    | A target-advertised statement "I can produce a credential of id I, audience A, from source S." Returned by `Target::auth_capabilities()` and via `TargetConfig.provides`.            |
+| **AuthBinding**       | The resolved triple of (requirement, target, source) plus enough metadata to redeem at apply time. The aggregate root of this domain.                                              |
+| **AuthSource**        | The *physical* origin of a credential value: secrets store path, env var, file, CLI invocation, OAuth flow, prompt, or upstream-credential reuse. A pure `enum`.                   |
+| **Audience**          | The intended-resource identifier of a credential. Free-form URL or URN; matched as canonical lowercased strings. Inspired by RFC 9068 `aud` claim. Matched literally — no globs.   |
+| **Redemption**        | The act and *form* of materialising a bound credential at apply time: as an env var, as a file, or both. Declared per-requirement, executed in a lifecycle hook.                  |
+| **Scope**             | When a credential is needed: `install` (lifecycle scripts only), `runtime` (when the installed tool is invoked), or `both`. Decides which lifecycle hook redeems.                   |
+| **DiscoveryHints**    | Component-side aliases that help the resolver auto-bind without explicit `targets.<n>.provides` config: env-var aliases, CLI aliases, OAuth provider id.                            |
+| **Gate 5**            | The new admission gate added by ADR-027: "every required `AuthRequirement` has exactly one `AuthBinding`." Blocks apply when violated.                                              |
+| **CredentialProviderChain** | The ordered candidate list inside the resolver, walked first-match-wins. Modelled on the AWS SDK pattern; explicit and inspectable, never implicit.                          |
+
+## Domain Events
+
+Emitted into the existing ledger (`StatusLedger`, PR #217). All redact values.
+
+| Event                          | Producer                | Payload (sketch)                                                       |
+| ------------------------------ | ----------------------- | ---------------------------------------------------------------------- |
+| `AuthRequirementDeclared`      | Component loader        | `component_id`, `requirement.name`, `audience`, `scope`, `optional`.   |
+| `AuthCapabilityRegistered`     | Target init / plugin    | `target_id`, `capability.id`, `audience`, `source.kind`.               |
+| `AuthBindingResolved`          | Resolver                | `binding.id`, `component_id`, `requirement.name`, `target_id`, `source.kind`, `priority`, `considered_count`. |
+| `AuthBindingDeferred`          | Resolver                | `component_id`, `requirement.name`, `reason: "no source matched"`.     |
+| `AuthBindingFailed`            | Resolver / Gate 5       | `component_id`, `requirement.name`, `reason`, `candidates_tried`.      |
+| `AuthRedeemed`                 | Apply hook              | `binding.id`, `redemption.kind`, `target_id`, `phase: pre-install/post-install`. |
+| `AuthCleanedUp`                | Apply hook (post-phase) | `binding.id`, `cleanup.kind: "env-zeroised" / "file-deleted" / "kept"`. |
+
+## Sequence Diagram — apply-time, happy path
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User
+  participant CLI as sindri (CLI)
+  participant R as sindri-resolver
+  participant P as sindri-policy (Gate 5)
+  participant T as sindri-targets (Target trait impl)
+  participant S as sindri-secrets
+  participant L as Ledger (StatusLedger)
+
+  U->>CLI: sindri apply
+  CLI->>R: resolve(BomManifest)
+  R->>R: walk components, collect AuthRequirements
+  R->>T: target.auth_capabilities() (per target)
+  R->>R: bind() — first-match-wins per req
+  R->>L: emit AuthBindingResolved(...)
+  R-->>CLI: Lockfile { auth_bindings: [...] }
+
+  CLI->>P: evaluate gates(lockfile)
+  P->>P: Gate 5 — check required reqs all bound
+  P-->>CLI: ok
+
+  CLI->>T: pre_install(component, env_seed)
+  T->>S: read(source.path)  %% only if FromSecretsStore
+  S-->>T: secret value (in-memory)
+  T->>L: emit AuthRedeemed(...)
+  T->>T: exec(install.sh, env+={ANTHROPIC_API_KEY: ***})
+  T->>T: zeroise local copy after exec
+  T->>L: emit AuthCleanedUp(...)
+  T-->>CLI: ok
+```
+
+## Bounded-Context Diagram
+
+```mermaid
+graph TB
+  subgraph Component[Component context — DDD-01]
+    CM[ComponentManifest]
+    AR[AuthRequirement &nbsp;VO]
+  end
+  subgraph Target[Target context — DDD-04]
+    TC[TargetConfig]
+    AC[AuthCapability VO]
+    OA[OAuthProvider]
+  end
+  subgraph Secrets[Secrets context — ADR-025]
+    VS[Vault / S3 / KV backend]
+    AV[AuthValue resolver]
+  end
+  subgraph Policy[Policy context — DDD-05]
+    G5[Gate 5 evaluator]
+  end
+  subgraph AuthBindings[Auth-Bindings context — DDD-07]
+    AB[AuthBinding aggregate]
+    RES[Resolver - bind algorithm]
+    RED[Redeemer - hook impl]
+  end
+
+  CM -->|declares| AR
+  TC -->|declares| AC
+  AR -->|input| RES
+  AC -->|input| RES
+  RES -->|produces| AB
+  AB -->|persisted in| Lock[(Per-target lockfile)]
+  AB -->|consulted by| G5
+  AB -->|consulted by| RED
+  RED -->|reads via| AV
+  AV -->|backend| VS
+  RED -->|emits| Led[(StatusLedger)]
+```
+
+## Boundary rules
+
+1. **Component never touches secrets.** A component cannot declare a
+   `secret:` path in its manifest. The component's only auth surface is
+   `AuthRequirement` — *what*, never *where*.
+2. **Target never touches the resolved value.** `Target::auth_capabilities()`
+   returns *references* (`AuthSource`), never resolved strings. Resolution is
+   the redeemer's job inside `sindri-extensions` apply hooks.
+3. **Secrets backend is fulfillment-only.** `sindri-secrets` does not know
+   about components, requirements, or audiences. It exposes
+   `read(backend, path) -> SecretValue` and that's it.
+4. **Policy never resolves.** Gate 5 inspects bindings and refuses to apply
+   when invariants are violated; it never reads the actual value.
+5. **The ledger always redacts.** No event payload contains a credential
+   value. Tests assert this with a fuzzed-redaction property test.
+
+## Mapping to existing v4 types
+
+- `AuthValue` (ADR-020, `sindri-targets/src/auth.rs`) is the *redemption*
+  primitive. It gains a fifth variant `Secret(SecretRef)` in Phase 0.
+- `BomManifest.secrets` (manifest.rs:25) becomes a *named source registry* —
+  i.e. `secrets.<id>: env:FOO` declares a named source, and a binding's
+  `AuthSource::FromSecretsStore { backend: "manifest", path: "<id>" }` can
+  reference it. (This is the most pleasant migration path for users who
+  already use the secrets map.)
+- `TargetConfig.auth` (manifest.rs:77) stays *control-plane* per ADR-020.
+  Workload-plane fulfillment is `TargetConfig.provides` (this domain).
+
+## References
+
+- [Survey](../research/auth-aware-survey-2026-04-28.md)
+- [ADR-026](../ADRs/026-auth-aware-components.md), [ADR-027](../ADRs/027-target-auth-injection.md)
+- [Implementation plan](../plans/auth-aware-implementation-plan-2026-04-28.md)
+- DDD-01 (Component), DDD-04 (Target), DDD-05 (Policy)

--- a/v4/docs/DDDs/README.md
+++ b/v4/docs/DDDs/README.md
@@ -13,6 +13,7 @@ v4 extensions-layer refactor. Each document describes one bounded context.
 | [04](04-target-domain.md)    | Target    | `Target`        | `TargetProfile`, `InfraLock`, `AuthValue`               |
 | [05](05-policy-domain.md)    | Policy    | `InstallPolicy` | `AdmissionGate`, `BackendPreference`, `PolicyPreset`    |
 | [06](06-discovery-domain.md) | Discovery | `RegistryCache` | `SearchResult`, `ComponentDetail`, `DependencyGraph`    |
+| [07](07-auth-bindings-domain.md) | Auth-Bindings | `AuthBinding`  | `AuthRequirement`, `AuthCapability`, `AuthSource`, `Audience` |
 
 ## Ubiquitous Language
 

--- a/v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md
+++ b/v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md
@@ -1,0 +1,375 @@
+# Auth-Aware Components & Targets — Implementation Plan
+
+**Status:** Draft (paired with [ADR-026](../ADRs/026-auth-aware-components.md), [ADR-027](../ADRs/027-target-auth-injection.md), [DDD-07](../DDDs/07-auth-bindings-domain.md))
+**Date:** 2026-04-28
+**Estimated horizon:** 6 phases × ~1–2 PRs each = ~10 PRs over 4–6 weeks
+**Companion to:** the v4 [implementation-plan](../plan/implementation-plan.md). This is a *vertical slice* spanning sprints 9–12 and beyond.
+
+This plan deliberately separates **schema land** from **behaviour change**.
+Phase 0 and Phase 1 are pure observability: they ship the new fields and the
+binding algorithm but apply still ignores the result. Phase 2 turns the
+behaviour on.
+
+---
+
+## Principles
+
+1. **Additive everywhere.** Until Phase 2, an existing `sindri.yaml` /
+   `component.yaml` / target plugin must produce identical apply behaviour to
+   today.
+2. **Observability before behaviour.** The lockfile records `auth_bindings:`
+   one phase before any consumer reads them. Operators get a chance to inspect
+   what would be redeemed before redemption is wired.
+3. **Each phase ends in a working build.** No `unimplemented!()` left on the
+   critical path of `sindri apply`.
+4. **Audit ledger at every step.** Every redeemed value flows through the
+   ledger (with redaction). No silent paths.
+
+---
+
+## Phase overview
+
+| Phase | Theme                                | PRs | Crates touched                                                  | Dependency        |
+| ----- | ------------------------------------ | --- | --------------------------------------------------------------- | ----------------- |
+| 0     | Schema additions                     | 1   | `sindri-core`, `sindri-targets/auth.rs`, `schemas/`             | —                 |
+| 1     | Resolver binding (write-through)     | 2   | `sindri-resolver`, `sindri-core` lockfile, `sindri-targets`     | Phase 0           |
+| 2     | Apply-time redemption                | 2   | `sindri-extensions`, `sindri-secrets`, `sindri-policy` (Gate 5) | Phase 1           |
+| 3     | Component migration                  | 1–3 | `registry-core/components/*/component.yaml`                     | Phase 0 (schema)  |
+| 4     | Target capability declaration        | 1–2 | `sindri-targets`, `sindri-targets/plugin.rs`                    | Phase 1           |
+| 5     | UX polish                            | 1   | `sindri` (CLI), docs                                            | Phase 2           |
+
+---
+
+## Phase 0 — Schema additions only
+
+**Goal:** ship the types. No behaviour change. Existing `sindri.yaml`,
+`component.yaml`, and `sindri.lock` files load and round-trip unchanged.
+
+### Scope
+
+- Add `AuthRequirements`, `TokenRequirement`, `OAuthRequirement`,
+  `CertRequirement`, `SshKeyRequirement`, `AuthScope`, `Redemption`,
+  `DiscoveryHints` to `sindri-core::component`.
+- Add the `auth: AuthRequirements` field to `ComponentManifest`
+  (`#[serde(default, skip_serializing_if = "AuthRequirements::is_empty")]`).
+- Add `AuthCapability`, `AuthSource`, `Audience` to `sindri-core` and
+  re-export from `sindri-targets`.
+- Add `provides: Vec<AuthCapability>` to `TargetConfig` (manifest).
+- Add `Secret(SecretRef)` variant to `AuthValue` enum
+  (`sindri-targets/src/auth.rs`); `secret:<backend>/<path>` parser branch.
+- Re-run `cargo run --bin schema-gen` (PR #224) → updated `bom.json`,
+  `component.json`. Schema URLs unchanged (ADR-013); only contents grow.
+
+### Files touched
+
+- `v4/crates/sindri-core/src/component.rs` (new types ~200 LOC).
+- `v4/crates/sindri-core/src/manifest.rs` (`TargetConfig.provides` field).
+- `v4/crates/sindri-targets/src/auth.rs` (Secret variant; minor).
+- `v4/schemas/{bom,component}.json` (regenerated).
+- `v4/tools/schema-gen` (no changes; just re-emit).
+
+### Test gates
+
+- `existing_registry_components_still_deserialize` (added in PR #214) passes
+  with new assertion: `m.auth.is_empty()` for all 97 components.
+- New unit tests round-trip a populated `auth:` block YAML.
+- `sindri lint` passes on all 97 component.yamls.
+- `cargo clippy --workspace --all-targets -- -D warnings` clean.
+
+### Rollback
+
+`git revert` the single PR. Schema additions are additive; no consumer reads
+them yet.
+
+### PR count
+
+**1 PR** — title `feat(v4): schema for auth-aware components/targets (ADR-026/027 §schema only)`.
+
+---
+
+## Phase 1 — Resolver binding (observability only)
+
+**Goal:** the resolver computes `AuthBinding`s and writes them to the per-target
+lockfile, but apply does not read them. Operators can inspect what would happen.
+
+### Scope
+
+- New module `sindri-resolver::auth_binding` implementing the algorithm
+  specified in [ADR-027 §3](../ADRs/027-target-auth-injection.md#3-binding-algorithm--sindri-resolver--new-module).
+- Extend `Lockfile` with `auth_bindings: Vec<AuthBinding>` field
+  (`#[serde(default)]`); writer in `sindri-resolver` populates it.
+- `Target::auth_capabilities()` default impl returns `vec![]`. Built-in
+  targets (local, docker, ssh) also default-empty for now (Phase 4 fills
+  these in).
+- Add `Lockfile.auth_bindings` to per-target lockfile schema
+  (`v4/schemas/lock.json`).
+- Emit `AuthRequirementDeclared`, `AuthCapabilityRegistered`,
+  `AuthBindingResolved`, `AuthBindingDeferred`, `AuthBindingFailed` ledger
+  events.
+- `sindri resolve` now lists `auth-bindings: N resolved, M deferred, K failed`
+  in its summary.
+
+### Files touched
+
+- `v4/crates/sindri-resolver/src/auth_binding.rs` (new, ~350 LOC + tests).
+- `v4/crates/sindri-resolver/src/lib.rs` (call sites).
+- `v4/crates/sindri-core/src/lockfile.rs` (add field).
+- `v4/crates/sindri-targets/src/traits.rs` (default-impl method).
+- `v4/crates/sindri/src/commands/resolve.rs` (summary line).
+
+### Test gates
+
+- Unit: 12+ algorithm tests (audience match, scope match, priority order,
+  considered-but-rejected list, deduplication, deterministic output, optional
+  vs required).
+- Integration: a scenario fixture in `v4/tests/integration/` with a manifest
+  declaring three components × two targets, each with overlapping requirements;
+  expected lockfile snapshot diffed.
+- Existing apply tests untouched (Phase 1 doesn't change apply).
+- Property test: feed random valid `(req, capabilities)` → assert binding
+  determinism (same input → same `binding.id`).
+
+### Rollback
+
+`git revert` the binding PR. The `auth_bindings:` field becomes empty in new
+lockfiles; deserialisers (`#[serde(default)]`) tolerate it. Old lockfiles with
+populated `auth_bindings:` still parse.
+
+### PR count
+
+**2 PRs**:
+
+1. `feat(v4): auth binding algorithm + lockfile field (ADR-027 §3, observability-only)`
+2. `feat(v4): ledger events for auth-bindings (DDD-07 §Domain Events)`
+
+---
+
+## Phase 2 — Apply-time redemption + Gate 5
+
+**Goal:** the resolver's bindings now drive apply behaviour. Gate 5 prevents
+broken applies; redemption injects credentials at the right lifecycle phase.
+
+### Scope
+
+- New `sindri-extensions::redeemer` module wired into the existing apply
+  hook executor (`v4/crates/sindri-extensions/src/`). Hooks into
+  `pre_install` for `scope: install|both`, `post_install` for `scope: runtime`.
+- Resolution: `AuthSource` → in-memory secret value via existing `AuthValue`
+  + new `AuthValue::Secret` reading from `sindri-secrets`.
+- Materialisation: env injection through `Target::exec(cmd, env)`; file
+  writes via `Target::upload`; cleanup hooks register in apply-state.
+- New Gate 5 in `sindri-policy` per ADR-027 §5. Default `on_unresolved_required: deny`.
+- `sindri.policy.yaml` schema (in DDD-05) gains the `auth:` block.
+- New ledger events `AuthRedeemed`, `AuthCleanedUp` with redaction tests.
+- `sindri apply --skip-auth` flag for emergency override (logs ledger).
+
+### Files touched
+
+- `v4/crates/sindri-extensions/src/redeemer.rs` (new, ~250 LOC).
+- `v4/crates/sindri-extensions/src/hooks.rs` (new before/after hook
+  registration).
+- `v4/crates/sindri-policy/src/gate5_auth.rs` (new).
+- `v4/crates/sindri-policy/src/lib.rs` (gate registration).
+- `v4/crates/sindri-secrets/...` (no API change — uses existing read API).
+- `v4/crates/sindri/src/commands/apply.rs` (--skip-auth flag).
+
+### Test gates
+
+- Mock target with capability matrix; apply scenarios for each `Redemption`
+  variant (`EnvVar`, `File`, `EnvFile`).
+- Gate 5 deny scenarios: required-and-unbound → exit
+  `EXIT_POLICY_DENIED`; CI-and-Prompt-source → deny.
+- Property test: ledger event for redemption never carries the resolved
+  value (fuzz inputs, regex-match payloads for the value, expect no match).
+- Integration: fly-target scenario where `claude-code` redeems
+  `ANTHROPIC_API_KEY` from Vault; assert `Target::exec` received it in env;
+  assert post-apply env on the target host has it cleared (zero traceability
+  outside the install process).
+
+### Rollback
+
+Behaviour change is gated by the new Gate 5 evaluator. Disable in policy
+(`auth.on_unresolved_required: warn`). PR can be reverted; lockfile bindings
+become inert again.
+
+### PR count
+
+**2 PRs**:
+
+1. `feat(v4): apply-time auth redemption (ADR-027 §6, DDD-07 redeemer)`
+2. `feat(v4): admission Gate 5 — auth-resolvable (ADR-027 §5)`
+
+---
+
+## Phase 3 — Existing component migration
+
+**Goal:** translate implicit auth requirements (currently in READMEs / install-script
+env reads) into declared `auth:` blocks. Mechanical, no behaviour code changes.
+
+### Migration backlog (from [survey §1.1](../research/auth-aware-survey-2026-04-28.md#11-components-in-v4registry-coreconponents))
+
+| Priority | Components                                                                                  | Requirement                              | Reason                                     |
+| -------- | ------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------ |
+| **P0**   | `claude-code`, `claude-codepro`, `codex`, `gemini-cli`, `goose`, `grok`, `droid`, `opencode` | Provider API key                         | Useless without; high user impact          |
+| **P0**   | `gh`, `glab`                                                                                | `GITHUB_TOKEN` / GitLab PAT (optional)   | Rate-limit cliff in CI                     |
+| **P1**   | `aws-cli`, `azure-cli`, `gcloud`, `ibmcloud`, `aliyun`, `doctl`, `flyctl`                  | Provider creds                           | Cloud CLIs always need creds at runtime    |
+| **P1**   | `linear-mcp`, `jira-mcp`, `pal-mcp-server`, `notebooklm-mcp-cli`                          | API token                                | MCP servers won't start without            |
+| **P2**   | `nodejs` (private regs), `python`, `rust`, `java`, `golang`                                | Registry tokens (`optional: true`)       | Only matters for users with private regs   |
+| **P2**   | `docker`, `supabase-cli`                                                                    | Service-specific tokens (optional)       | Public usage is fine without               |
+| **P3**   | `compahook`, `claudish`, `claude-marketplace`, `ruflo`                                      | Anthropic-team tokens (optional or req)  | Internal usage; escalate as P0 internally  |
+
+### Scope
+
+- Edit each component's `component.yaml` to add an `auth:` block matching the
+  table.
+- Update `v4/docs/AUTHORING.md` with canonical audience strings (e.g.
+  `urn:anthropic:api`, `https://api.github.com`).
+- Add a `sindri lint --auth` rule that *recommends* an `auth:` block on
+  components in known-credentialed categories (cloud, ai-dev, MCP) but
+  doesn't fail.
+
+### Files touched
+
+- ~30 `v4/registry-core/components/*/component.yaml` files.
+- `v4/docs/AUTHORING.md` (audience reference table).
+- `v4/tools/validate_registry.py` (new lint rule).
+
+### Test gates
+
+- `existing_registry_components_still_deserialize` updated to assert P0
+  components have a non-empty `auth.tokens`.
+- Lint passes on all components; warnings only on P2/P3 cloud/AI components
+  that opt out via comment annotation (e.g. `# sindri-lint: auth-not-required`).
+
+### Rollback
+
+Cherry-pick revert per component is fine — each is a leaf edit.
+
+### PR count
+
+**1–3 PRs**: one for P0 (~10 components), one for P1 (~10), one for
+P2/P3+lint rule. Pulls staged sequentially over a sprint.
+
+### Dependencies
+
+Strictly Phase 0. Migrations don't *need* Phase 1 or 2 to land — they just
+sit dormant until the resolver/applier read them.
+
+---
+
+## Phase 4 — Target capability declaration
+
+**Goal:** built-in and plugin targets advertise what they can fulfill. The
+binding algorithm gains real candidates.
+
+### Scope
+
+- For each built-in target (`local`, `docker`, `ssh`, `fly`, `e2b`, `runpod`,
+  `northflank`, `k8s`, `devpod`, `wsl`), implement a non-trivial
+  `auth_capabilities()`:
+  - `local` advertises `cli:gh auth token` if `gh` is on PATH (audience
+    `https://api.github.com`); env-aliases like `ANTHROPIC_API_KEY`,
+    `OPENAI_API_KEY` (audience-tagged).
+  - `fly` advertises its OAuth-result token (audience github), plus
+    `fly secrets get <key>` as a per-secret CLI source.
+  - `k8s` advertises projected secrets via `valueFrom: { secretKeyRef }`
+    semantics — translates into a `FromSecretsStore` with backend `k8s`.
+  - `runpod`/`northflank` advertise their native secret-group APIs as
+    `FromSecretsStore { backend: "runpod-secrets", path: "..." }` etc.
+- Extend ADR-019 plugin protocol with `auth_capabilities` method; update
+  the Rust client (`sindri-targets/src/plugin.rs`).
+- Document the contract in `v4/docs/TARGETS.md`.
+
+### Files touched
+
+- `v4/crates/sindri-targets/src/{local,docker,ssh,plugin}.rs`.
+- `v4/crates/sindri-targets/src/cloud/*.rs` (each cloud target).
+- `v4/docs/TARGETS.md`.
+
+### Test gates
+
+- Per-target unit tests with mocked underlying tools (e.g. mock `gh` in
+  PATH; assert `local::auth_capabilities()` includes `cli:gh auth token`).
+- Plugin protocol integration test using a wiremock plugin that
+  implements / fails to implement `auth_capabilities`.
+
+### Rollback
+
+Revert per-target. Defaults back to empty capabilities; bindings degrade to
+`AuthBindingDeferred` for optional, Gate 5 deny for required.
+
+### PR count
+
+**1–2 PRs**.
+
+---
+
+## Phase 5 — UX polish
+
+**Goal:** users have first-class verbs for inspecting and managing bindings.
+
+### Scope
+
+- `sindri auth show [<component>]` — prints a table of every requirement,
+  its binding (or rejection reason), and the considered candidates.
+- `sindri auth refresh [<component>]` — re-runs binding (and, for OAuth,
+  re-acquires the token).
+- `sindri doctor --auth` — focused doctor view that runs Gate 5 against the
+  current manifest+target set and prints remediation hints.
+- `sindri target auth ... --bind <req>` — explicit user-driven binding
+  that writes a `provides:` entry into the target manifest.
+- Tab completions and JSON output (`--json`) for all of the above.
+
+### Files touched
+
+- `v4/crates/sindri/src/commands/auth.rs` (new file ~200 LOC).
+- `v4/crates/sindri/src/commands/doctor.rs` (--auth flag wiring).
+- `v4/crates/sindri/src/commands/target.rs` (extend existing `auth` subverb).
+- `v4/docs/CLI.md` (new sections).
+
+### Test gates
+
+- CLI smoke tests for each verb (TTY + `--json`).
+- Snapshot test of `auth show` output for the integration scenario.
+
+### Rollback
+
+Revert; nothing else depends on these verbs.
+
+### PR count
+
+**1 PR**.
+
+---
+
+## Cross-phase non-goals
+
+- **No migration off the v3 `sindri-secrets` shape.** ADR-025 stays unchanged;
+  this work piggy-backs on it.
+- **No new secrets backend.** Vault, S3, env, file, CLI, OAuth — all already
+  exist. We don't add HSM/KMS support in this initiative.
+- **No multi-tenant binding model.** One sindri install = one user identity.
+  Multi-user binding is deferred.
+- **No automated rotation.** Phase 5 ships *manual* `sindri auth refresh`.
+  Cron-style auto-rotation is a candidate for v4.1.
+
+## Cross-phase dependencies
+
+```
+Phase 0 (schema) ───┬──▶ Phase 1 (resolver) ───▶ Phase 2 (apply) ───▶ Phase 5 (UX)
+                    │            ▲
+                    │            │
+                    └─▶ Phase 3 (component migration; can land any time after Phase 0)
+                                 │
+                                 └─▶ Phase 4 (target capabilities; needs Phase 1 to be useful)
+```
+
+Phase 3 is parallelisable with Phases 1, 2, 4. Phase 5 must wait for Phase 2.
+
+## References
+
+- [Survey](../research/auth-aware-survey-2026-04-28.md)
+- [ADR-026](../ADRs/026-auth-aware-components.md), [ADR-027](../ADRs/027-target-auth-injection.md)
+- [DDD-07](../DDDs/07-auth-bindings-domain.md)
+- [v4 implementation plan](../plan/implementation-plan.md) §9–§12 — this work
+  inserts into Sprint 9 (Targets) and Sprint 12 (Hardening).

--- a/v4/docs/research/auth-aware-survey-2026-04-28.md
+++ b/v4/docs/research/auth-aware-survey-2026-04-28.md
@@ -1,0 +1,364 @@
+# Auth-Aware Components & Targets — Research Survey
+
+**Date:** 2026-04-28
+**Author:** sindri-architect (design pass)
+**Status:** Input to ADR-026, ADR-027, ADR-028 and DDD-07.
+
+This survey is the ground-truth dossier for the auth-aware initiative. It records
+*what exists today* in the v4 codebase plus *what comparable tools do*, so the
+ADRs and DDD that follow can make decisions instead of describing the world.
+
+---
+
+## Part 1 — Codebase inventory
+
+### 1.1 Components in `v4/registry-core/components/`
+
+There are **97** component manifests on the v4 branch as of 2026-04-28. Spot
+checks across cloud CLIs, AI assistants, and language toolchains all show the
+same shape: `metadata`, `platforms`, `install`, `depends_on` — and *nothing
+auth-related*.
+
+Representative `component.yaml` (the AWS CLI):
+
+```yaml
+metadata:
+  name: aws-cli
+  version: "2.34.33"
+  description: "AWS CLI v2"
+  license: Apache-2.0
+  homepage: "https://aws.amazon.com/cli"
+  tags: [cloud, aws]
+platforms:
+  - { os: linux, arch: x86_64 }
+  - { os: linux, arch: aarch64 }
+install:
+  binary:
+    url_template: "https://awscli.amazonaws.com/awscli-exe-{os}-{arch}-{version}.zip"
+    install_path: "~/.local/bin/aws-cli"
+    checksums: { … }
+depends_on: []
+```
+
+The `ComponentManifest` Rust type that backs every one of these files
+(`v4/crates/sindri-core/src/component.rs:182-211`) has zero auth fields. The
+DDD-01 expansion in PR #214 added `Options`, `ValidateConfig`, `ConfigureConfig`,
+`RemoveConfig`, `PlatformOverride` — but no `AuthRequirements`. **There is no
+first-class concept of "this component needs a credential to function."**
+
+#### Implicit auth requirements (the hidden surface)
+
+Even though no manifest declares auth, plenty of components are useless without
+one. The categories below are the migration backlog for ADR-027 phase 3:
+
+| Category                | Examples                                                                                       | Implicit credential                       | Source                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------------------------------- |
+| **Cloud CLIs**          | `aws-cli`, `azure-cli`, `gcloud`, `ibmcloud`, `aliyun`, `doctl`, `flyctl`                      | API key / OIDC / cloud config dir         | env var or `~/.<vendor>/` config        |
+| **AI assistants**       | `claude-code`, `claude-codepro`, `codex`, `goose`, `gemini-cli`, `grok`, `droid`, `opencode`   | Provider API key (Anthropic, OpenAI, …)   | env var (`ANTHROPIC_API_KEY` etc.)      |
+| **GitHub-asset tools**  | `gh`, `glab`, `gitnexus`, anything installing from GitHub releases                             | `GITHUB_TOKEN` (rate-limit avoidance)     | env var                                 |
+| **Language ecosystems** | `nodejs` (npm private regs), `python` (pip index URLs), `rust` (cargo creds), `java` (maven)  | Registry tokens                           | `~/.npmrc`, `pip.conf`, `~/.cargo/`     |
+| **Container/registry** | `docker` (private registries)                                                                  | Docker config json                        | `~/.docker/config.json`                  |
+| **MCP servers**         | `linear-mcp`, `jira-mcp`, `pal-mcp-server`, `notebooklm-mcp-cli`, `excalidraw-mcp`, `context7-mcp` | API tokens for downstream SaaS            | env var or per-server config            |
+| **Specialty SaaS**      | `supabase-cli`, `ollama` (HF gated models), `playwright` (private CDN mirrors)                 | Service-specific token                    | env var                                 |
+| **Org-internal**        | `compahook`, `claudish`, `claude-marketplace`, `ruflo`, `agent-skills-cli`, `claude-code-mux`  | Anthropic team / org tokens               | env var (varies)                        |
+
+None of these components today have a *machine-readable* way to say "I need
+`ANTHROPIC_API_KEY`". The knowledge lives in READMEs and tribal knowledge, and
+`sindri doctor` cannot tell a user that they're about to install something that
+will be inert without a credential.
+
+#### Install scripts that read auth out-of-band
+
+A grep across `v4/registry-core/components/*/install.sh` (where they exist —
+script-backend components only, per ADR-024) shows shell scripts that
+opportunistically read env vars during install. These break silently in CI
+without those vars being set, and there is no manifest-level declaration that
+the env var is required. This is exactly the gap ADR-026 must close.
+
+### 1.2 Targets in `v4/crates/sindri-targets/`
+
+| File                  | Target kind | Upstream auth (PR #236 / Wave 6B) | Can inject auth into the workload? |
+| --------------------- | ----------- | --------------------------------- | ---------------------------------- |
+| `local.rs`            | `local`     | none (just runs locally)          | No — workload inherits parent env  |
+| `docker.rs`           | `docker`    | docker daemon socket              | Via `-e ENV=…` — manual            |
+| `ssh.rs`              | `ssh`       | SSH keys / agent                  | Via `ssh -E …` — manual            |
+| `cloud/e2b.rs`        | `e2b`       | `E2B_API_KEY` (env or `auth:`)    | No structured pathway              |
+| `cloud/fly.rs`        | `fly`       | `flyctl` config / `FLY_API_TOKEN` | `fly secrets set` (target-specific) |
+| `cloud/runpod.rs`     | `runpod`    | `RUNPOD_API_KEY` (PR #227 native)  | No structured pathway              |
+| `cloud/northflank.rs` | `northflank`| API token (PR #227 native)        | Native secret groups (manual)      |
+| `cloud/k8s.rs`        | `k8s`       | `~/.kube/config`                  | `kubectl create secret` (manual)   |
+| `cloud/devpod.rs`     | `devpod`    | provider-delegated                | provider-dependent                 |
+| `cloud/wsl.rs`        | `wsl`       | host inheritance                  | host-dependent                     |
+| `oauth.rs`            | (OAuth helper) | RFC 8628 device flow for GitHub | persists token via `auth.token`    |
+| `auth.rs`             | (helper)    | `AuthValue` parser (ADR-020)      | n/a                                |
+| `plugin.rs`           | plugin      | subprocess JSON (ADR-019)         | undefined contract                 |
+
+The pattern is clear: **every target knows how to authenticate *itself* upstream,
+but none knows how to satisfy a *component's* auth need.** The OAuth device flow
+in `oauth.rs:1-60` even comments that the resulting access token is "stored
+[via] `targets.<name>.auth.token`" — i.e. only target-scoped. There is no
+binding step that says "this `gh` component installed on this `local` target can
+read that GitHub token."
+
+The `Target` trait (`v4/crates/sindri-targets/src/traits.rs:19-76`) carries
+`exec(cmd, env)` and `check_prerequisites()` but no `auth_capabilities()` and
+no way to enumerate what credentials the target can fulfill.
+
+### 1.3 Manifest surface (`v4/crates/sindri-core/src/manifest.rs`)
+
+Auth-adjacent fields that already exist:
+
+- `BomManifest.secrets: HashMap<String, String>` (lines 19-25) — added in
+  Sprint 12 / Wave 4C. Maps a *secret-id* to a prefixed `AuthValue` string
+  (`env:FOO`, `file:~/.token`, `cli:gh`, `plain:…`). Resolved on demand by
+  `sindri secrets validate`. **Comment is explicit: "values are never persisted."**
+- `RegistryConfig.identity: Option<RegistryIdentity>` (lines 50-71) — keyless
+  cosign OIDC identity for ADR-014 D1. Distinct concern from runtime auth.
+- `TargetConfig.auth: Option<HashMap<String, String>>` (line 77) — the
+  prefixed-value bag that ADR-020 standardises (`env:`, `file:`, `cli:`, `plain:`).
+  Per ADR-020 §"Auth vs workload-plane env" this is **control-plane only** and
+  is "never injected into the running workload."
+
+The current schema has good primitives (`AuthValue`, the `secrets:` registry,
+the `targets.<name>.auth:` block) but **no relationship between them and a
+component's needs.** The hole this initiative fills is exactly that
+relationship.
+
+### 1.4 `AuthValue` resolver (`v4/crates/sindri-targets/src/auth.rs`)
+
+A clean enum with four variants — `Env`, `File`, `Cli`, `Plain` — and a
+`resolve()` method that reaches each source. ADR-020 §"Supported prefixes"
+documents two more (`secret:<backend>/<path>`, `oauth:<provider>`,
+`keychain:<name>`) that are *spec'd but not yet wired into this enum*. The
+`secret:` prefix in particular is the bridge to Sprint 12's `sindri secrets`
+subsystem and Vault HTTP client (`v4/crates/sindri/src/commands/secrets.rs`)
+but does not currently have an `AuthValue::Secret` variant.
+
+### 1.5 Cross-cutting concerns
+
+| Concern                  | Doc / code                                        | Interaction with auth-aware design                                                                                                                              |
+| ------------------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lifecycle hooks (ADR-024) | `v4/docs/ADRs/024-script-component-lifecycle-contract.md` | Hooks (`pre-install`, `post-install`, `pre-project-init`, `post-project-init`) are where *redemption* happens — the moment auth must be materialised in env.    |
+| Trust scope (ADR-014)    | `v4/docs/ADRs/014-signed-registries-cosign.md`    | Per-component verification (Wave 6A.1) is *integrity* of the artifact. Auth-awareness is *runtime authorisation*. Same component scope — different concept.    |
+| Admission gates (ADR-008)| `v4/docs/ADRs/008-install-policy-subsystem.md`    | Policy already gates licenses, signatures, privilege. ADR-027 adds **Gate 5: auth-resolvable** — refuse to apply a component whose required auth has no source. |
+| Plugin protocol (ADR-019)| `v4/docs/ADRs/019-subprocess-json-target-plugins.md` | Plugin contract methods today: `profile/plan/create/exec`. Adds `auth_capabilities` so 3rd-party targets can advertise what they can fulfill.                  |
+| Secrets store (ADR-020)  | `v4/docs/ADRs/020-unified-auth-prefixed-values.md`   | The prefixed-value model is the *plumbing*. ADR-026 declares *what is needed*, ADR-027 *who fulfills it*, ADR-020 stays the *how to fetch a value*.            |
+| Per-target lockfiles (PR #231) | `v4/crates/sindri-resolver` (lockfile writer)  | The lockfile is the natural home for resolved `AuthBinding` records — observability before runtime behaviour change (Phase 1).                                 |
+
+---
+
+## Part 2 — Web research: how comparable tools handle this
+
+Each subsection follows the same structure: *model — config surface — what to
+steal — what to avoid — lessons for sindri.*
+
+### 2.1 Renovate — `hostRules` and credential routing
+
+**Model.** Renovate has a unified `hostRules` array. Each rule has
+`matchHost`, optional `hostType`, and one of `token` / `username` + `password`.
+Renovate then translates the rule into whatever the underlying *manager* needs —
+e.g. writing `COMPOSER_AUTH` for Composer, environment variables for Bundler,
+`.npmrc` lines for npm. The manager declares what it needs; the host-rules
+layer reformats. ([Renovate hostRules docs][r1], [private-packages doc][r2])
+
+**Config surface.** Three input pathways: encrypted blocks in repo config,
+self-hosted config, and `RENOVATE_*` environment variables.
+
+**Steal.** The *separation between (a) declared host rule and (b) per-manager
+materialisation* maps perfectly onto sindri's component-needs vs target-fulfills
+split. Sindri's "binding" is Renovate's "translation step."
+
+**Avoid.** Renovate has zero schema for *declaring needs* on a manager — every
+manager just looks for the env vars it knows about. Don't copy that part; sindri
+should require components to declare needs explicitly.
+
+**Lessons for sindri.** A binding layer that knows how to materialise an
+abstract `AuthRequirement` into the env-var / config-file / CLI-login form a
+specific component needs is essential. Components shouldn't reach into the
+secrets store directly.
+
+### 2.2 Helm — `values.schema.json`
+
+**Model.** A chart ships a JSON Schema (`values.schema.json`) alongside its
+`values.yaml`. The schema's `required` array enumerates fields a parent chart or
+end user *must* supply. `helm install` validates inputs against the schema;
+missing required values fail rendering before any cluster contact happens.
+([Helm charts][h1], [validation-with-json-schema][h2])
+
+**Config surface.** Standard JSON Schema with extensions; schemas compose
+across sub-charts so a parent cannot bypass a sub-chart's requirements.
+
+**Steal.** The `values.schema.json` precedent is exactly the right shape for
+declaring auth requirements on a component: a side-car schema that validates
+*before any side effect.* Sindri already emits JSON Schemas via `schemars` (PR
+#224); extending that to `auth_requirements` is mechanical.
+
+**Avoid.** Helm encodes credentials *in values* — fragile and easy to leak. The
+schema can mark fields as required but cannot say "this field is a credential
+that must be sourced from a secrets manager." Sindri must distinguish
+*credential* from *plain configuration*.
+
+**Lessons for sindri.** Auth requirements should be modelled as a *typed
+structure* (not a free-form schema) that downstream tooling can introspect —
+e.g. `sindri doctor` listing every component's unfulfilled auth.
+
+### 2.3 Terraform — `sensitive = true` and provider auth
+
+**Model.** Variables can be `sensitive = true`, which redacts them from CLI/log
+output and propagates the sensitivity through every derived expression.
+Providers themselves declare credential schemas (e.g. AWS provider's
+`access_key`, `secret_key`, `token`, `profile`) and accept values from the
+variable, env vars (`AWS_ACCESS_KEY_ID`), or shared config files —
+provider-coded fallback chains. ([Terraform sensitive variables][t1], [variable
+block reference][t2])
+
+**Steal.** The sensitivity *propagation* (any expression touching a sensitive
+var inherits sensitivity) is a great audit-log property. Sindri's ledger
+(PR #217) should redact anything traceable to an `AuthRequirement`. Also: the
+*provider-coded fallback chain* idea — provider declares ordered sources —
+matches sindri's "target advertises an ordered list of `AuthSource` it can use
+to fulfill a need."
+
+**Avoid.** Terraform's *state file* records sensitive values in cleartext —
+arguably its single biggest security pitfall. Sindri's lockfile must record an
+`AuthBinding` *reference* (which source resolved the requirement) but never the
+resolved value itself. Hard rule.
+
+**Lessons for sindri.** `AuthBinding.resolved_value` does not exist. The
+binding records the *requirement → source* edge; resolution happens at apply
+time, in memory, never persisted.
+
+### 2.4 AWS / GCP / Azure SDK credential provider chains
+
+**Model.** Each SDK ships a default chain that tries sources in order: env vars
+→ shared config → IMDS / metadata server → SSO → web-identity. First non-empty
+wins; if all fail, the chain throws. Refresh is built in. ([AWS SDK credential
+chain][a1], [PHP default chain][a2])
+
+**Steal.** The *ordered fallback chain* is the right model for component-side
+auth resolution. A component declares `AuthRequirement { name: "GITHUB_TOKEN" }`;
+the resolver walks an ordered list of sources (target capabilities, secrets
+store, env, OAuth) and binds the first one that reports it can satisfy.
+
+**Avoid.** AWS's chain is *implicit* and hard-coded per SDK. That's why users
+hit the famous "wrong credential picked up" issue. Sindri's chain must be
+*explicit and inspectable* — a `sindri auth show <component>` verb that lists
+the chain, the candidate sources, and which one bound. This is exactly the
+inspectability gap UX phase 5 fills.
+
+**Lessons for sindri.** Make the chain visible; never make it surprising.
+
+### 2.5 mise — GitHub-tokens-for-asset-download
+
+**Model.** mise checks `MISE_GITHUB_TOKEN` then falls back to `GITHUB_TOKEN`,
+plus an integration that lifts the token from the `gh` CLI's stored credentials
+if the user has it installed. Without a token, GitHub's anonymous rate limit
+(60 req/hr) is the cliff most CI users discover the hard way. The mise lockfile
+is the second-line mitigation: pinned URLs + checksums skip the API entirely.
+([mise GitHub tokens][m1])
+
+**Steal.** The *integration with already-installed CLIs as a credential
+source* is exactly `cli:` in ADR-020. It generalises: `cli:gh` already works in
+sindri; we just need components to be able to *declare* "my install path will
+benefit from a GitHub token, please bind one if available."
+
+**Avoid.** mise has no first-class "this plugin requires a token" — it's
+discovered when the install fails with a 403. Sindri must *predict* the
+requirement at admission time so failures happen fast and with a fixable
+message.
+
+**Lessons for sindri.** "Declared optional" is a real category. A component
+might run without a token (anonymous GitHub fetch) but with one is faster /
+private. The schema must distinguish `optional: true` requirements from hard
+ones.
+
+### 2.6 OAuth 2.0 — RFC 8628 device flow + RFC 9068 audience binding
+
+**Model.** Sindri already implements RFC 8628 device flow for GitHub
+(`v4/crates/sindri-targets/src/oauth.rs`). The token, once obtained, is stored
+under `targets.<name>.auth.token`. RFC 9068 governs the *content* of the JWT
+access token: an `aud` claim must identify the intended resource server, and
+the resource server MUST validate `aud` matches itself. ([RFC 9068][o1],
+[OAuth best practices RFC 9700][o2], [MCP authorization spec][o3])
+
+**Steal.** The audience constraint translates directly into an
+`AuthRequirement.audience` field. A component that needs an OpenAI key declares
+`audience: "https://api.openai.com"`. A target that *holds* a GitHub OAuth
+token declares its audience as `https://api.github.com`. Mismatched audiences
+fail to bind at admission — the *confused-deputy* prevention property RFC 9068
+enforces transitively to sindri.
+
+**Avoid.** Storing access tokens in `sindri.yaml` as `plain:` values (the
+fly/Northflank fallback today). Tokens belong in the secrets store. Migration
+target: move existing OAuth-flow outputs into `secret:` references.
+
+**Lessons for sindri.** Audience binding is the single most important security
+invariant we get for free if we model it. A `gh`-component must not be able to
+silently consume an Anthropic API key just because the env var name happened to
+match.
+
+### 2.7 OCI registry bearer tokens & cosign keyless
+
+We already implemented this end-to-end in PR #228 + PR #237 (ADR-014). The
+relevant lesson is that registry auth (cosign + OCI bearer flow) is a *peer
+domain* to component runtime auth, not the same problem. Don't try to merge
+them: registry trust gates *integrity*, runtime auth gates *authorisation*.
+
+### 2.8 Docker Compose / Kubernetes — secret mounts
+
+**Model.** Workload declares `env: { name: API_KEY, valueFrom: { secretKeyRef:
+{ name: "my-secret", key: "api-key" } } }`. The pod has no idea where the
+secret lives; the cluster provides. This is the cleanest possible "workload
+declares need without knowing source" model.
+
+**Steal.** Schema shape for the requirement (`name`, `description`,
+`optional`). The *projection-vs-env-vs-file* materialisation choice — let the
+component declare which form it wants the credential in (env var name, file
+path, both).
+
+**Avoid.** K8s' implicit, cluster-scoped namespace assumption. Sindri's binding
+must be *explicit per-component, per-target* — there is no global "default
+secret namespace."
+
+---
+
+## Part 3 — Synthesis: what the design must do
+
+From the surveys above, six concrete asks fall out:
+
+1. **A `ComponentManifest.auth` field** with sub-typed lists of token, oauth,
+   cert, ssh-key, and arbitrary "value" requirements. Each has `name`,
+   `description`, `scope` (install / runtime / both), `optional`, `audience`,
+   `redemption` (env var, file, both).
+2. **A `Target` trait method `auth_capabilities()`** returning a list of
+   `AuthCapability` records — the abstract slots a target can fulfill.
+3. **A reconciliation algorithm** in `sindri-resolver` that produces an
+   `AuthBinding` per requirement, recording the source (`AuthSource` enum) and
+   the redemption strategy. Bindings are persisted in the per-target lockfile
+   (PR #231) — *references only, never values.*
+4. **A new admission gate (Gate 5)** in `sindri-policy` that fails apply when
+   a non-optional requirement has no binding source.
+5. **Apply-time redemption** at `pre_install` — resolves the binding's source
+   into a concrete env-var / file via `AuthValue`, injects it into the
+   `Target::exec` env, lets the install script consume it, then drops the
+   value from memory.
+6. **Audit & lifecycle**: domain events emitted into the ledger
+   (`AuthBindingResolved`, `AuthRedeemed`) with values redacted; future-proof
+   for rotation by recording binding-validity windows.
+
+---
+
+## Sources
+
+- [r1] Renovate self-hosted hostRules — <https://docs.renovatebot.com/self-hosted-configuration/>
+- [r2] Renovate private-packages — <https://docs.renovatebot.com/getting-started/private-packages/>
+- [h1] Helm Charts (values.schema.json) — <https://helm.sh/docs/topics/charts/>
+- [h2] Helm chart development tips & tricks — <https://helm.sh/docs/howto/charts_tips_and_tricks/>
+- [t1] Terraform protect sensitive input variables — <https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables>
+- [t2] Terraform variable block reference — <https://developer.hashicorp.com/terraform/language/block/variable>
+- [a1] AWS SDKs standardized credential providers — <https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html>
+- [a2] AWS SDK PHP default credential chain — <https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_default_chain.html>
+- [m1] mise GitHub Tokens — <https://mise.jdx.dev/dev-tools/github-tokens.html>
+- [o1] RFC 9068 JWT Profile for OAuth 2.0 Access Tokens — <https://datatracker.ietf.org/doc/html/rfc9068>
+- [o2] OAuth 2.0 Security Best Current Practice (RFC 9700) — <https://oauth.net/2/oauth-best-practice/>
+- [o3] MCP Authorization spec — <https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization>


### PR DESCRIPTION
## Summary

Design + documentation package introducing **auth-aware components and
targets** to v4. No code changes — pure docs, ready for review and to gate
the implementation work that follows.

Today, a `ComponentManifest` has no first-class way to say *"I need a
credential to function"*, and a `Target` has no protocol to *fulfill* such a
need. Roughly a third of the 97 components in `v4/registry-core/components/`
are silently inert without an environment variable that lives only in tribal
knowledge or a README. This PR closes that gap with a declaration/fulfillment
split, an explicit binding algorithm, and a six-phase rollout that's strictly
additive until Phase 2.

## Table of contents

| Doc | Path | Purpose |
| --- | --- | --- |
| Research survey | [`v4/docs/research/auth-aware-survey-2026-04-28.md`](../blob/docs/v4-auth-aware-design/v4/docs/research/auth-aware-survey-2026-04-28.md) | Codebase inventory + prior-art (Renovate, Helm, Terraform, AWS SDK, mise, RFC 9068, K8s). Cited URLs. |
| ADR-026 | [`v4/docs/ADRs/026-auth-aware-components.md`](../blob/docs/v4-auth-aware-design/v4/docs/ADRs/026-auth-aware-components.md) | Component-side `auth: AuthRequirements` schema, audience-binding invariant, optional vs required failure mode. |
| ADR-027 | [`v4/docs/ADRs/027-target-auth-injection.md`](../blob/docs/v4-auth-aware-design/v4/docs/ADRs/027-target-auth-injection.md) | Target-side `auth_capabilities()`, `AuthSource` enum, deterministic binding algorithm, admission Gate 5, plugin-protocol verb. |
| DDD-07 | [`v4/docs/DDDs/07-auth-bindings-domain.md`](../blob/docs/v4-auth-aware-design/v4/docs/DDDs/07-auth-bindings-domain.md) | Bounded context, `AuthBinding` aggregate, ubiquitous language, domain events, mermaid diagrams. |
| Implementation plan | [`v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md`](../blob/docs/v4-auth-aware-design/v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md) | Six phases, ~10 PRs, sequencing tied to existing v4 sprints. |

`ADRs/README.md` and `DDDs/README.md` have been updated to register the new
documents.

## Highest-leverage decision

**Audience binding (ADR-026 §"Audience binding").** Every `AuthRequirement`
declares an `audience` (RFC 9068-style); every `AuthCapability` declares an
`audience`; the resolver refuses to bind across mismatched audiences. We get
RFC-9068-grade confused-deputy protection at zero runtime cost — a `gh`
component can never be silently fulfilled by an Anthropic key just because
the env-var name happened to match. This is the single biggest security
property the design buys, and it constrains every other decision (default
sources, plugin claims, prompt-mode policy).

## Highest-stakes open questions punted to user review

1. **Should `FromUpstreamCredentials` be allowed by default?** (ADR-027
   §Open questions Q1.) Default-deny keeps audience binding strict but adds
   friction (every reuse must be an explicit `provides:` entry). Default-allow
   is convenient but quietly weakens the audience invariant. A policy knob
   exists either way; the question is which side of it ships off by default.
2. **Where should `Prompt` source actually prompt — controlling-CLI TTY or
   target stdin?** (ADR-027 §Open questions Q2.) Affects the e2e UX for
   `ssh` and `e2b` targets; today's `sindri target auth` wizard is local-only.
   A wrong choice here forces a redesign of the prompt path mid-implementation.

## Test plan

- [ ] Reviewers verify the survey claims against the cited code (paths +
      line numbers given throughout).
- [ ] Cross-reference ADR-026 and ADR-027 schema with `sindri-core`'s
      `ComponentManifest` and `TargetConfig` to confirm additive-only.
- [ ] Validate that Phase 0 + Phase 1 are observability-only (no apply
      behaviour change).
- [ ] Confirm ADR-008 Gate 5 fits the existing admission framework.
- [ ] Confirm ADR-019 plugin protocol can carry the new `auth_capabilities`
      method without a breaking change.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)