### PR TITLE
feat(v4): auth: declarations for P0 components (ADR-026 §Phase 3)

### DIFF
--- a/v4/registry-core/components/claude-code/component.yaml
+++ b/v4/registry-core/components/claude-code/component.yaml
@@ -26,3 +26,14 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by the Claude Code CLI."
+      scope: runtime
+      optional: false
+      audience: "urn:anthropic:api"
+      redemption:
+        env-var:
+          env-name: ANTHROPIC_API_KEY

--- a/v4/registry-core/components/claude-code/component.yaml
+++ b/v4/registry-core/components/claude-code/component.yaml
@@ -35,5 +35,5 @@ auth:
       optional: false
       audience: "urn:anthropic:api"
       redemption:
-        env-var:
-          env-name: ANTHROPIC_API_KEY
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY

--- a/v4/registry-core/components/claude-codepro/component.yaml
+++ b/v4/registry-core/components/claude-codepro/component.yaml
@@ -26,3 +26,14 @@ depends_on:
   - "mise:nodejs"
   - "mise:python"
   - "binary:gh"
+
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by the Claude CodePro workflow bundle."
+      scope: runtime
+      optional: false
+      audience: "urn:anthropic:api"
+      redemption:
+        env-var:
+          env-name: ANTHROPIC_API_KEY

--- a/v4/registry-core/components/claude-codepro/component.yaml
+++ b/v4/registry-core/components/claude-codepro/component.yaml
@@ -35,5 +35,5 @@ auth:
       optional: false
       audience: "urn:anthropic:api"
       redemption:
-        env-var:
-          env-name: ANTHROPIC_API_KEY
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY

--- a/v4/registry-core/components/codex/component.yaml
+++ b/v4/registry-core/components/codex/component.yaml
@@ -35,5 +35,5 @@ auth:
       optional: false
       audience: "urn:openai:api"
       redemption:
-        env-var:
-          env-name: OPENAI_API_KEY
+        kind: env-var
+        env-name: OPENAI_API_KEY

--- a/v4/registry-core/components/codex/component.yaml
+++ b/v4/registry-core/components/codex/component.yaml
@@ -26,3 +26,14 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: openai_api_key
+      description: "OpenAI API key used by the Codex CLI."
+      scope: runtime
+      optional: false
+      audience: "urn:openai:api"
+      redemption:
+        env-var:
+          env-name: OPENAI_API_KEY

--- a/v4/registry-core/components/droid/component.yaml
+++ b/v4/registry-core/components/droid/component.yaml
@@ -35,5 +35,5 @@ auth:
       optional: false
       audience: "urn:factory:api"
       redemption:
-        env-var:
-          env-name: FACTORY_API_KEY
+        kind: env-var
+        env-name: FACTORY_API_KEY

--- a/v4/registry-core/components/droid/component.yaml
+++ b/v4/registry-core/components/droid/component.yaml
@@ -26,3 +26,14 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: factory_api_key
+      description: "Factory API key used by the Droid CLI."
+      scope: runtime
+      optional: false
+      audience: "urn:factory:api"
+      redemption:
+        env-var:
+          env-name: FACTORY_API_KEY

--- a/v4/registry-core/components/gemini-cli/component.yaml
+++ b/v4/registry-core/components/gemini-cli/component.yaml
@@ -35,5 +35,5 @@ auth:
       optional: false
       audience: "urn:google:generative-language"
       redemption:
-        env-var:
-          env-name: GEMINI_API_KEY
+        kind: env-var
+        env-name: GEMINI_API_KEY

--- a/v4/registry-core/components/gemini-cli/component.yaml
+++ b/v4/registry-core/components/gemini-cli/component.yaml
@@ -26,3 +26,14 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: gemini_api_key
+      description: "Google Gemini API key used by the Gemini CLI."
+      scope: runtime
+      optional: false
+      audience: "urn:google:generative-language"
+      redemption:
+        env-var:
+          env-name: GEMINI_API_KEY

--- a/v4/registry-core/components/gh/component.yaml
+++ b/v4/registry-core/components/gh/component.yaml
@@ -38,5 +38,5 @@ auth:
       optional: true
       audience: "https://api.github.com"
       redemption:
-        env-var:
-          env-name: GITHUB_TOKEN
+        kind: env-var
+        env-name: GITHUB_TOKEN

--- a/v4/registry-core/components/gh/component.yaml
+++ b/v4/registry-core/components/gh/component.yaml
@@ -29,3 +29,14 @@ install:
       macos-aarch64: "sha256:a0423acd5954932a817d531a8160b67cf0456ea6c9e68c11c054c19ea7a6714b"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: github_token
+      description: "GitHub token used by the gh CLI; avoids the unauthenticated rate-limit cliff in CI."
+      scope: runtime
+      optional: true
+      audience: "https://api.github.com"
+      redemption:
+        env-var:
+          env-name: GITHUB_TOKEN

--- a/v4/registry-core/components/glab/component.yaml
+++ b/v4/registry-core/components/glab/component.yaml
@@ -24,3 +24,14 @@ install:
       glab: "1.44.0"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: gitlab_token
+      description: "GitLab personal access token used by the glab CLI."
+      scope: runtime
+      optional: true
+      audience: "https://gitlab.com/api/v4"
+      redemption:
+        env-var:
+          env-name: GITLAB_TOKEN

--- a/v4/registry-core/components/glab/component.yaml
+++ b/v4/registry-core/components/glab/component.yaml
@@ -33,5 +33,5 @@ auth:
       optional: true
       audience: "https://gitlab.com/api/v4"
       redemption:
-        env-var:
-          env-name: GITLAB_TOKEN
+        kind: env-var
+        env-name: GITLAB_TOKEN

--- a/v4/registry-core/components/goose/component.yaml
+++ b/v4/registry-core/components/goose/component.yaml
@@ -24,3 +24,14 @@ install:
     timeout: "600"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: openai_api_key
+      description: "Provider API key used by the Goose agent (OpenAI by default)."
+      scope: runtime
+      optional: false
+      audience: "urn:openai:api"
+      redemption:
+        env-var:
+          env-name: OPENAI_API_KEY

--- a/v4/registry-core/components/goose/component.yaml
+++ b/v4/registry-core/components/goose/component.yaml
@@ -33,5 +33,5 @@ auth:
       optional: false
       audience: "urn:openai:api"
       redemption:
-        env-var:
-          env-name: OPENAI_API_KEY
+        kind: env-var
+        env-name: OPENAI_API_KEY

--- a/v4/registry-core/components/grok/component.yaml
+++ b/v4/registry-core/components/grok/component.yaml
@@ -35,5 +35,5 @@ auth:
       optional: false
       audience: "urn:xai:api"
       redemption:
-        env-var:
-          env-name: XAI_API_KEY
+        kind: env-var
+        env-name: XAI_API_KEY

--- a/v4/registry-core/components/grok/component.yaml
+++ b/v4/registry-core/components/grok/component.yaml
@@ -26,3 +26,14 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: xai_api_key
+      description: "xAI API key used by the Grok CLI."
+      scope: runtime
+      optional: false
+      audience: "urn:xai:api"
+      redemption:
+        env-var:
+          env-name: XAI_API_KEY

--- a/v4/registry-core/components/opencode/component.yaml
+++ b/v4/registry-core/components/opencode/component.yaml
@@ -34,5 +34,5 @@ auth:
       optional: false
       audience: "urn:openai:api"
       redemption:
-        env-var:
-          env-name: OPENAI_API_KEY
+        kind: env-var
+        env-name: OPENAI_API_KEY

--- a/v4/registry-core/components/opencode/component.yaml
+++ b/v4/registry-core/components/opencode/component.yaml
@@ -25,3 +25,14 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: openai_api_key
+      description: "Provider API key used by the OpenCode terminal assistant (OpenAI by default)."
+      scope: runtime
+      optional: false
+      audience: "urn:openai:api"
+      redemption:
+        env-var:
+          env-name: OPENAI_API_KEY


### PR DESCRIPTION
## Summary

Adds declared `auth:` blocks to the ten **P0** components called out in the
auth-aware implementation plan §Phase 3 (PR #242, branch
`docs/v4-auth-aware-design`). Each component gets a single, minimal
`TokenRequirement` covering its provider API key — or its GitHub / GitLab
token (marked `optional: true`) for the two SCM CLIs.

Pure-data, leaf-level YAML edits. No schema, lint, or Rust source touched.

**Depends on Phase 0** (`feat/v4-auth-schema-phase0`). Until that PR lands,
the new `auth:` field deserializes as an unknown key under serde defaults;
the existing `existing_registry_components_still_deserialize` test in
`sindri-core` continues to pass (verified — see Test plan).

## Components edited

| Component        | Audience                              | Env var            | Optional |
| ---------------- | ------------------------------------- | ------------------ | -------- |
| `claude-code`    | `urn:anthropic:api`                   | `ANTHROPIC_API_KEY`| no       |
| `claude-codepro` | `urn:anthropic:api`                   | `ANTHROPIC_API_KEY`| no       |
| `codex`          | `urn:openai:api`                      | `OPENAI_API_KEY`   | no       |
| `gemini-cli`     | `urn:google:generative-language`      | `GEMINI_API_KEY`   | no       |
| `goose`          | `urn:openai:api`                      | `OPENAI_API_KEY`   | no       |
| `grok`           | `urn:xai:api`                         | `XAI_API_KEY`      | no       |
| `droid`          | `urn:factory:api`                     | `FACTORY_API_KEY`  | no       |
| `opencode`       | `urn:openai:api`                      | `OPENAI_API_KEY`   | no       |
| `gh`             | `https://api.github.com`              | `GITHUB_TOKEN`     | **yes**  |
| `glab`           | `https://gitlab.com/api/v4`           | `GITLAB_TOKEN`     | **yes**  |

Each block is intentionally minimal: `name`, `description`, `scope: runtime`,
`optional`, `audience`, and `redemption: env-var`. No `discovery` hints or
other speculative fields — easy to extend later.

## References

- Plan §Phase 3 (P0): `v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md`
- ADR-026: `v4/docs/ADRs/026-auth-aware-components.md` (schema + audience guidance)
- Survey §1.1 table of components needing auth: `v4/docs/research/auth-aware-survey-2026-04-28.md`
- Parent design PR: #242

## Test plan

- [x] `cargo test -p sindri-core` — all 34 tests pass, including
      `existing_registry_components_still_deserialize`
- [x] `cargo fmt --all --check` clean (YAML-only changes)
- [x] `sindri lint` not yet implemented (`sindri lint --auth` is part of a
      later Phase 3 follow-up PR per the plan); not a blocker
- [ ] Re-verify after Phase 0 lands: deserialize tests should now populate
      `manifest.auth.tokens` for these 10 components

## Out of scope

- P1 / P2 / P3 component migrations — separate PRs per the plan
- Schema additions (Phase 0)
- Resolver / admission Gate 5 (Phase 1, 2)
- `sindri lint --auth` recommendation rule (later Phase 3 PR)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)