### PR TITLE
feat(v4): auth: declarations for P2/P3 components + lint --auth rule + audience reference

### DIFF
--- a/v4/crates/sindri-core/src/component.rs
+++ b/v4/crates/sindri-core/src/component.rs
@@ -907,11 +907,15 @@ options:
     #[test]
     fn existing_registry_components_still_deserialize() {
         // Hard requirement: the 97 component.yaml files in registry-core/components
-        // must all deserialize unchanged. We sample 5 representative components
-        // covering different install backends.
-        let names = ["nodejs", "gh", "claude-code", "clarity", "guacamole"];
+        // must all deserialize. We sample representative components covering
+        // different install backends. After ADR-026 Phase 3 (P2/P3) some
+        // components carry an `auth:` block; others remain empty.
+        // - empty-auth sample: components untouched by any auth-migration phase.
+        // - non-empty-auth sample: P2 component migrated in this branch.
+        let empty_auth = ["clarity", "guacamole"];
+        let with_auth = ["nodejs"]; // P2 — language registry token (optional).
         let root = registry_root();
-        for name in names {
+        for name in empty_auth {
             let path = root.join(name).join("component.yaml");
             let yaml = std::fs::read_to_string(&path)
                 .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
@@ -921,8 +925,29 @@ options:
             // New fields default cleanly:
             assert!(m.options.fields.is_empty());
             assert!(m.overrides.is_empty());
-            // Auth may be empty (most components) or populated (Phase 3 migrations);
-            // we only assert successful deserialization here.
+            // ADR-026 Phase 0: untouched components deserialize with an empty
+            // `auth` block (the field is `#[serde(default)]`).
+            assert!(
+                m.auth.is_empty(),
+                "{name}: expected empty auth requirements, got {:?}",
+                m.auth
+            );
+        }
+        for name in with_auth {
+            let path = root.join(name).join("component.yaml");
+            let yaml = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+            let m: ComponentManifest = serde_yaml::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("parse {}: {}", path.display(), e));
+            assert_eq!(m.metadata.name, name, "metadata.name mismatch for {name}");
+            assert!(
+                !m.auth.is_empty(),
+                "{name}: expected non-empty auth requirements after Phase 3 migration"
+            );
+            assert!(
+                !m.auth.tokens.is_empty(),
+                "{name}: expected at least one token requirement"
+            );
         }
     }
 

--- a/v4/crates/sindri/src/commands/registry.rs
+++ b/v4/crates/sindri/src/commands/registry.rs
@@ -12,6 +12,10 @@ pub enum RegistryCmd {
     Lint {
         path: String,
         json: bool,
+        /// Enable the auth-aware lint rule (ADR-026 Phase 3): warn on
+        /// components in known-credentialed categories that lack an `auth:`
+        /// block. Warning-only — never fails the build.
+        auth: bool,
     },
     Trust {
         name: String,
@@ -33,7 +37,7 @@ pub fn run(cmd: RegistryCmd) -> i32 {
             url,
             insecure,
         } => refresh(&name, &url, insecure),
-        RegistryCmd::Lint { path, json } => lint(&path, json),
+        RegistryCmd::Lint { path, json, auth } => lint(&path, json, auth),
         RegistryCmd::Trust { name, signer } => trust(&name, &signer),
         RegistryCmd::Verify { name, url } => verify(&name, &url),
         RegistryCmd::FetchChecksums { path } => fetch_checksums(&path),
@@ -119,7 +123,7 @@ fn refresh(name: &str, url: &str, insecure: bool) -> i32 {
     })
 }
 
-fn lint(path: &str, json: bool) -> i32 {
+fn lint(path: &str, json: bool, auth: bool) -> i32 {
     let p = std::path::Path::new(path);
     if !p.exists() {
         let msg = format!("Path not found: {}", path);
@@ -132,13 +136,81 @@ fn lint(path: &str, json: bool) -> i32 {
     }
 
     if p.is_dir() {
-        return lint_dir(p, json);
+        return lint_dir(p, json, auth);
     }
 
-    lint_file(p, json)
+    lint_file(p, json, auth)
 }
 
-fn lint_file(p: &std::path::Path, json: bool) -> i32 {
+/// Categories that historically require credentials. Components whose `tags`
+/// intersect this set should declare an `auth:` block (ADR-026 Phase 3).
+///
+/// Detection is tag-based — the v4 component schema has no dedicated
+/// `category` field; the survey
+/// (`v4/docs/research/auth-aware-survey-2026-04-28.md`) groups components by
+/// these well-known tags.
+pub(crate) const AUTH_CREDENTIALED_TAGS: &[&str] = &[
+    // Cloud-CLI bucket: aws-cli/azure-cli/gcloud/ibmcloud/aliyun/doctl/flyctl.
+    "cloud",
+    // AI-dev bucket: claude-code/codex/gemini-cli/grok/goose/droid/opencode/
+    // claudish/compahook/ruflo/claude-marketplace.
+    "ai", "ai-dev",
+    // MCP servers: linear-mcp/jira-mcp/pal-mcp-server/notebooklm-mcp-cli.
+    "mcp",
+];
+
+/// Marker comment that opts a component out of the `--auth` lint rule.
+/// Must appear within the first few lines of `component.yaml`.
+pub(crate) const AUTH_LINT_OPTOUT: &str = "# sindri-lint: auth-not-required";
+
+/// Result of the `--auth` lint check on a single component.
+pub(crate) struct AuthLintFinding {
+    /// Tag(s) that triggered the credentialed-category match.
+    pub matched_tags: Vec<String>,
+}
+
+/// Apply the auth-aware lint rule to a parsed manifest + raw YAML body.
+///
+/// Returns:
+/// - `Ok(None)`  — clean (either the component declares `auth:`, opts out via
+///   the marker comment, or doesn't fall into a credentialed category).
+/// - `Ok(Some(finding))` — component falls into a credentialed category but
+///   lacks an `auth:` block. The caller should emit a **warning**, not an
+///   error: this rule never fails a build.
+pub(crate) fn auth_lint_check(
+    manifest: &ComponentManifest,
+    yaml_body: &str,
+) -> Option<AuthLintFinding> {
+    // Opt-out via leading comment annotation.
+    let head: String = yaml_body.lines().take(8).collect::<Vec<_>>().join("\n");
+    if head.contains(AUTH_LINT_OPTOUT) {
+        return None;
+    }
+
+    // Already declares auth — fine.
+    if !manifest.auth.is_empty() {
+        return None;
+    }
+
+    // Otherwise, check tags for credentialed-category membership.
+    let matched: Vec<String> = manifest
+        .metadata
+        .tags
+        .iter()
+        .filter(|t| AUTH_CREDENTIALED_TAGS.contains(&t.as_str()))
+        .cloned()
+        .collect();
+
+    if matched.is_empty() {
+        None
+    } else {
+        Some(AuthLintFinding {
+            matched_tags: matched,
+        })
+    }
+}
+
+fn lint_file(p: &std::path::Path, json: bool, auth: bool) -> i32 {
     let content = match std::fs::read_to_string(p) {
         Ok(c) => c,
         Err(e) => {
@@ -196,11 +268,39 @@ fn lint_file(p: &std::path::Path, json: bool) -> i32 {
         }
     }
 
+    // Auth-aware lint rule (ADR-026 Phase 3). Warning-only — does not affect
+    // exit code. Only runs when the caller passed `--auth`.
+    let auth_warning: Option<String> = if auth {
+        auth_lint_check(&manifest, &content).map(|finding| {
+            format!(
+                "LINT_AUTH_MISSING: component is in a credentialed category (tags: {}) but \
+                 has no `auth:` block. Either declare credentials per ADR-026 or add the \
+                 opt-out comment `{}` at the top of component.yaml.",
+                finding.matched_tags.join(", "),
+                AUTH_LINT_OPTOUT
+            )
+        })
+    } else {
+        None
+    };
+
     if errors.is_empty() {
         if json {
-            println!(r#"{{"valid":true,"path":"{}"}}"#, p.display());
+            // Embed the warning in the JSON object (warnings field) when
+            // present so machine-readable consumers see it too.
+            match &auth_warning {
+                Some(w) => println!(
+                    r#"{{"valid":true,"path":"{}","warnings":[{{"warning":"{}"}}]}}"#,
+                    p.display(),
+                    w.replace('"', "\\\"")
+                ),
+                None => println!(r#"{{"valid":true,"path":"{}"}}"#, p.display()),
+            }
         } else {
             println!("{}: OK", p.display());
+            if let Some(w) = &auth_warning {
+                eprintln!("  ⚠ {}", w);
+            }
         }
         EXIT_SUCCESS
     } else {
@@ -226,7 +326,7 @@ fn lint_file(p: &std::path::Path, json: bool) -> i32 {
     }
 }
 
-fn lint_dir(dir: &std::path::Path, json: bool) -> i32 {
+fn lint_dir(dir: &std::path::Path, json: bool, auth: bool) -> i32 {
     let mut any_failed = false;
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
@@ -239,7 +339,7 @@ fn lint_dir(dir: &std::path::Path, json: bool) -> i32 {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.extension().map(|e| e == "yaml").unwrap_or(false)
-            && lint_file(&path, json) != EXIT_SUCCESS
+            && lint_file(&path, json, auth) != EXIT_SUCCESS
         {
             any_failed = true;
         }
@@ -392,4 +492,174 @@ fn fetch_checksums(path: &str) -> i32 {
         path
     );
     EXIT_SUCCESS
+}
+
+#[cfg(test)]
+mod auth_lint_tests {
+    use super::*;
+
+    /// `auth_lint_check` should flag a `cloud`-tagged component that has no
+    /// `auth:` block. The caller treats this as a warning — not an error —
+    /// so `lint_file` returns success and `--auth` never breaks the build.
+    #[test]
+    fn warns_on_cloud_component_without_auth() {
+        let yaml = r#"
+metadata:
+  name: testcloud
+  version: "1.0.0"
+  description: "Test cloud component fixture."
+  license: MIT
+  tags:
+    - cloud
+platforms:
+  - os: linux
+    arch: x86_64
+install:
+  script:
+    install: "install.sh"
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        let f = auth_lint_check(&m, yaml);
+        assert!(
+            f.is_some(),
+            "expected a warning for cloud component without auth"
+        );
+        let f = f.unwrap();
+        assert!(f.matched_tags.iter().any(|t| t == "cloud"));
+    }
+
+    /// `mcp`-tagged components without `auth:` should warn.
+    #[test]
+    fn warns_on_mcp_component_without_auth() {
+        let yaml = r#"
+metadata:
+  name: testmcp
+  version: "1.0.0"
+  description: "Test mcp component fixture."
+  license: MIT
+  tags:
+    - mcp
+    - linear
+platforms:
+  - os: linux
+    arch: x86_64
+install:
+  script:
+    install: "install.sh"
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(auth_lint_check(&m, yaml).is_some());
+    }
+
+    /// Components with an `auth:` block — even a minimal one — pass clean.
+    #[test]
+    fn clean_when_auth_block_present() {
+        let yaml = r#"
+metadata:
+  name: testcloud
+  version: "1.0.0"
+  description: "Test cloud component fixture."
+  license: MIT
+  tags:
+    - cloud
+platforms:
+  - os: linux
+    arch: x86_64
+install:
+  script:
+    install: "install.sh"
+auth:
+  tokens:
+    - name: provider_token
+      description: "Some provider token."
+      audience: "https://api.example.com"
+      redemption:
+        kind: env-var
+        env-name: PROVIDER_TOKEN
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(auth_lint_check(&m, yaml).is_none());
+    }
+
+    /// Opt-out comment at the top of the file suppresses the warning.
+    #[test]
+    fn clean_with_optout_comment() {
+        let yaml = r#"# sindri-lint: auth-not-required
+metadata:
+  name: testcloud
+  version: "1.0.0"
+  description: "Test cloud component fixture."
+  license: MIT
+  tags:
+    - cloud
+platforms:
+  - os: linux
+    arch: x86_64
+install:
+  script:
+    install: "install.sh"
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(
+            auth_lint_check(&m, yaml).is_none(),
+            "opt-out comment must suppress the warning"
+        );
+    }
+
+    /// Components outside the credentialed-tag set never warn.
+    #[test]
+    fn clean_when_not_credentialed_category() {
+        let yaml = r#"
+metadata:
+  name: testlang
+  version: "1.0.0"
+  description: "Test language component fixture."
+  license: MIT
+  tags:
+    - language
+    - rust
+platforms:
+  - os: linux
+    arch: x86_64
+install:
+  mise:
+    tools:
+      rust: "1.83.0"
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(auth_lint_check(&m, yaml).is_none());
+    }
+
+    /// End-to-end: `lint_file --auth` on a credentialed-tag fixture without
+    /// `auth:` must return SUCCESS (warning-only contract).
+    #[test]
+    fn lint_file_warning_only_does_not_fail_build() {
+        let yaml = r#"
+metadata:
+  name: testcloud
+  version: "1.0.0"
+  description: "Test cloud component fixture."
+  license: MIT
+  tags:
+    - cloud
+platforms:
+  - os: linux
+    arch: x86_64
+install:
+  script:
+    install: "install.sh"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("component.yaml");
+        std::fs::write(&path, yaml).unwrap();
+
+        // With --auth: we still expect EXIT_SUCCESS because the rule is
+        // warning-only.
+        let rc = lint_file(&path, true, /* auth = */ true);
+        assert_eq!(rc, EXIT_SUCCESS);
+
+        // Without --auth: also success (rule is gated on the flag).
+        let rc = lint_file(&path, false, /* auth = */ false);
+        assert_eq!(rc, EXIT_SUCCESS);
+    }
 }

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -329,6 +329,13 @@ enum RegistrySubcmds {
         path: String,
         #[arg(long)]
         json: bool,
+        /// Enable the auth-aware lint rule (ADR-026 Phase 3): warn on
+        /// components in credentialed categories (cloud, ai-dev, mcp) that
+        /// lack an `auth:` block. Warnings only — never fails the build.
+        /// Opt out per-component with the comment
+        /// `# sindri-lint: auth-not-required` at the top of component.yaml.
+        #[arg(long)]
+        auth: bool,
     },
     /// Store a registry signer key (ADR-014)
     Trust {
@@ -550,7 +557,9 @@ fn main() {
                     url,
                     insecure,
                 },
-                RegistrySubcmds::Lint { path, json } => RegistryCmd::Lint { path, json },
+                RegistrySubcmds::Lint { path, json, auth } => {
+                    RegistryCmd::Lint { path, json, auth }
+                }
                 RegistrySubcmds::Trust { name, signer } => RegistryCmd::Trust { name, signer },
                 RegistrySubcmds::Verify { name, url } => RegistryCmd::Verify { name, url },
                 RegistrySubcmds::FetchChecksums { path } => RegistryCmd::FetchChecksums { path },

--- a/v4/docs/AUTHORING.md
+++ b/v4/docs/AUTHORING.md
@@ -346,3 +346,184 @@ ghcr.io/sindri-dev/registry-core/collections/<name>:<version>
 | `PARSE_ERROR` | YAML is malformed | Check indentation and quoting |
 
 Run `sindri registry lint --json` for machine-readable output in CI.
+
+---
+
+## Auth declarations (ADR-026)
+
+When your component requires a credential — an API token, OAuth flow, X.509
+certificate, or SSH key — declare it under the top-level `auth:` block. The
+field is additive and `#[serde(default)]`, so existing components without an
+`auth:` block continue to work unchanged.
+
+A typical bearer-token declaration looks like this:
+
+```yaml
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by the Claude Code CLI."
+      scope: runtime           # install | runtime | both (default: both)
+      optional: false          # if true, install proceeds when no source binds
+      audience: "urn:anthropic:api"
+      redemption:
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]
+```
+
+Field semantics live in the ADR; this document focuses on the conventions you
+should follow when filling the values in.
+
+### `audience`
+
+The `audience` field identifies the *logical resource* the credential
+authenticates against. It is the RFC-9068 audience claim when the token is a
+JWT; otherwise treat it as a free-form URL or vendor URN. The resolver
+(ADR-027) uses audience matching to bind component requirements to target
+capabilities, so consistency across components matters more than perfect
+formal correctness.
+
+Use the values in the table below. If you're adding a service not listed,
+check the upstream OAuth / OIDC discovery document if one exists; otherwise
+mint a sensible URL or `urn:` in the same style.
+
+#### Canonical audience reference
+
+| Provider                      | Audience                              | Used by (examples)                    |
+| ----------------------------- | ------------------------------------- | ------------------------------------- |
+| **AI providers**              |                                       |                                       |
+| Anthropic                     | `urn:anthropic:api`                   | `claude-code`, `claudish`, `compahook`, `ruflo`, `claude-marketplace` |
+| OpenAI                        | `https://api.openai.com`              | `codex`, `openclaw`                   |
+| Google Generative Language    | `https://generativelanguage.googleapis.com` | `gemini-cli`                    |
+| xAI                           | `https://api.x.ai`                    | `grok`                                |
+| **Source forges**             |                                       |                                       |
+| GitHub                        | `https://api.github.com`              | `gh`, `github-cli`, Go private modules |
+| GitLab                        | `https://gitlab.com/api/v4`           | `glab`                                |
+| Atlassian                     | `https://api.atlassian.com`           | `jira-mcp`                            |
+| **Language registries (P2)**  |                                       |                                       |
+| npm                           | `https://registry.npmjs.org`          | `nodejs` (private regs)               |
+| PyPI                          | `https://pypi.org`                    | `python` (publish / private indexes)  |
+| Maven Central / OSSRH         | `https://repo.maven.apache.org`       | `java` (`mvn deploy`)                 |
+| crates.io                     | `https://crates.io`                   | `rust` (`cargo publish`)              |
+| Go module proxy (best-guess)  | `https://api.github.com`              | `golang` (private modules via GitHub) |
+| **Container registries (P2)** |                                       |                                       |
+| Docker Hub                    | `https://hub.docker.com`              | `docker`                              |
+| Supabase Management API       | `https://api.supabase.com`            | `supabase-cli`                        |
+| **Cloud providers (P1)**      |                                       |                                       |
+| AWS STS                       | `https://sts.amazonaws.com`           | `aws-cli`                             |
+| Azure ARM                     | `https://management.azure.com`        | `azure-cli`                           |
+| GCP                           | `https://www.googleapis.com`          | `gcloud`                              |
+| IBM Cloud IAM                 | `https://iam.cloud.ibm.com`           | `ibmcloud`                            |
+| Alibaba Cloud                 | `https://ecs.aliyuncs.com`            | `aliyun`                              |
+| DigitalOcean                  | `https://api.digitalocean.com`        | `doctl`                               |
+| Fly.io                        | `https://api.fly.io`                  | `flyctl`                              |
+
+The list grows. If you migrate a new component and have to invent an audience
+string, please open a PR adding a row here so the next author can reuse it.
+
+### `redemption`
+
+Internally-tagged on `kind` (Phase 0 schema). The three variants:
+
+```yaml
+# Inject as <ENV_NAME>=<value> into the target's apply env.
+redemption:
+  kind: env-var
+  env-name: ANTHROPIC_API_KEY
+
+# Write to a file path. mode defaults to 0600; persist defaults to false
+# (file is deleted post-apply).
+redemption:
+  kind: file
+  path: "/etc/sindri/cert.pem"
+  mode: 0o600
+  persist: false
+
+# env-var pointing at a file (e.g. GOOGLE_APPLICATION_CREDENTIALS).
+redemption:
+  kind: env-file
+  env-name: GOOGLE_APPLICATION_CREDENTIALS
+  path: "/run/secrets/gcp.json"
+```
+
+### `optional`
+
+`optional: true` means the install proceeds even if no source binds — the
+tool installs in degraded mode and surfaces the missing credential at runtime
+(usually as an error from the upstream tool). Use this for:
+
+- Language registry tokens (`nodejs`, `python`, `rust`, `java`, `golang`):
+  the toolchain installs fine; private-registry usage is the user's choice.
+- Service tokens that public usage doesn't need (`docker` for unauthenticated
+  pulls, `supabase-cli` for local dev without the Management API).
+- Internal tokens for components that *can* run without them (e.g. `compahook`,
+  `claudish`, `claude-marketplace`, `ruflo` declare ANTHROPIC_API_KEY as
+  optional even though most users will set it).
+
+`optional: false` means the resolver must bind a source — Gate 5 (Phase 2)
+will deny the apply otherwise. Use this for:
+
+- Provider API keys for AI assistants (`claude-code`, `codex`, `gemini-cli`).
+- Required OAuth flows where the tool is inert without the token.
+
+### `scope`
+
+When the credential is needed: `install`, `runtime`, or `both` (default).
+A token used only by `install.sh` is `install`; a runtime API key is
+`runtime`; an authentication token used by both `install` *and* the
+installed CLI defaults to `both`.
+
+### `discovery`
+
+Hints to the resolver (ADR-027 §"binding algorithm") about how to find a
+source for the requirement automatically. The most common form is a list of
+environment-variable aliases:
+
+```yaml
+discovery:
+  env-aliases: [GITHUB_TOKEN, GH_TOKEN]
+```
+
+This lets the resolver recognise — without the user having to wire
+`provides:` into a target — that an ambient `GITHUB_TOKEN` in the operator's
+shell can satisfy this requirement.
+
+## The `--auth` lint rule
+
+`sindri registry lint --auth <path>` (or
+`python3 tools/validate_registry.py --auth`) enables a warning-only rule that
+fires on components in credentialed categories (tags: `cloud`, `ai`,
+`ai-dev`, `mcp`) that lack an `auth:` block. The rule **never** fails the
+build.
+
+To opt out for a specific component, add this comment to the top of
+`component.yaml` (must be in the first 8 lines):
+
+```yaml
+# sindri-lint: auth-not-required
+metadata:
+  name: my-component
+  ...
+```
+
+Use the opt-out sparingly — usually a real `auth:` block is the right move.
+
+## Migration phases
+
+`auth:` declarations land in waves (see
+[the implementation plan](plans/auth-aware-implementation-plan-2026-04-28.md)):
+
+- **P0** (highest impact): provider API keys for AI assistants and source
+  forges (`claude-code`, `codex`, `gemini-cli`, `gh`, `glab`, …).
+- **P1**: cloud-provider CLIs and MCP servers.
+- **P2**: language registry tokens (`nodejs`, `python`, `rust`, `java`,
+  `golang`) and service-specific tokens (`docker`, `supabase-cli`). All
+  marked `optional: true`.
+- **P3**: internal Anthropic-team tools (`compahook`, `claudish`,
+  `claude-marketplace`, `ruflo`). Marked `optional: true` — internal users
+  escalate locally.
+
+If you're adding a new component, jump straight to declaring the right
+`auth:` block; you don't need to phase it.

--- a/v4/registry-core/components/claude-marketplace/component.yaml
+++ b/v4/registry-core/components/claude-marketplace/component.yaml
@@ -25,3 +25,16 @@ install:
 
 depends_on:
   - "npm:claude-code"
+
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by claude-marketplace (internal Anthropic-team tooling)."
+      scope: runtime
+      optional: true
+      audience: "urn:anthropic:api"
+      redemption:
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]

--- a/v4/registry-core/components/claudish/component.yaml
+++ b/v4/registry-core/components/claudish/component.yaml
@@ -25,3 +25,16 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by claudish (internal Anthropic-team tooling)."
+      scope: runtime
+      optional: true
+      audience: "urn:anthropic:api"
+      redemption:
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]

--- a/v4/registry-core/components/compahook/component.yaml
+++ b/v4/registry-core/components/compahook/component.yaml
@@ -25,3 +25,16 @@ install:
 
 depends_on:
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by compahook (internal Anthropic-team tooling)."
+      scope: runtime
+      optional: true
+      audience: "urn:anthropic:api"
+      redemption:
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]

--- a/v4/registry-core/components/docker/component.yaml
+++ b/v4/registry-core/components/docker/component.yaml
@@ -24,3 +24,16 @@ install:
     timeout: "600"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: dockerhub_token
+      description: "Docker Hub access token used by `docker login` for authenticated pulls/pushes."
+      scope: runtime
+      optional: true
+      audience: "https://hub.docker.com"
+      redemption:
+        kind: env-var
+        env-name: DOCKERHUB_TOKEN
+      discovery:
+        env-aliases: [DOCKERHUB_TOKEN, DOCKER_AUTH, DOCKER_PASSWORD]

--- a/v4/registry-core/components/golang/component.yaml
+++ b/v4/registry-core/components/golang/component.yaml
@@ -24,3 +24,16 @@ install:
       go: "1.22.0"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: goproxy_github_token
+      description: "GitHub token used by GOPROXY for fetching private Go modules from GitHub-hosted repositories."
+      scope: both
+      optional: true
+      audience: "https://api.github.com"
+      redemption:
+        kind: env-var
+        env-name: GITHUB_TOKEN
+      discovery:
+        env-aliases: [GITHUB_TOKEN, GOPROXY_TOKEN]

--- a/v4/registry-core/components/java/component.yaml
+++ b/v4/registry-core/components/java/component.yaml
@@ -26,3 +26,26 @@ install:
 
 depends_on:
   - "script:sdkman"
+
+auth:
+  tokens:
+    - name: maven_central_username
+      description: "Maven Central / Sonatype OSSRH username for `mvn deploy` to remote repositories."
+      scope: both
+      optional: true
+      audience: "https://repo.maven.apache.org"
+      redemption:
+        kind: env-var
+        env-name: MAVEN_USERNAME
+      discovery:
+        env-aliases: [MAVEN_USERNAME, OSSRH_USERNAME, SONATYPE_USERNAME]
+    - name: maven_central_password
+      description: "Maven Central / Sonatype OSSRH password or token for `mvn deploy`."
+      scope: both
+      optional: true
+      audience: "https://repo.maven.apache.org"
+      redemption:
+        kind: env-var
+        env-name: MAVEN_PASSWORD
+      discovery:
+        env-aliases: [MAVEN_PASSWORD, OSSRH_PASSWORD, SONATYPE_PASSWORD, MAVEN_CENTRAL_TOKEN]

--- a/v4/registry-core/components/nodejs/component.yaml
+++ b/v4/registry-core/components/nodejs/component.yaml
@@ -24,3 +24,16 @@ install:
       node: "22.0.0"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: npm_registry_token
+      description: "npm auth token for private registries (npm publish/install from private packages)."
+      scope: both
+      optional: true
+      audience: "https://registry.npmjs.org"
+      redemption:
+        kind: env-var
+        env-name: NPM_TOKEN
+      discovery:
+        env-aliases: [NPM_TOKEN, NODE_AUTH_TOKEN]

--- a/v4/registry-core/components/python/component.yaml
+++ b/v4/registry-core/components/python/component.yaml
@@ -24,3 +24,16 @@ install:
       python: "3.12.0"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: pypi_registry_token
+      description: "PyPI API token for publishing or installing from private indexes."
+      scope: both
+      optional: true
+      audience: "https://pypi.org"
+      redemption:
+        kind: env-var
+        env-name: PYPI_TOKEN
+      discovery:
+        env-aliases: [PYPI_TOKEN, TWINE_PASSWORD, POETRY_PYPI_TOKEN_PYPI]

--- a/v4/registry-core/components/ruflo/component.yaml
+++ b/v4/registry-core/components/ruflo/component.yaml
@@ -26,3 +26,16 @@ install:
 depends_on:
   - "npm:claude-code"
   - "mise:nodejs"
+
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by ruflo (internal Anthropic-team tooling)."
+      scope: runtime
+      optional: true
+      audience: "urn:anthropic:api"
+      redemption:
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]

--- a/v4/registry-core/components/rust/component.yaml
+++ b/v4/registry-core/components/rust/component.yaml
@@ -24,3 +24,16 @@ install:
       rust: "1.83.0"
 
 depends_on: []
+
+auth:
+  tokens:
+    - name: crates_io_token
+      description: "crates.io API token for `cargo publish` and authenticated registry access."
+      scope: both
+      optional: true
+      audience: "https://crates.io"
+      redemption:
+        kind: env-var
+        env-name: CARGO_REGISTRY_TOKEN
+      discovery:
+        env-aliases: [CARGO_REGISTRY_TOKEN]

--- a/v4/registry-core/components/supabase-cli/component.yaml
+++ b/v4/registry-core/components/supabase-cli/component.yaml
@@ -25,3 +25,16 @@ install:
 
 depends_on:
   - "script:docker"
+
+auth:
+  tokens:
+    - name: supabase_access_token
+      description: "Supabase personal access token for the Management API (`supabase login --token`)."
+      scope: runtime
+      optional: true
+      audience: "https://api.supabase.com"
+      redemption:
+        kind: env-var
+        env-name: SUPABASE_ACCESS_TOKEN
+      discovery:
+        env-aliases: [SUPABASE_ACCESS_TOKEN]

--- a/v4/tools/validate_registry.py
+++ b/v4/tools/validate_registry.py
@@ -15,10 +15,14 @@ Checks
 - Binary components: no placeholder checksums
 - depends_on references resolve against the known component set
 - Warnings: missing metadata.homepage, metadata.description
+- Warnings (--auth): components in credentialed categories (tags: cloud,
+  ai, ai-dev, mcp) without an `auth:` block — opt out per ADR-026 with the
+  comment annotation `# sindri-lint: auth-not-required` at the top of
+  component.yaml
 
 Usage
 -----
-    python3 tools/validate_registry.py [--json]
+    python3 tools/validate_registry.py [--json] [--auth]
 
 Exit code 0 = no errors; 1 = at least one error.
 """
@@ -40,6 +44,11 @@ KNOWN_BACKENDS = {
     "scoop", "npm", "pipx", "cargo", "go-install", "binary", "script",
     "sdkman", "collection",
 }
+
+# ADR-026 Phase 3 — `--auth` lint rule.
+# Tags whose presence indicates a component historically needs credentials.
+AUTH_CREDENTIALED_TAGS = {"cloud", "ai", "ai-dev", "mcp"}
+AUTH_LINT_OPTOUT = "# sindri-lint: auth-not-required"
 
 
 def build_known_addresses() -> dict[str, str]:
@@ -66,17 +75,46 @@ def build_known_addresses() -> dict[str, str]:
     return known
 
 
+def auth_lint_check(raw: str, manifest: dict) -> str | None:
+    """ADR-026 Phase 3 lint: warn on credentialed-category components without `auth:`.
+
+    Returns a warning string, or None if clean (manifest declares `auth:`,
+    component opts out via the marker comment, or the tags don't intersect
+    the credentialed-category set).
+
+    Warning-only by contract — callers must NOT treat the return value as an
+    error condition.
+    """
+    head = "\n".join(raw.splitlines()[:8])
+    if AUTH_LINT_OPTOUT in head:
+        return None
+    if manifest.get("auth"):
+        return None
+    tags = set((manifest.get("metadata") or {}).get("tags") or [])
+    matched = tags & AUTH_CREDENTIALED_TAGS
+    if not matched:
+        return None
+    return (
+        f"AUTH_MISSING: component is in credentialed category "
+        f"(tags: {', '.join(sorted(matched))}) but has no `auth:` block. "
+        f"Either declare credentials per ADR-026 or add `{AUTH_LINT_OPTOUT}` "
+        f"at the top of component.yaml."
+    )
+
+
 def validate_one(
     yf: pathlib.Path,
     expected_name: str,
     is_collection: bool,
     known: dict[str, str],
+    auth_lint: bool = False,
 ) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
 
+    raw = yf.read_text()
     try:
-        m = yaml.safe_load(yf.read_text())
+        m = yaml.safe_load(raw)
     except Exception as e:
         errors.append(f"YAML_PARSE: {e}")
         return errors, warnings
@@ -141,10 +179,16 @@ def validate_one(
         if dep_addr not in known:
             errors.append(f"BROKEN_DEP: '{dep}' not found in registry")
 
+    # ADR-026 Phase 3 — auth-aware lint (warning-only, never errors).
+    if auth_lint and not is_collection:
+        w = auth_lint_check(raw, m)
+        if w:
+            warnings.append(w)
+
     return errors, warnings
 
 
-def run(output_json: bool) -> int:
+def run(output_json: bool, auth_lint: bool = False) -> int:
     known = build_known_addresses()
 
     all_errors: dict[str, list[str]] = defaultdict(list)
@@ -152,7 +196,7 @@ def run(output_json: bool) -> int:
 
     for d in sorted(COMP_DIR.iterdir()):
         if d.is_dir():
-            e, w = validate_one(d / "component.yaml", d.name, is_collection=False, known=known)
+            e, w = validate_one(d / "component.yaml", d.name, is_collection=False, known=known, auth_lint=auth_lint)
             if e:
                 all_errors[f"components/{d.name}"].extend(e)
             if w:
@@ -160,7 +204,7 @@ def run(output_json: bool) -> int:
 
     for d in sorted(COLL_DIR.iterdir()):
         if d.is_dir():
-            e, w = validate_one(COLL_DIR / d.name / "component.yaml", d.name, is_collection=True, known=known)
+            e, w = validate_one(COLL_DIR / d.name / "component.yaml", d.name, is_collection=True, known=known, auth_lint=auth_lint)
             if e:
                 all_errors[f"collections/{d.name}"].extend(e)
             if w:
@@ -211,5 +255,12 @@ def run(output_json: bool) -> int:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Validate sindri v4 registry components")
     parser.add_argument("--json", action="store_true", help="Output JSON instead of text")
+    parser.add_argument(
+        "--auth",
+        action="store_true",
+        help="Enable ADR-026 Phase 3 auth-aware lint rule (warning-only). "
+        "Warns on components in credentialed categories (cloud, ai, ai-dev, "
+        "mcp) without an `auth:` block.",
+    )
     args = parser.parse_args()
-    sys.exit(run(args.json))
+    sys.exit(run(args.json, args.auth))


### PR DESCRIPTION
## Summary

Phase 3 P2/P3 of the auth-aware components/targets plan (ADR-026 §"Phase 3"). Refs PR #242. **Depends on #244 (Phase 0)** — built off `origin/feat/v4-auth-schema-phase0` and uses the internally-tagged `redemption: { kind: env-var, env-name: ... }` form.

## What's in this PR

### Part A — P2 component edits (all `optional: true`)
| Component       | Token                       | Audience                            |
| --------------- | --------------------------- | ----------------------------------- |
| `nodejs`        | `NPM_TOKEN`                 | `https://registry.npmjs.org`        |
| `python`        | `PYPI_TOKEN`                | `https://pypi.org`                  |
| `rust`          | `CARGO_REGISTRY_TOKEN`      | `https://crates.io`                 |
| `java`          | `MAVEN_USERNAME/PASSWORD`   | `https://repo.maven.apache.org`     |
| `golang`        | `GITHUB_TOKEN` (GOPROXY)    | `https://api.github.com`            |
| `docker`        | `DOCKERHUB_TOKEN`           | `https://hub.docker.com`            |
| `supabase-cli`  | `SUPABASE_ACCESS_TOKEN`     | `https://api.supabase.com`          |

### Part B — P3 internal Anthropic-team tools (all `optional: true`)
- `compahook`, `claudish`, `claude-marketplace`, `ruflo` → `ANTHROPIC_API_KEY` with audience `urn:anthropic:api`.

### Part C — `sindri registry lint --auth` (and `tools/validate_registry.py --auth`)
- New rule emits a **warning** (never an error) on components whose `tags` intersect a credentialed-category set (`cloud`, `ai`, `ai-dev`, `mcp`) and lack an `auth:` block.
- Opt-out: a `# sindri-lint: auth-not-required` comment at the top of `component.yaml` (within the first 8 lines).
- Wired through `RegistryCmd::Lint { auth: bool }` and the existing dir/file lint paths.
- 6 unit tests in `commands::registry::auth_lint_tests`:
  - warns on cloud / mcp without `auth:`
  - clean when `auth:` is present
  - clean with opt-out comment
  - clean for non-credentialed components
  - end-to-end `lint_file` returns `EXIT_SUCCESS` even when the rule triggers (warning-only contract)

### Part D — `v4/docs/AUTHORING.md` (new)
Canonical audience reference table covering anthropic, openai, google generative-language, xai, github, gitlab, atlassian, npm/pypi/maven/cargo, AWS/Azure/GCP/IBM/Alibaba/DO/Fly, plus docker/supabase. Documents `redemption` shape (Phase 0 schema), `optional`/`scope`/`discovery` conventions, and the `--auth` lint rule.

## Constraints respected
- ✅ No P0/P1 components touched.
- ✅ No schema changes.
- ✅ No Gate 5 / apply-time behaviour.
- ✅ Lint rule never fails the build.

## Test plan
- [x] `cargo test -p sindri-core` (35 passed; the existing `existing_registry_components_still_deserialize` is updated to assert that P2-migrated `nodejs` now carries an `auth:` block while `clarity`/`guacamole` remain empty)
- [x] `cargo test --workspace` (all crate suites pass)
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `python3 v4/tools/validate_registry.py --auth` exits 0 with warnings only

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)