### PR TITLE
feat(v4): auth: declarations for P1 components (cloud CLIs + MCP servers)

### DIFF
--- a/v4/crates/sindri-core/src/component.rs
+++ b/v4/crates/sindri-core/src/component.rs
@@ -971,6 +971,80 @@ auth:
     }
 
     #[test]
+    fn p1_components_declare_non_empty_auth() {
+        // ADR-026 Phase 3 P1: cloud CLIs and MCP servers must declare auth
+        // requirements. Each manifest must deserialize cleanly, expose at
+        // least one token requirement, declare every token with `runtime`
+        // scope and a non-empty audience, and use a kebab-cased `kind:`
+        // discriminator on `redemption` (per Phase 0's internally-tagged
+        // schema).
+        use crate::auth::{AuthScope, Redemption};
+
+        let names = [
+            "aws-cli",
+            "azure-cli",
+            "gcloud",
+            "ibmcloud",
+            "aliyun",
+            "doctl",
+            "flyctl",
+            "linear-mcp",
+            "jira-mcp",
+            "pal-mcp-server",
+            "notebooklm-mcp-cli",
+        ];
+        let root = registry_root();
+        for name in names {
+            let path = root.join(name).join("component.yaml");
+            let yaml = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+            let m: ComponentManifest = serde_yaml::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("parse {}: {}", path.display(), e));
+            assert!(
+                !m.auth.is_empty(),
+                "{name}: expected non-empty auth requirements"
+            );
+            assert!(
+                !m.auth.tokens.is_empty(),
+                "{name}: expected at least one token requirement"
+            );
+            for t in &m.auth.tokens {
+                assert!(!t.name.is_empty(), "{name}: token has empty name");
+                assert!(!t.audience.is_empty(), "{name}/{}: empty audience", t.name);
+                assert_eq!(
+                    t.scope,
+                    AuthScope::Runtime,
+                    "{name}/{}: expected runtime scope",
+                    t.name
+                );
+                match &t.redemption {
+                    Redemption::EnvVar { env_name } => {
+                        assert!(!env_name.is_empty(), "{name}/{}: empty env-name", t.name);
+                    }
+                    Redemption::EnvFile { env_name, path } => {
+                        assert!(
+                            !env_name.is_empty() && !path.is_empty(),
+                            "{name}/{}: empty env-file fields",
+                            t.name
+                        );
+                    }
+                    Redemption::File { path, .. } => {
+                        assert!(!path.is_empty(), "{name}/{}: empty file path", t.name);
+                    }
+                }
+            }
+
+            // Round-trip: serialise then deserialise, the `auth` block must survive.
+            let s = serde_yaml::to_string(&m).unwrap();
+            let m2: ComponentManifest = serde_yaml::from_str(&s).unwrap();
+            assert_eq!(
+                m.auth, m2.auth,
+                "{name}: auth block did not round-trip through serde_yaml"
+            );
+        }
+    }
+
+    #[test]
     fn manifest_without_auth_block_has_empty_default() {
         let yaml = r#"
 metadata: { name: t, version: "1.0.0", description: x, license: MIT }

--- a/v4/registry-core/components/aliyun/component.yaml
+++ b/v4/registry-core/components/aliyun/component.yaml
@@ -29,3 +29,25 @@ install:
       macos-aarch64: "sha256:23f3f379f0f41bc5cbbf5e97b3ec95568719d074a5ff97da4c782b046aa9b92a"
 
 depends_on: []
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# `aliyun configure` supports an interactive AK/SK or RAM-role flow, so these
+# tokens are optional. When both are present, the CLI runs fully headless.
+auth:
+  tokens:
+    - name: alibaba-cloud-access-key-id
+      description: "Alibaba Cloud RAM access key ID."
+      audience: "https://sts.aliyuncs.com"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: ALIBABA_CLOUD_ACCESS_KEY_ID
+    - name: alibaba-cloud-access-key-secret
+      description: "Alibaba Cloud RAM access key secret."
+      audience: "https://sts.aliyuncs.com"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: ALIBABA_CLOUD_ACCESS_KEY_SECRET

--- a/v4/registry-core/components/aws-cli/component.yaml
+++ b/v4/registry-core/components/aws-cli/component.yaml
@@ -23,3 +23,26 @@ install:
       linux-aarch64: "sha256:9ce0b00b7926ea7b4f6fd7576e6b0e14ee783fe101e077fd861dc423be3b74e3"
 
 depends_on: []
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# AWS CLI requires both an access key id and matching secret access key at
+# runtime. Both are marked required per the Phase 3 plan; users who prefer
+# `aws configure` / SSO can override via target config.
+auth:
+  tokens:
+    - name: aws-access-key-id
+      description: "AWS access key ID for the AWS CLI."
+      audience: "https://sts.amazonaws.com"
+      scope: runtime
+      optional: false
+      redemption:
+        kind: env-var
+        env-name: AWS_ACCESS_KEY_ID
+    - name: aws-secret-access-key
+      description: "AWS secret access key paired with AWS_ACCESS_KEY_ID."
+      audience: "https://sts.amazonaws.com"
+      scope: runtime
+      optional: false
+      redemption:
+        kind: env-var
+        env-name: AWS_SECRET_ACCESS_KEY

--- a/v4/registry-core/components/azure-cli/component.yaml
+++ b/v4/registry-core/components/azure-cli/component.yaml
@@ -24,3 +24,33 @@ install:
 
 depends_on:
   - "mise:python"
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# Azure CLI supports interactive `az login`, so service-principal credentials
+# are declared optional. When all three are present they enable headless auth.
+auth:
+  tokens:
+    - name: azure-client-id
+      description: "Azure AD application (client) ID for service-principal login."
+      audience: "https://management.azure.com/"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: AZURE_CLIENT_ID
+    - name: azure-client-secret
+      description: "Azure AD application client secret."
+      audience: "https://management.azure.com/"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: AZURE_CLIENT_SECRET
+    - name: azure-tenant-id
+      description: "Azure AD tenant ID for service-principal login."
+      audience: "https://management.azure.com/"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: AZURE_TENANT_ID

--- a/v4/registry-core/components/doctl/component.yaml
+++ b/v4/registry-core/components/doctl/component.yaml
@@ -29,3 +29,17 @@ install:
       macos-aarch64: "sha256:25fea2ed8cb95e9d350a51e65b45a466db4b311640166cf92f39993d0acb56bc"
 
 depends_on: []
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# `doctl auth init` accepts an interactive prompt, so the access-token env
+# binding is optional but recommended for headless use.
+auth:
+  tokens:
+    - name: digitalocean-access-token
+      description: "DigitalOcean personal access token used by doctl."
+      audience: "https://api.digitalocean.com"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: DIGITALOCEAN_ACCESS_TOKEN

--- a/v4/registry-core/components/flyctl/component.yaml
+++ b/v4/registry-core/components/flyctl/component.yaml
@@ -29,3 +29,17 @@ install:
       macos-aarch64: "sha256:6b5627b6a3aca1215501590fecb00c858a00e682336ff37107ea00f6a41e233f"
 
 depends_on: []
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# `fly auth login` is the canonical interactive path; FLY_API_TOKEN is the
+# optional headless equivalent.
+auth:
+  tokens:
+    - name: fly-api-token
+      description: "Fly.io API token (`flyctl auth token`) for headless use."
+      audience: "https://api.fly.io"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: FLY_API_TOKEN

--- a/v4/registry-core/components/gcloud/component.yaml
+++ b/v4/registry-core/components/gcloud/component.yaml
@@ -24,3 +24,18 @@ install:
     timeout: "600"
 
 depends_on: []
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# `gcloud auth login` is the canonical interactive path; service-account JSON
+# via GOOGLE_APPLICATION_CREDENTIALS is therefore optional.
+auth:
+  tokens:
+    - name: google-application-credentials
+      description: "Path to a Google Cloud service-account JSON key file."
+      audience: "https://www.googleapis.com/auth/cloud-platform"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-file
+        env-name: GOOGLE_APPLICATION_CREDENTIALS
+        path: "~/.config/sindri/gcp-credentials.json"

--- a/v4/registry-core/components/ibmcloud/component.yaml
+++ b/v4/registry-core/components/ibmcloud/component.yaml
@@ -23,3 +23,17 @@ install:
       linux-aarch64: "sha256:14784db2fc0338b2876f454098b92a65606c9204be24fa1d610bcd6046f66c81"
 
 depends_on: []
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# `ibmcloud login` supports SSO + interactive flows, so the API-key path is
+# optional but the canonical headless option.
+auth:
+  tokens:
+    - name: ibmcloud-api-key
+      description: "IBM Cloud IAM API key for headless `ibmcloud login --apikey`."
+      audience: "https://iam.cloud.ibm.com"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: IBMCLOUD_API_KEY

--- a/v4/registry-core/components/jira-mcp/component.yaml
+++ b/v4/registry-core/components/jira-mcp/component.yaml
@@ -25,3 +25,26 @@ install:
 
 depends_on:
   - "npm:claude-code"
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# Jira MCP needs an Atlassian API token plus the tenant base URL. Audience is
+# the canonical Atlassian API host; per-tenant URLs (e.g.
+# `https://<tenant>.atlassian.net`) are bound through the JIRA_BASE_URL token.
+auth:
+  tokens:
+    - name: jira-api-token
+      description: "Atlassian API token for the Jira MCP server."
+      audience: "https://api.atlassian.com"
+      scope: runtime
+      optional: false
+      redemption:
+        kind: env-var
+        env-name: JIRA_API_TOKEN
+    - name: jira-base-url
+      description: "Per-tenant Jira base URL, e.g. https://<tenant>.atlassian.net."
+      audience: "https://api.atlassian.com"
+      scope: runtime
+      optional: false
+      redemption:
+        kind: env-var
+        env-name: JIRA_BASE_URL

--- a/v4/registry-core/components/linear-mcp/component.yaml
+++ b/v4/registry-core/components/linear-mcp/component.yaml
@@ -25,3 +25,17 @@ install:
 
 depends_on:
   - "npm:claude-code"
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# Linear MCP authenticates against the Linear GraphQL API with a personal API
+# key; required for any tool invocation.
+auth:
+  tokens:
+    - name: linear-api-key
+      description: "Linear personal API key used by the Linear MCP server."
+      audience: "https://api.linear.app"
+      scope: runtime
+      optional: false
+      redemption:
+        kind: env-var
+        env-name: LINEAR_API_KEY

--- a/v4/registry-core/components/notebooklm-mcp-cli/component.yaml
+++ b/v4/registry-core/components/notebooklm-mcp-cli/component.yaml
@@ -25,3 +25,27 @@ install:
 
 depends_on:
   - "mise:python"
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# NotebookLM bridges accept either a Google API key or a service-account
+# JSON. Both are optional because some users authenticate through the local
+# `gcloud` ADC chain.
+auth:
+  tokens:
+    - name: google-api-key
+      description: "Google API key for the NotebookLM MCP bridge."
+      audience: "https://generativelanguage.googleapis.com"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: GOOGLE_API_KEY
+    - name: google-application-credentials
+      description: "Service-account JSON for NotebookLM (alternate to GOOGLE_API_KEY)."
+      audience: "https://www.googleapis.com/auth/cloud-platform"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-file
+        env-name: GOOGLE_APPLICATION_CREDENTIALS
+        path: "~/.config/sindri/notebooklm-credentials.json"

--- a/v4/registry-core/components/pal-mcp-server/component.yaml
+++ b/v4/registry-core/components/pal-mcp-server/component.yaml
@@ -25,3 +25,35 @@ install:
 
 depends_on:
   - "mise:python"
+
+# ADR-026: auth-aware components (Phase 3 P1).
+# PAL delegates to upstream LLM providers; per the upstream README at least
+# one provider key (Gemini, OpenAI, or OpenRouter) must be present in `.env`.
+# Gemini is the default headline provider in the README (1M-token context),
+# so it is declared required; the others are optional alternates.
+auth:
+  tokens:
+    - name: gemini-api-key
+      description: "Google AI Studio API key used by PAL's Gemini provider."
+      audience: "https://generativelanguage.googleapis.com"
+      scope: runtime
+      optional: false
+      redemption:
+        kind: env-var
+        env-name: GEMINI_API_KEY
+    - name: openai-api-key
+      description: "OpenAI API key used by PAL's OpenAI provider (alternate)."
+      audience: "https://api.openai.com"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: OPENAI_API_KEY
+    - name: openrouter-api-key
+      description: "OpenRouter API key used by PAL's OpenRouter provider (alternate)."
+      audience: "https://openrouter.ai/api"
+      scope: runtime
+      optional: true
+      redemption:
+        kind: env-var
+        env-name: OPENROUTER_API_KEY


### PR DESCRIPTION
## Summary

Phase 3 P1 of the auth-aware components implementation plan
(`v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md`,
ADR-026). Adds minimal `auth:` blocks to 11 P1 components.

Refs #242. **Depends on #244** (Phase 0 schema) — this PR is opened
against `feat/v4-auth-schema-phase0` so the `AuthRequirements` types
are in scope for tests.

### Components touched

| Component | Tokens | Required? | Audience |
|---|---|---|---|
| `aws-cli` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | required | `https://sts.amazonaws.com` |
| `azure-cli` | `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID` | optional | `https://management.azure.com/` |
| `gcloud` | `GOOGLE_APPLICATION_CREDENTIALS` (env-file) | optional | `https://www.googleapis.com/auth/cloud-platform` |
| `ibmcloud` | `IBMCLOUD_API_KEY` | optional | `https://iam.cloud.ibm.com` |
| `aliyun` | `ALIBABA_CLOUD_ACCESS_KEY_ID`, `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | optional | `https://sts.aliyuncs.com` |
| `doctl` | `DIGITALOCEAN_ACCESS_TOKEN` | optional | `https://api.digitalocean.com` |
| `flyctl` | `FLY_API_TOKEN` | optional | `https://api.fly.io` |
| `linear-mcp` | `LINEAR_API_KEY` | required | `https://api.linear.app` |
| `jira-mcp` | `JIRA_API_TOKEN`, `JIRA_BASE_URL` | required | `https://api.atlassian.com` |
| `pal-mcp-server` | `GEMINI_API_KEY` (req), `OPENAI_API_KEY`, `OPENROUTER_API_KEY` | mixed | per-provider |
| `notebooklm-mcp-cli` | `GOOGLE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS` | optional | Google APIs |

All tokens are `scope: runtime`. Cloud CLIs are marked optional because
each has a native interactive login path (`aws configure`, `az login`,
`gcloud auth login`, `ibmcloud login`, `aliyun configure`,
`doctl auth init`, `fly auth login`); MCP servers are required (no
ambient auth path). PAL declares Gemini as required and OpenAI/OpenRouter
as optional alternates per the upstream README's provider model.

`discovery_hints` are intentionally omitted to keep blocks minimal per
the plan.

### Schema conformance

All blocks use the Phase 0 internally-tagged `kind:` discriminator on
`redemption`:

```yaml
redemption:
  kind: env-var       # or env-file
  env-name: ...
```

### Test fixture

Added `p1_components_declare_non_empty_auth` in
`v4/crates/sindri-core/src/component.rs` (alongside the existing
`existing_registry_components_still_deserialize` test) that:

- Loads each P1 component.yaml from disk.
- Asserts `auth` is non-empty and every token has a non-empty `name`,
  `audience`, `scope: runtime`, and a populated `redemption`.
- Round-trips each manifest through `serde_yaml`.

## Test plan

- [x] `cd v4 && cargo test -p sindri-core` — 36 tests pass (was 35;
      adds `p1_components_declare_non_empty_auth`).
- [x] `cd v4 && cargo fmt --all --check` clean.
- [ ] Reviewer: confirm audiences match Phase 1 resolver expectations.
- [ ] Reviewer: confirm PAL provider strategy (Gemini-required) is
      acceptable, or downgrade all three to optional.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)