### PR TITLE
feat(v4): UX polish — auth show/refresh + doctor --auth + target auth --bind (ADR-027 §Phase 5)

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -3302,6 +3302,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sindri-core",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -221,6 +221,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2209,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2312,12 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2407,6 +2447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2716,6 +2765,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3228,6 +3289,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dirs-next",
+ "proptest",
+ "regex",
  "semver",
  "serde",
  "serde_json",
@@ -3748,6 +3811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,6 +3901,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -3280,6 +3280,7 @@ name = "sindri-resolver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dirs-next",
  "hex",
  "serde",
  "serde_json",

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -3312,6 +3312,7 @@ dependencies = [
  "serde_yaml",
  "sindri-core",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -391,6 +391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,6 +3230,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "dirs-next",
  "hex",
  "serde",

--- a/v4/crates/sindri-core/src/auth.rs
+++ b/v4/crates/sindri-core/src/auth.rs
@@ -1,0 +1,586 @@
+// ADR-026: Auth-Aware Components — declaration side schema.
+// ADR-027: Target → Component Auth Injection — target capability schema.
+// DDD-07: Auth-Bindings Domain — value-object types live here in `sindri-core`.
+//
+// This module is **schema-only** (Phase 0 of the auth-aware implementation
+// plan, 2026-04-28). No resolver, lockfile, or apply paths read these types
+// yet; they ship now so Phase 1+ can populate them.
+//
+// All new fields are additive and `#[serde(default)]`-protected: existing
+// component.yaml / sindri.yaml / target manifests deserialize unchanged.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// =============================================================================
+// Component-side declaration (ADR-026)
+// =============================================================================
+
+/// What credentials a component needs to install and/or run.
+///
+/// Mounted on `ComponentManifest.auth` as `#[serde(default)]`. Existing
+/// manifests (which omit `auth:`) deserialize as `AuthRequirements::default()`,
+/// for which [`AuthRequirements::is_empty`] returns `true`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthRequirements {
+    /// API tokens / static bearer secrets (anything that lives as a single
+    /// string).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tokens: Vec<TokenRequirement>,
+    /// OAuth-flow credentials (RFC 8628 device flow today; auth-code in
+    /// future).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub oauth: Vec<OAuthRequirement>,
+    /// X.509 / PEM materials.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub certs: Vec<CertRequirement>,
+    /// SSH key material (private + optional passphrase).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ssh: Vec<SshKeyRequirement>,
+}
+
+impl AuthRequirements {
+    /// True if no requirements of any kind are declared.
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+            && self.oauth.is_empty()
+            && self.certs.is_empty()
+            && self.ssh.is_empty()
+    }
+}
+
+/// A single static bearer-style token requirement.
+///
+/// See ADR-026 §"Schema" for field semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct TokenRequirement {
+    /// Stable id, unique within the component (e.g. `github_token`).
+    pub name: String,
+    /// One-line human description shown by `sindri doctor` and
+    /// `sindri auth show`.
+    pub description: String,
+    /// When the credential is needed.
+    #[serde(default)]
+    pub scope: AuthScope,
+    /// If true, install proceeds when no source binds (degraded mode).
+    #[serde(default)]
+    pub optional: bool,
+    /// Logical resource the token is intended for. RFC-9068 audience claim
+    /// when the token is a JWT; otherwise a free-form URL or vendor URN
+    /// (e.g. `https://api.github.com`, `urn:anthropic:api`).
+    pub audience: String,
+    /// How the component wants to *receive* the resolved value at apply time.
+    #[serde(default)]
+    pub redemption: Redemption,
+    /// Hints the resolver uses to find a source automatically (ADR-027).
+    #[serde(default)]
+    pub discovery: DiscoveryHints,
+}
+
+/// OAuth-flow credential requirement (RFC 8628 device flow today).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct OAuthRequirement {
+    /// Stable id (e.g. `github_oauth`).
+    pub name: String,
+    /// Human-friendly description.
+    pub description: String,
+    /// Audience the resulting access-token is intended for.
+    pub audience: String,
+    /// OAuth provider id (matches `OAuthProvider.id` in DDD-07).
+    pub provider: String,
+    /// OAuth scopes to request.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    /// When the credential is needed.
+    #[serde(default)]
+    pub scope: AuthScope,
+    /// If true, install proceeds without a bound source.
+    #[serde(default)]
+    pub optional: bool,
+    /// How the component wants the redeemed token delivered.
+    #[serde(default)]
+    pub redemption: Redemption,
+}
+
+/// X.509 / PEM certificate-material requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct CertRequirement {
+    /// Stable id (e.g. `client_cert`).
+    pub name: String,
+    /// Human-friendly description.
+    pub description: String,
+    /// Audience the certificate authenticates against.
+    pub audience: String,
+    /// When the material is needed.
+    #[serde(default)]
+    pub scope: AuthScope,
+    /// If true, install proceeds without a bound source.
+    #[serde(default)]
+    pub optional: bool,
+    /// Where the cert should be placed at apply time.
+    #[serde(default)]
+    pub redemption: Redemption,
+}
+
+/// SSH-key material requirement (private key + optional passphrase).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct SshKeyRequirement {
+    /// Stable id (e.g. `git_ssh_key`).
+    pub name: String,
+    /// Human-friendly description.
+    pub description: String,
+    /// Audience the key authenticates against
+    /// (e.g. `ssh://git@github.com`).
+    pub audience: String,
+    /// When the key is needed.
+    #[serde(default)]
+    pub scope: AuthScope,
+    /// If true, install proceeds without a bound source.
+    #[serde(default)]
+    pub optional: bool,
+    /// Where the key file should be placed at apply time.
+    #[serde(default)]
+    pub redemption: Redemption,
+}
+
+/// When in the lifecycle a credential is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuthScope {
+    /// Needed only while install/configure scripts run.
+    Install,
+    /// Needed when the installed tool is invoked by the user.
+    Runtime,
+    /// Both phases.
+    #[default]
+    Both,
+}
+
+/// How the component wants to *receive* a resolved credential at apply time.
+///
+/// Internally-tagged on `kind` for serde_yaml compatibility (matches the
+/// [`AuthSource`] convention). Field names are kebab-cased on the wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum Redemption {
+    /// Inject as `<env_name>=<value>` into `Target::exec` env.
+    EnvVar {
+        #[serde(rename = "env-name")]
+        env_name: String,
+    },
+    /// Write to `<path>` (mode 0600 by default; deleted post-apply unless
+    /// `persist: true`).
+    File {
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mode: Option<u32>,
+        #[serde(default)]
+        persist: bool,
+    },
+    /// Both: env-var pointing at file (e.g.
+    /// `GOOGLE_APPLICATION_CREDENTIALS`).
+    EnvFile {
+        #[serde(rename = "env-name")]
+        env_name: String,
+        path: String,
+    },
+}
+
+impl Default for Redemption {
+    fn default() -> Self {
+        // An empty env-var name is the "unspecified" sentinel; the real value
+        // is supplied per-requirement when the manifest declares one. The
+        // default exists so `#[serde(default)]` on a wrapping requirement
+        // can still produce a valid value during partial-decode scenarios.
+        Redemption::EnvVar {
+            env_name: String::new(),
+        }
+    }
+}
+
+/// Component-side aliases that help the resolver auto-bind without explicit
+/// `targets.<n>.provides` configuration (ADR-026 §"Schema",
+/// ADR-027 §"Binding algorithm").
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct DiscoveryHints {
+    /// Env-var names to probe (e.g. `["ANTHROPIC_API_KEY","CLAUDE_API_KEY"]`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_aliases: Vec<String>,
+    /// `cli:` invocations that produce the token
+    /// (e.g. `["gh auth token"]`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cli_aliases: Vec<String>,
+    /// OAuth provider id this requirement maps to (matches
+    /// `OAuthProvider.id`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth_provider: Option<String>,
+}
+
+// =============================================================================
+// Target-side capability declaration (ADR-027)
+// =============================================================================
+
+/// Audience the resulting credential is valid for.
+///
+/// Currently a thin newtype around `String`; matched as canonicalised,
+/// lower-cased strings (no globs). See ADR-026 §"Audience binding".
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct Audience(pub String);
+
+impl Audience {
+    /// Wrap an audience string in the newtype.
+    pub fn new(s: impl Into<String>) -> Self {
+        Audience(s.into())
+    }
+
+    /// Borrow the underlying string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for Audience {
+    fn from(s: String) -> Self {
+        Audience(s)
+    }
+}
+
+impl From<&str> for Audience {
+    fn from(s: &str) -> Self {
+        Audience(s.to_string())
+    }
+}
+
+/// What a target advertises it can fulfill (ADR-027 §1).
+///
+/// Returned by `Target::auth_capabilities()` (added in Phase 1) and
+/// declarable per-target via `TargetConfig.provides`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthCapability {
+    /// Capability id (e.g. `github_token`, `anthropic_api_key`, `aws_sso`).
+    pub id: String,
+    /// Audience the produced credential is valid for. Must match a
+    /// requirement's audience (ADR-026 §"Audience binding") to bind.
+    pub audience: String,
+    /// Where this credential physically comes from when redeemed.
+    pub source: AuthSource,
+    /// Priority for resolver tie-breaking (higher = preferred). Default `0`.
+    #[serde(default)]
+    pub priority: i32,
+}
+
+/// Where a credential value physically comes from when redeemed (ADR-027 §1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum AuthSource {
+    /// Resolve via `sindri-secrets` (Vault, S3, KV).
+    FromSecretsStore { backend: String, path: String },
+    /// Resolve from environment variable on the target.
+    FromEnv { var: String },
+    /// Resolve from a file readable on the target.
+    FromFile {
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mode: Option<u32>,
+    },
+    /// Delegate to an installed CLI (mirrors `cli:` of ADR-020).
+    FromCli { command: String },
+    /// Reuse the target's own upstream auth (e.g. the target's session token
+    /// doubles as a child-workload credential).
+    FromUpstreamCredentials,
+    /// Run an OAuth device flow
+    /// (ADR-026 → `DiscoveryHints.oauth_provider`).
+    #[serde(rename = "from-oauth")]
+    FromOAuth { provider: String },
+    /// Interactive prompt (TTY only; rejected in `--ci` mode by Gate 5).
+    Prompt,
+}
+
+// =============================================================================
+// Secret reference (minimal, until `sindri-secrets` lands)
+// =============================================================================
+
+/// Typed reference to a secret in a backend store.
+///
+/// Used by [`crate::auth::AuthSource::FromSecretsStore`] and by the
+/// `secret:<backend>/<path>` form of `AuthValue` (ADR-020).
+///
+/// This is a deliberately minimal placeholder for the eventual
+/// `sindri-secrets` crate (ADR-025). When that crate lands, the canonical
+/// definition will move there and this module will re-export it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct SecretRef {
+    /// Backend id (e.g. `vault`, `aws-sm`, `gcp-sm`, `kv`).
+    pub backend: String,
+    /// Backend-specific path / key reference.
+    pub path: String,
+}
+
+impl SecretRef {
+    /// Construct a new [`SecretRef`].
+    pub fn new(backend: impl Into<String>, path: impl Into<String>) -> Self {
+        Self {
+            backend: backend.into(),
+            path: path.into(),
+        }
+    }
+
+    /// Parse the `<backend>/<path>` portion of a `secret:<backend>/<path>`
+    /// reference. The leading `secret:` prefix MUST already have been
+    /// stripped by the caller.
+    ///
+    /// Returns `None` if the input is missing the `/` separator or if either
+    /// side is empty.
+    pub fn parse(rest: &str) -> Option<Self> {
+        let (backend, path) = rest.split_once('/')?;
+        if backend.is_empty() || path.is_empty() {
+            return None;
+        }
+        Some(SecretRef {
+            backend: backend.to_string(),
+            path: path.to_string(),
+        })
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_requirements_default_is_empty() {
+        let a = AuthRequirements::default();
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn auth_requirements_round_trip_token() {
+        let yaml = r#"
+tokens:
+  - name: anthropic_api_key
+    description: "Anthropic API key used by the Claude Code CLI."
+    scope: runtime
+    optional: false
+    audience: "urn:anthropic:api"
+    redemption:
+      kind: env-var
+      env-name: ANTHROPIC_API_KEY
+    discovery:
+      env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]
+      cli-aliases: ["sindri-anthropic-cli token"]
+"#;
+        let a: AuthRequirements = serde_yaml::from_str(yaml).unwrap();
+        assert!(!a.is_empty());
+        assert_eq!(a.tokens.len(), 1);
+        let t = &a.tokens[0];
+        assert_eq!(t.name, "anthropic_api_key");
+        assert_eq!(t.scope, AuthScope::Runtime);
+        assert!(!t.optional);
+        assert_eq!(t.audience, "urn:anthropic:api");
+        match &t.redemption {
+            Redemption::EnvVar { env_name } => assert_eq!(env_name, "ANTHROPIC_API_KEY"),
+            other => panic!("expected EnvVar, got {:?}", other),
+        }
+        assert_eq!(
+            t.discovery.env_aliases,
+            vec![
+                "ANTHROPIC_API_KEY".to_string(),
+                "CLAUDE_API_KEY".to_string(),
+            ]
+        );
+        assert_eq!(
+            t.discovery.cli_aliases,
+            vec!["sindri-anthropic-cli token".to_string()]
+        );
+
+        // Round-trip
+        let s = serde_yaml::to_string(&a).unwrap();
+        let a2: AuthRequirements = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(a, a2);
+    }
+
+    #[test]
+    fn auth_scope_default_is_both() {
+        assert_eq!(AuthScope::default(), AuthScope::Both);
+    }
+
+    #[test]
+    fn redemption_file_round_trips() {
+        let yaml = r#"
+tokens:
+  - name: gcp_creds
+    description: "GCP service account JSON."
+    audience: "https://iam.googleapis.com"
+    redemption:
+      kind: env-file
+      env-name: GOOGLE_APPLICATION_CREDENTIALS
+      path: "/run/secrets/gcp.json"
+"#;
+        let a: AuthRequirements = serde_yaml::from_str(yaml).unwrap();
+        let t = &a.tokens[0];
+        match &t.redemption {
+            Redemption::EnvFile { env_name, path } => {
+                assert_eq!(env_name, "GOOGLE_APPLICATION_CREDENTIALS");
+                assert_eq!(path, "/run/secrets/gcp.json");
+            }
+            other => panic!("expected EnvFile, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn redemption_file_persist_default_false() {
+        let yaml = r#"
+tokens:
+  - name: client_cert
+    description: "Client cert."
+    audience: "https://example.com"
+    redemption:
+      kind: file
+      path: "/etc/sindri/cert.pem"
+      mode: 0o600
+"#;
+        let a: AuthRequirements = serde_yaml::from_str(yaml).unwrap();
+        match &a.tokens[0].redemption {
+            Redemption::File {
+                path,
+                mode,
+                persist,
+            } => {
+                assert_eq!(path, "/etc/sindri/cert.pem");
+                assert_eq!(*mode, Some(0o600));
+                assert!(!*persist);
+            }
+            other => panic!("expected File, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn auth_source_round_trips_all_variants() {
+        let cases: &[(&str, AuthSource)] = &[
+            (
+                r#"{ kind: from-secrets-store, backend: vault, path: "secrets/x" }"#,
+                AuthSource::FromSecretsStore {
+                    backend: "vault".to_string(),
+                    path: "secrets/x".to_string(),
+                },
+            ),
+            (
+                r#"{ kind: from-env, var: GITHUB_TOKEN }"#,
+                AuthSource::FromEnv {
+                    var: "GITHUB_TOKEN".to_string(),
+                },
+            ),
+            (
+                r#"{ kind: from-cli, command: "gh auth token" }"#,
+                AuthSource::FromCli {
+                    command: "gh auth token".to_string(),
+                },
+            ),
+            (
+                r#"{ kind: from-upstream-credentials }"#,
+                AuthSource::FromUpstreamCredentials,
+            ),
+            (
+                r#"{ kind: from-oauth, provider: github }"#,
+                AuthSource::FromOAuth {
+                    provider: "github".to_string(),
+                },
+            ),
+            (r#"{ kind: prompt }"#, AuthSource::Prompt),
+        ];
+        for (yaml, expected) in cases {
+            let parsed: AuthSource = serde_yaml::from_str(yaml).unwrap();
+            assert_eq!(&parsed, expected, "yaml={}", yaml);
+            let s = serde_yaml::to_string(&parsed).unwrap();
+            let again: AuthSource = serde_yaml::from_str(&s).unwrap();
+            assert_eq!(parsed, again);
+        }
+    }
+
+    #[test]
+    fn auth_capability_round_trips() {
+        let yaml = r#"
+id: github_token
+audience: "https://api.github.com"
+source: { kind: from-secrets-store, backend: vault, path: "secrets/github/team" }
+priority: 100
+"#;
+        let c: AuthCapability = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(c.id, "github_token");
+        assert_eq!(c.audience, "https://api.github.com");
+        assert_eq!(c.priority, 100);
+        match &c.source {
+            AuthSource::FromSecretsStore { backend, path } => {
+                assert_eq!(backend, "vault");
+                assert_eq!(path, "secrets/github/team");
+            }
+            other => panic!("expected FromSecretsStore, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn auth_capability_priority_defaults_to_zero() {
+        let yaml = r#"
+id: local_env
+audience: "https://api.github.com"
+source: { kind: from-env, var: GITHUB_TOKEN }
+"#;
+        let c: AuthCapability = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(c.priority, 0);
+    }
+
+    #[test]
+    fn secret_ref_parses_canonical_form() {
+        let r = SecretRef::parse("vault/secrets/anthropic/prod").unwrap();
+        assert_eq!(r.backend, "vault");
+        assert_eq!(r.path, "secrets/anthropic/prod");
+    }
+
+    #[test]
+    fn secret_ref_rejects_malformed() {
+        assert!(SecretRef::parse("no-slash").is_none());
+        assert!(SecretRef::parse("/missing-backend").is_none());
+        assert!(SecretRef::parse("missing-path/").is_none());
+    }
+
+    #[test]
+    fn audience_newtype_round_trips() {
+        let a = Audience::new("urn:anthropic:api");
+        let s = serde_json::to_string(&a).unwrap();
+        // transparent → serialises as a bare string
+        assert_eq!(s, "\"urn:anthropic:api\"");
+        let back: Audience = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn oauth_requirement_round_trips() {
+        let yaml = r#"
+name: github_oauth
+description: "GitHub OAuth for repo access."
+audience: "https://api.github.com"
+provider: github
+scopes: [repo, read:org]
+scope: install
+optional: true
+"#;
+        let o: OAuthRequirement = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(o.name, "github_oauth");
+        assert_eq!(o.provider, "github");
+        assert_eq!(o.scopes, vec!["repo".to_string(), "read:org".to_string()]);
+        assert_eq!(o.scope, AuthScope::Install);
+        assert!(o.optional);
+    }
+}

--- a/v4/crates/sindri-core/src/auth.rs
+++ b/v4/crates/sindri-core/src/auth.rs
@@ -305,6 +305,114 @@ pub enum AuthSource {
 }
 
 // =============================================================================
+// Auth binding (DDD-07 — aggregate root of the Auth-Bindings domain)
+// =============================================================================
+
+/// Status of an [`AuthBinding`] once the resolver has walked the candidate
+/// chain (DDD-07 §"Lifecycle states", excluding the transient `Redeemed`
+/// state which lives only at apply time).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuthBindingStatus {
+    /// A candidate source matched and was selected.
+    Bound,
+    /// No source matched, but the requirement is `optional: true` —
+    /// install proceeds with a warning.
+    Deferred,
+    /// No source matched and the requirement is non-optional — Gate 5
+    /// (Phase 2) will deny apply.
+    Failed,
+}
+
+/// A candidate that was considered but rejected by the binding algorithm
+/// (ADR-027 §3 "considered-but-rejected list").
+///
+/// Persisted into the lockfile so `sindri auth show` can explain *why* a
+/// particular source did not win.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct RejectedCandidate {
+    /// The capability id that was considered.
+    pub capability_id: String,
+    /// The source kind (the discriminant of [`AuthSource`]).
+    pub source_kind: String,
+    /// Reason for rejection (e.g. `"audience-mismatch"`,
+    /// `"scope-mismatch"`, `"duplicate"`).
+    pub reason: String,
+}
+
+/// The aggregate root of the Auth-Bindings domain (DDD-07 §"Core
+/// Aggregate"). Computed at resolve time; persisted in the per-target
+/// lockfile.
+///
+/// The binding records *references only* — no resolved credential value
+/// can ever live here (DDD-07 invariant 3 "no value capture").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthBinding {
+    /// Deterministic id: `sha256(component_address || requirement.name ||
+    /// target_id)` truncated to 16 hex chars. Stable across hosts so
+    /// lockfile diffs reflect intent changes only (DDD-07 invariant 4).
+    pub id: String,
+    /// Component address (e.g. `npm:claude-code`).
+    pub component: String,
+    /// Requirement name within the component manifest.
+    pub requirement: String,
+    /// Audience canonicalised to lower-case. Equal to
+    /// `req.audience == source.audience` (DDD-07 invariant 1).
+    pub audience: String,
+    /// Target name (key in `BomManifest.targets`).
+    pub target: String,
+    /// The bound source (None if status is `Deferred` or `Failed`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<AuthSource>,
+    /// Capability priority that won (0 if none).
+    #[serde(default)]
+    pub priority: i32,
+    /// Lifecycle state of the binding.
+    pub status: AuthBindingStatus,
+    /// Reason string when `status` is `Deferred` or `Failed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Other candidates that were considered but rejected (ordered as
+    /// walked).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub considered: Vec<RejectedCandidate>,
+}
+
+/// Discriminant string for an [`AuthSource`] — used by the binding
+/// algorithm's tie-breaker and by [`RejectedCandidate::source_kind`].
+///
+/// The order also defines the deterministic tie-breaker when capability
+/// priorities are equal (ADR-027 §3 "Stable order"):
+/// `FromSecretsStore` > `FromEnv` > `FromFile` > `FromCli` >
+/// `FromUpstreamCredentials` > `FromOAuth` > `Prompt`.
+pub fn auth_source_kind(s: &AuthSource) -> &'static str {
+    match s {
+        AuthSource::FromSecretsStore { .. } => "from-secrets-store",
+        AuthSource::FromEnv { .. } => "from-env",
+        AuthSource::FromFile { .. } => "from-file",
+        AuthSource::FromCli { .. } => "from-cli",
+        AuthSource::FromUpstreamCredentials => "from-upstream-credentials",
+        AuthSource::FromOAuth { .. } => "from-oauth",
+        AuthSource::Prompt => "prompt",
+    }
+}
+
+/// Sort rank for [`auth_source_kind`] — lower is preferred.
+pub fn auth_source_rank(s: &AuthSource) -> u8 {
+    match s {
+        AuthSource::FromSecretsStore { .. } => 0,
+        AuthSource::FromEnv { .. } => 1,
+        AuthSource::FromFile { .. } => 2,
+        AuthSource::FromCli { .. } => 3,
+        AuthSource::FromUpstreamCredentials => 4,
+        AuthSource::FromOAuth { .. } => 5,
+        AuthSource::Prompt => 6,
+    }
+}
+
+// =============================================================================
 // Secret reference (minimal, until `sindri-secrets` lands)
 // =============================================================================
 

--- a/v4/crates/sindri-core/src/component.rs
+++ b/v4/crates/sindri-core/src/component.rs
@@ -3,6 +3,8 @@
 // ADR-024: Script-component lifecycle contract (validate/configure/remove)
 // DDD-01: Component domain — full aggregate (id, manifest, options,
 //         install/validate/configure/remove, per-platform overrides, capabilities)
+// ADR-026: Auth-Aware Components — `auth: AuthRequirements` field on ComponentManifest.
+use crate::auth::AuthRequirements;
 use crate::platform::{Arch, Os, Platform};
 use crate::version::VersionSpec;
 use schemars::JsonSchema;
@@ -208,6 +210,13 @@ pub struct ComponentManifest {
     /// See [`platform_key`].
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub overrides: HashMap<String, PlatformOverride>,
+
+    // ----- ADR-026 addition (additive; default-empty) -----
+    /// Credentials this component declares it needs to install and/or run
+    /// (ADR-026). Phase 0 ships the schema only; the resolver, lockfile, and
+    /// apply paths do not read this field yet (Phases 1+ will).
+    #[serde(default, skip_serializing_if = "AuthRequirements::is_empty")]
+    pub auth: AuthRequirements,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -912,6 +921,77 @@ options:
             // New fields default cleanly:
             assert!(m.options.fields.is_empty());
             assert!(m.overrides.is_empty());
+            // ADR-026 Phase 0: every existing component must deserialize with
+            // an empty `auth` block (the field is `#[serde(default)]`).
+            assert!(
+                m.auth.is_empty(),
+                "{name}: expected empty auth requirements, got {:?}",
+                m.auth
+            );
         }
+    }
+
+    // ----- ADR-026: auth block round-trips through ComponentManifest -----
+
+    #[test]
+    fn manifest_with_auth_block_round_trips() {
+        use crate::auth::{AuthScope, Redemption};
+
+        let yaml = r#"
+metadata: { name: claude-code, version: "1.0.0", description: x, license: MIT }
+platforms: [{ os: linux, arch: x86_64 }]
+install:
+  npm:
+    package: "@anthropic-ai/claude-code"
+    global: true
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key used by the Claude Code CLI."
+      scope: runtime
+      optional: false
+      audience: "urn:anthropic:api"
+      redemption:
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(!m.auth.is_empty());
+        assert_eq!(m.auth.tokens.len(), 1);
+        let t = &m.auth.tokens[0];
+        assert_eq!(t.name, "anthropic_api_key");
+        assert_eq!(t.scope, AuthScope::Runtime);
+        assert_eq!(t.audience, "urn:anthropic:api");
+        match &t.redemption {
+            Redemption::EnvVar { env_name } => assert_eq!(env_name, "ANTHROPIC_API_KEY"),
+            other => panic!("expected EnvVar, got {:?}", other),
+        }
+
+        // Round-trip: serialise then deserialise, the `auth` block must survive.
+        let s = serde_yaml::to_string(&m).unwrap();
+        let m2: ComponentManifest = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(m.auth, m2.auth);
+    }
+
+    #[test]
+    fn manifest_without_auth_block_has_empty_default() {
+        let yaml = r#"
+metadata: { name: t, version: "1.0.0", description: x, license: MIT }
+platforms: [{ os: linux, arch: x86_64 }]
+install: {}
+"#;
+        let m: ComponentManifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(m.auth.is_empty());
+
+        // And serialising back must NOT emit an empty `auth:` key
+        // (the field is `skip_serializing_if = "AuthRequirements::is_empty"`).
+        let s = serde_yaml::to_string(&m).unwrap();
+        assert!(
+            !s.contains("auth:"),
+            "expected serialised manifest to omit empty auth block, got:\n{}",
+            s
+        );
     }
 }

--- a/v4/crates/sindri-core/src/lib.rs
+++ b/v4/crates/sindri-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+pub mod auth;
 pub mod component;
 pub mod exit_codes;
 pub mod lockfile;

--- a/v4/crates/sindri-core/src/lockfile.rs
+++ b/v4/crates/sindri-core/src/lockfile.rs
@@ -1,3 +1,4 @@
+use crate::auth::AuthBinding;
 use crate::component::{Backend, ComponentId, ComponentManifest};
 use crate::version::Version;
 use schemars::JsonSchema;
@@ -10,6 +11,15 @@ pub struct Lockfile {
     pub bom_hash: String,
     pub target: String,
     pub components: Vec<ResolvedComponent>,
+    /// Auth bindings produced by the resolver's binding pass (ADR-027 §3,
+    /// DDD-07 aggregate root).
+    ///
+    /// Phase 1 of the auth-aware implementation plan ships this field as
+    /// **observability-only**: the apply path does not yet read these
+    /// entries (Phase 2 will). Existing lockfiles deserialize unchanged
+    /// because the field is `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auth_bindings: Vec<AuthBinding>,
 }
 
 impl Lockfile {
@@ -19,6 +29,7 @@ impl Lockfile {
             bom_hash,
             target,
             components: Vec::new(),
+            auth_bindings: Vec::new(),
         }
     }
 

--- a/v4/crates/sindri-core/src/manifest.rs
+++ b/v4/crates/sindri-core/src/manifest.rs
@@ -1,4 +1,6 @@
 // ADR-001: User-authored sindri.yaml BOM as single source of truth
+// ADR-027: Target → Component Auth Injection — `provides: Vec<AuthCapability>` on TargetConfig.
+use crate::auth::AuthCapability;
 use crate::component::BomEntry;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -35,6 +37,11 @@ pub struct TargetConfig {
     pub kind: String,
     pub infra: Option<serde_json::Value>,
     pub auth: Option<HashMap<String, String>>,
+    /// User-visible overrides of (or additions to) the target's intrinsic
+    /// auth capabilities (ADR-027 §"Per-target manifest extension"). Empty by
+    /// default; existing target configs deserialize unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provides: Vec<AuthCapability>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -47,4 +54,71 @@ pub struct Preferences {
 pub struct OverrideEntry {
     pub address: String,
     pub reason: String,
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::AuthSource;
+
+    #[test]
+    fn target_config_without_provides_defaults_empty() {
+        let yaml = r#"
+kind: fly
+"#;
+        let t: TargetConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(t.provides.is_empty());
+    }
+
+    #[test]
+    fn target_config_with_provides_round_trips() {
+        let yaml = r#"
+kind: fly
+auth: { token: "secret:vault/fly/team-prod" }
+provides:
+  - id: github_token
+    audience: "https://api.github.com"
+    source: { kind: from-secrets-store, backend: vault, path: "secrets/github/team" }
+    priority: 100
+"#;
+        let t: TargetConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(t.kind, "fly");
+        assert_eq!(t.provides.len(), 1);
+        let cap = &t.provides[0];
+        assert_eq!(cap.id, "github_token");
+        assert_eq!(cap.audience, "https://api.github.com");
+        assert_eq!(cap.priority, 100);
+        match &cap.source {
+            AuthSource::FromSecretsStore { backend, path } => {
+                assert_eq!(backend, "vault");
+                assert_eq!(path, "secrets/github/team");
+            }
+            other => panic!("expected FromSecretsStore, got {:?}", other),
+        }
+
+        // Round-trip
+        let s = serde_yaml::to_string(&t).unwrap();
+        let t2: TargetConfig = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(t.provides, t2.provides);
+    }
+
+    #[test]
+    fn target_config_empty_provides_omitted_on_serialise() {
+        let t = TargetConfig {
+            kind: "local".to_string(),
+            infra: None,
+            auth: None,
+            provides: vec![],
+        };
+        let s = serde_yaml::to_string(&t).unwrap();
+        assert!(
+            !s.contains("provides"),
+            "expected serialised TargetConfig to omit empty provides, got:\n{}",
+            s
+        );
+    }
 }

--- a/v4/crates/sindri-core/src/policy.rs
+++ b/v4/crates/sindri-core/src/policy.rs
@@ -24,6 +24,59 @@ pub struct InstallPolicy {
     pub require_checksums: Option<bool>,
     pub offline: Option<bool>,
     pub audit: Option<AuditConfig>,
+    /// Auth-aware admission knobs (Gate 5; ADR-027 §5).
+    ///
+    /// Additive; existing policy files without an `auth:` block deserialize
+    /// as [`AuthPolicy::default()`] which is the **strict default-deny**
+    /// posture user-approved for Phase 2B:
+    /// - `on_unresolved_required: deny`
+    /// - `allow_upstream_credentials: false`
+    /// - `allow_prompt_in_ci: false`
+    #[serde(default)]
+    pub auth: AuthPolicy,
+}
+
+/// Auth-aware admission policy (ADR-027 §5).
+///
+/// All three knobs default to the **deny** stance. Operators must opt in
+/// explicitly to relax any of them, and each opt-in is documented with a
+/// security caveat in `v4/docs/policy.md`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct AuthPolicy {
+    /// What to do when a non-`optional` requirement has no bound source
+    /// in the lockfile. Default: `deny` (Gate 5 fails-fast at admission).
+    /// Setting `warn` makes the gate purely advisory; `prompt` is reserved
+    /// for Phase 5 interactive resolution.
+    #[serde(default = "default_on_unresolved_required")]
+    pub on_unresolved_required: PolicyAction,
+
+    /// If `false` (default), bindings whose `AuthSource` is
+    /// `FromUpstreamCredentials` are denied at Gate 5. Forces operators
+    /// to mint dedicated child-workload credentials rather than reusing
+    /// the target's session token.
+    #[serde(default)]
+    pub allow_upstream_credentials: bool,
+
+    /// If `false` (default), bindings whose `AuthSource` is `Prompt` are
+    /// denied at Gate 5 in non-interactive runs (no TTY OR `CI=1` /
+    /// `SINDRI_CI=1` set).
+    #[serde(default)]
+    pub allow_prompt_in_ci: bool,
+}
+
+fn default_on_unresolved_required() -> PolicyAction {
+    PolicyAction::Deny
+}
+
+impl Default for AuthPolicy {
+    fn default() -> Self {
+        AuthPolicy {
+            on_unresolved_required: PolicyAction::Deny,
+            allow_upstream_credentials: false,
+            allow_prompt_in_ci: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/v4/crates/sindri-extensions/Cargo.toml
+++ b/v4/crates/sindri-extensions/Cargo.toml
@@ -21,3 +21,5 @@ dirs-next = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+proptest = "1"
+regex = "1"

--- a/v4/crates/sindri-extensions/src/collision/mod.rs
+++ b/v4/crates/sindri-extensions/src/collision/mod.rs
@@ -217,6 +217,7 @@ mod tests {
             configure: None,
             remove: None,
             overrides: Default::default(),
+            auth: Default::default(),
         }
     }
 

--- a/v4/crates/sindri-extensions/src/lib.rs
+++ b/v4/crates/sindri-extensions/src/lib.rs
@@ -17,6 +17,7 @@ pub mod configure;
 pub mod error;
 pub mod hooks;
 pub mod project_init;
+pub mod redeemer;
 pub mod validate;
 
 pub use collision::{CollisionContext, CollisionPlan, CollisionResolver};
@@ -24,4 +25,7 @@ pub use configure::{ConfigureContext, ConfigureExecutor};
 pub use error::ExtensionError;
 pub use hooks::{HookContext, HooksExecutor};
 pub use project_init::{ComponentRef, ProjectInitContext, ProjectInitExecutor};
+pub use redeemer::{
+    group_bindings_by_component, AuthRedeemer, ComponentBindings, RedeemedEnv, TempFile,
+};
 pub use validate::{ValidateContext, ValidateExecutor};

--- a/v4/crates/sindri-extensions/src/redeemer.rs
+++ b/v4/crates/sindri-extensions/src/redeemer.rs
@@ -1,0 +1,920 @@
+//! Apply-time auth redemption (ADR-027 §6, DDD-07 redeemer).
+//!
+//! Phase 2A of the auth-aware implementation plan. The resolver's
+//! observability-only [`AuthBinding`]s now drive apply behaviour:
+//!
+//! 1. Before the install lifecycle starts, [`AuthRedeemer::redeem_install_scope`]
+//!    walks the lockfile's `auth_bindings` and materialises the bound source
+//!    into a runtime [`RedemptionEnv`] (env vars, files on disk).
+//! 2. After install completes, [`AuthRedeemer::redeem_runtime_scope`] handles
+//!    `scope: runtime` bindings symmetrically (these are wanted at *runtime*
+//!    of the installed tool, not during install).
+//! 3. Once the lifecycle phase that needed the credential finishes, the
+//!    [`RedemptionEnv`] is *cleaned up*: in-memory copies are dropped, files
+//!    flagged `persist: false` are deleted, and an `AuthCleanedUp` ledger
+//!    event is emitted.
+//!
+//! ## Redaction discipline
+//!
+//! The [`AuthBinding`] domain captures only references (DDD-07 invariant 3).
+//! All ledger events emitted from this module follow the same rule:
+//! payloads carry the binding id, redemption kind, and target — *never* the
+//! resolved value. A property test in `tests/redaction.rs` fails closed if
+//! any code path here ever leaks a value into a ledger event.
+//!
+//! ## Why this lives in `sindri-extensions`
+//!
+//! The redeemer hooks the same apply lifecycle as `HooksExecutor` and
+//! `ConfigureExecutor`: it is a capability executor whose unit of work is a
+//! lockfile entry, not a resolver pass. Putting it in `sindri-extensions`
+//! keeps `sindri-core` schema-only and matches the ADR-027 §6 narrative
+//! "redemption happens immediately before pre_install".
+
+use crate::error::ExtensionError;
+use sindri_core::auth::{
+    AuthBinding, AuthBindingStatus, AuthRequirements, AuthScope, AuthSource, Redemption,
+};
+use sindri_core::component::ComponentManifest;
+use sindri_core::lockfile::Lockfile;
+use sindri_targets::auth::AuthValue;
+use sindri_targets::Target;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Default file mode for redeemed credential files (ADR-027 §6).
+const DEFAULT_FILE_MODE: u32 = 0o600;
+
+/// Owned env-var pair for redemption injection.
+///
+/// The values are kept on the stack of the apply lifecycle (held by the
+/// caller for the duration of one lifecycle step) and dropped — i.e. memory
+/// zeroised by the allocator's normal mechanism — as soon as the step
+/// returns. We do not expose this struct outside the crate.
+#[derive(Debug, Clone)]
+pub struct RedeemedEnv {
+    /// `(NAME, VALUE)` pairs to merge into [`Target::exec`] env.
+    pub env: Vec<(String, String)>,
+    /// Files written to disk that should be deleted post-apply
+    /// (mode + persist semantics from [`Redemption::File`] /
+    /// [`Redemption::EnvFile`]).
+    pub temp_files: Vec<TempFile>,
+    /// Binding ids that were redeemed in this batch — used by the cleanup
+    /// hook to emit one `AuthCleanedUp` event per binding.
+    pub binding_ids: Vec<String>,
+}
+
+/// A file written by redemption that may need cleanup post-apply.
+#[derive(Debug, Clone)]
+pub struct TempFile {
+    pub path: PathBuf,
+    pub persist: bool,
+    pub binding_id: String,
+}
+
+impl RedeemedEnv {
+    /// Empty redeemed-env (no bindings produced output for this scope).
+    pub fn empty() -> Self {
+        RedeemedEnv {
+            env: Vec::new(),
+            temp_files: Vec::new(),
+            binding_ids: Vec::new(),
+        }
+    }
+
+    /// True when nothing was redeemed.
+    pub fn is_empty(&self) -> bool {
+        self.env.is_empty() && self.temp_files.is_empty()
+    }
+
+    /// View as `&[(&str, &str)]` borrowed slice for [`Target::exec`].
+    pub fn env_borrowed(&self) -> Vec<(&str, &str)> {
+        self.env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect()
+    }
+}
+
+/// Stateless capability executor for auth redemption.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AuthRedeemer;
+
+/// Per-component view of bindings that apply to a specific component.
+///
+/// Built once per apply run from the lockfile's `auth_bindings`.
+pub struct ComponentBindings<'a> {
+    /// Component address (e.g. `npm:claude-code`).
+    pub component: &'a str,
+    /// Bindings whose `component == component`.
+    pub bindings: Vec<&'a AuthBinding>,
+    /// The resolved component manifest's `auth:` block — needed to recover
+    /// per-requirement [`Redemption`] and [`AuthScope`] (the binding itself
+    /// only carries the source).
+    pub auth: &'a AuthRequirements,
+}
+
+impl AuthRedeemer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Redeem all bindings whose scope is `Install` or `Both` for this
+    /// component. Called immediately before `pre_install`.
+    pub fn redeem_install_scope(
+        &self,
+        cb: &ComponentBindings<'_>,
+        target: &dyn Target,
+    ) -> Result<RedeemedEnv, ExtensionError> {
+        self.redeem_with_filter(cb, target, |s| {
+            matches!(s, AuthScope::Install | AuthScope::Both)
+        })
+    }
+
+    /// Redeem all bindings whose scope is `Runtime` for this component.
+    /// Called after `post_install` so the installed tool has its credential
+    /// for first-run.
+    pub fn redeem_runtime_scope(
+        &self,
+        cb: &ComponentBindings<'_>,
+        target: &dyn Target,
+    ) -> Result<RedeemedEnv, ExtensionError> {
+        self.redeem_with_filter(cb, target, |s| matches!(s, AuthScope::Runtime))
+    }
+
+    fn redeem_with_filter<F: Fn(AuthScope) -> bool>(
+        &self,
+        cb: &ComponentBindings<'_>,
+        _target: &dyn Target,
+        wants_scope: F,
+    ) -> Result<RedeemedEnv, ExtensionError> {
+        let mut out = RedeemedEnv::empty();
+
+        for b in &cb.bindings {
+            if b.status != AuthBindingStatus::Bound {
+                continue;
+            }
+            let Some(source) = b.source.as_ref() else {
+                continue;
+            };
+            // Recover the requirement's redemption + scope from the manifest.
+            let (redemption, scope) = match find_requirement(cb.auth, &b.requirement) {
+                Some(p) => p,
+                None => {
+                    tracing::warn!(
+                        component = b.component.as_str(),
+                        requirement = b.requirement.as_str(),
+                        "auth binding refers to requirement not declared on the component manifest; \
+                         skipping redemption"
+                    );
+                    continue;
+                }
+            };
+            if !wants_scope(scope) {
+                continue;
+            }
+
+            let value = resolve_source(source).map_err(|e| ExtensionError::HookFailed {
+                component: cb.component.to_string(),
+                command: format!("auth_redeem({})", b.requirement),
+                detail: e.to_string(),
+            })?;
+            apply_redemption(&redemption, &value, b, &mut out)?;
+            out.binding_ids.push(b.id.clone());
+            ledger::emit_redeemed(b, redemption_kind(&redemption));
+        }
+
+        Ok(out)
+    }
+
+    /// Run cleanup for a previously-redeemed batch. Idempotent: running it
+    /// twice on the same [`RedeemedEnv`] does not error if the file is
+    /// already gone (the second pass is a no-op).
+    pub fn cleanup(&self, env: &RedeemedEnv, target_name: &str) {
+        for tf in &env.temp_files {
+            if tf.persist {
+                continue;
+            }
+            // Best-effort delete; do not fail apply because cleanup ran twice.
+            let _ = std::fs::remove_file(&tf.path);
+        }
+        for binding_id in &env.binding_ids {
+            // Number of files that this binding contributed (0 or 1 in
+            // current redemption variants).
+            let files_removed = env
+                .temp_files
+                .iter()
+                .filter(|tf| &tf.binding_id == binding_id && !tf.persist)
+                .count();
+            ledger::emit_cleanup(binding_id, target_name, files_removed);
+        }
+    }
+}
+
+/// Build the per-component binding view by joining the lockfile's bindings
+/// with each component's manifest. Components without bindings yield no
+/// entries.
+pub fn group_bindings_by_component<'a>(
+    lockfile: &'a Lockfile,
+    manifests: &'a HashMap<String, &'a ComponentManifest>,
+) -> Vec<ComponentBindings<'a>> {
+    // address -> Vec<&AuthBinding>
+    let mut by_addr: HashMap<&str, Vec<&AuthBinding>> = HashMap::new();
+    for b in &lockfile.auth_bindings {
+        by_addr.entry(b.component.as_str()).or_default().push(b);
+    }
+
+    let mut out = Vec::new();
+    for (addr, bindings) in by_addr {
+        if let Some(m) = manifests.get(addr) {
+            out.push(ComponentBindings {
+                component: addr,
+                bindings,
+                auth: &m.auth,
+            });
+        }
+    }
+    out
+}
+
+/// Locate the [`Redemption`] + [`AuthScope`] for a requirement name across
+/// all four requirement families on an [`AuthRequirements`] block.
+fn find_requirement(auth: &AuthRequirements, name: &str) -> Option<(Redemption, AuthScope)> {
+    if let Some(t) = auth.tokens.iter().find(|t| t.name == name) {
+        return Some((t.redemption.clone(), t.scope));
+    }
+    if let Some(o) = auth.oauth.iter().find(|o| o.name == name) {
+        return Some((o.redemption.clone(), o.scope));
+    }
+    if let Some(c) = auth.certs.iter().find(|c| c.name == name) {
+        return Some((c.redemption.clone(), c.scope));
+    }
+    if let Some(s) = auth.ssh.iter().find(|s| s.name == name) {
+        return Some((s.redemption.clone(), s.scope));
+    }
+    None
+}
+
+fn redemption_kind(r: &Redemption) -> &'static str {
+    match r {
+        Redemption::EnvVar { .. } => "env-var",
+        Redemption::File { .. } => "file",
+        Redemption::EnvFile { .. } => "env-file",
+    }
+}
+
+/// Resolve an [`AuthSource`] to a string secret value. The value is held
+/// only on the stack; never logged, never persisted, never returned via
+/// any error type.
+fn resolve_source(source: &AuthSource) -> Result<String, ResolveError> {
+    match source {
+        AuthSource::FromEnv { var } => std::env::var(var)
+            .map_err(|_| ResolveError(format!("env var {var} is not set"))),
+        AuthSource::FromFile { path, .. } => std::fs::read_to_string(path)
+            .map(|s| s.trim().to_string())
+            .map_err(|e| ResolveError(format!("read {path}: {e}"))),
+        AuthSource::FromCli { command } => {
+            // Reuse the AuthValue::Cli resolver so behaviour matches the
+            // existing ADR-020 plumbing.
+            AuthValue::Cli(command.clone())
+                .resolve()
+                .map_err(|e| ResolveError(e.to_string()))
+        }
+        AuthSource::FromSecretsStore { backend, path } => {
+            // sindri-secrets is not yet wired (Phase 0 placeholder; ADR-025).
+            // Surface a typed error so Gate 5 can deny / users get clear
+            // remediation. NEVER fall back to empty string.
+            Err(ResolveError(format!(
+                "secrets backend `{backend}` is not yet wired (sindri-secrets unavailable); \
+                 path was {path}"
+            )))
+        }
+        AuthSource::FromUpstreamCredentials => Err(ResolveError(
+            "from-upstream-credentials redemption is gated by policy.auth.allow_upstream_credentials; \
+             enable explicitly or add `provides:` on the target".into(),
+        )),
+        AuthSource::FromOAuth { provider } => Err(ResolveError(format!(
+            "OAuth redemption (provider={provider}) lands in Phase 5"
+        ))),
+        AuthSource::Prompt => Err(ResolveError(
+            "Prompt redemption requires an interactive TTY (Phase 5)".into(),
+        )),
+    }
+}
+
+#[derive(Debug)]
+struct ResolveError(String);
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for ResolveError {}
+
+/// Apply a [`Redemption`] decision to the in-progress [`RedeemedEnv`]. The
+/// resolved `value` is consumed once and never logged.
+fn apply_redemption(
+    r: &Redemption,
+    value: &str,
+    binding: &AuthBinding,
+    out: &mut RedeemedEnv,
+) -> Result<(), ExtensionError> {
+    match r {
+        Redemption::EnvVar { env_name } => {
+            if env_name.is_empty() {
+                return Err(ExtensionError::HookFailed {
+                    component: binding.component.clone(),
+                    command: "auth_redeem(EnvVar)".into(),
+                    detail: "redemption.env-name is empty".into(),
+                });
+            }
+            out.env.push((env_name.clone(), value.to_string()));
+        }
+        Redemption::File {
+            path,
+            mode,
+            persist,
+        } => {
+            let p = expand_path(path);
+            write_secret_file(&p, value, mode.unwrap_or(DEFAULT_FILE_MODE))?;
+            out.temp_files.push(TempFile {
+                path: p,
+                persist: *persist,
+                binding_id: binding.id.clone(),
+            });
+        }
+        Redemption::EnvFile { env_name, path } => {
+            let p = expand_path(path);
+            write_secret_file(&p, value, DEFAULT_FILE_MODE)?;
+            out.env
+                .push((env_name.clone(), p.to_string_lossy().to_string()));
+            out.temp_files.push(TempFile {
+                path: p,
+                // env-file is by definition transient unless caller pinned
+                // persist on the underlying File-redemption (which env-file
+                // doesn't expose). Default cleanup.
+                persist: false,
+                binding_id: binding.id.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn expand_path(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs_next::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+fn write_secret_file(path: &std::path::Path, value: &str, mode: u32) -> Result<(), ExtensionError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Write atomically: temp + rename. For 0600-mode secrets the parent
+    // directory ACL is not changed; we trust the caller to put creds in a
+    // private dir.
+    std::fs::write(path, value)?;
+    set_permissions(path, mode)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_permissions(path: &std::path::Path, mode: u32) -> Result<(), ExtensionError> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(mode);
+    std::fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_permissions(_path: &std::path::Path, _mode: u32) -> Result<(), ExtensionError> {
+    // Windows file ACLs are not modelled by mode bits; rely on the user
+    // profile dir being private. No-op rather than spurious failure.
+    Ok(())
+}
+
+// =============================================================================
+// Ledger emission (Phase 2 events: AuthRedeemed, AuthCleanedUp,
+// AuthSkippedByUser).
+// =============================================================================
+
+pub mod ledger {
+    //! Phase 2A audit ledger events.
+    //!
+    //! These events live in the same JSONL file as the Phase 1 binding
+    //! events (`~/.sindri/ledger.jsonl`). Payloads NEVER carry the
+    //! redeemed credential value — they reference the binding by id.
+    //! See [`crate::redeemer`] module docs for the redaction property
+    //! test that enforces this.
+
+    use serde::{Deserialize, Serialize};
+    use sindri_core::auth::AuthBinding;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// A Phase 2A redemption event.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct RedemptionLedgerEvent {
+        pub timestamp: u64,
+        /// One of `AuthRedeemed`, `AuthCleanedUp`, `AuthSkippedByUser`.
+        pub event_type: String,
+        /// Binding id (sha256 prefix). Empty for `AuthSkippedByUser`.
+        #[serde(default)]
+        pub binding_id: String,
+        /// Redemption kind: `env-var`, `file`, `env-file`. Empty when
+        /// not applicable.
+        #[serde(default)]
+        pub redemption_kind: String,
+        /// Target name (e.g. `local`, `prod-fly`).
+        #[serde(default)]
+        pub target: String,
+        /// Component address; populated for `AuthSkippedByUser` so the
+        /// auditor can see which install bypassed redemption.
+        #[serde(default)]
+        pub component: String,
+        /// File count for `AuthCleanedUp`. 0 for env-only bindings.
+        #[serde(default)]
+        pub files_removed: usize,
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+
+    fn ledger_path() -> Option<PathBuf> {
+        // Allow tests / sandboxes to redirect via an env var. Unset in
+        // production deployments.
+        if let Ok(p) = std::env::var("SINDRI_AUTH_LEDGER_PATH") {
+            return Some(PathBuf::from(p));
+        }
+        dirs_next::home_dir().map(|h| h.join(".sindri").join("ledger.jsonl"))
+    }
+
+    fn append(event: &RedemptionLedgerEvent) {
+        let Some(path) = ledger_path() else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            if std::fs::create_dir_all(parent).is_err() {
+                return;
+            }
+        }
+        let json = match serde_json::to_string(event) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("auth-ledger serialise failed: {}", e);
+                return;
+            }
+        };
+        use std::io::Write;
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            Ok(mut f) => {
+                if let Err(e) = writeln!(f, "{}", json) {
+                    tracing::warn!("auth-ledger write failed: {}", e);
+                }
+            }
+            Err(e) => tracing::warn!("auth-ledger open failed: {}", e),
+        }
+    }
+
+    pub fn emit_redeemed(b: &AuthBinding, redemption_kind: &str) {
+        append(&RedemptionLedgerEvent {
+            timestamp: now_secs(),
+            event_type: "AuthRedeemed".into(),
+            binding_id: b.id.clone(),
+            redemption_kind: redemption_kind.into(),
+            target: b.target.clone(),
+            component: String::new(),
+            files_removed: 0,
+        });
+    }
+
+    pub fn emit_cleanup(binding_id: &str, target: &str, files_removed: usize) {
+        append(&RedemptionLedgerEvent {
+            timestamp: now_secs(),
+            event_type: "AuthCleanedUp".into(),
+            binding_id: binding_id.into(),
+            redemption_kind: String::new(),
+            target: target.into(),
+            component: String::new(),
+            files_removed,
+        });
+    }
+
+    pub fn emit_skipped_by_user(component: &str, target: &str) {
+        append(&RedemptionLedgerEvent {
+            timestamp: now_secs(),
+            event_type: "AuthSkippedByUser".into(),
+            binding_id: String::new(),
+            redemption_kind: String::new(),
+            target: target.into(),
+            component: component.into(),
+            files_removed: 0,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::auth::{
+        AuthBinding, AuthBindingStatus, AuthScope, AuthSource, DiscoveryHints, Redemption,
+        TokenRequirement,
+    };
+
+    fn token_req(
+        name: &str,
+        audience: &str,
+        redemption: Redemption,
+        scope: AuthScope,
+    ) -> TokenRequirement {
+        TokenRequirement {
+            name: name.into(),
+            description: name.into(),
+            scope,
+            optional: false,
+            audience: audience.into(),
+            redemption,
+            discovery: DiscoveryHints::default(),
+        }
+    }
+
+    fn binding(
+        component: &str,
+        requirement: &str,
+        target: &str,
+        source: AuthSource,
+    ) -> AuthBinding {
+        AuthBinding {
+            id: format!("{component}:{requirement}:{target}"),
+            component: component.into(),
+            requirement: requirement.into(),
+            audience: "urn:x".into(),
+            target: target.into(),
+            source: Some(source),
+            priority: 0,
+            status: AuthBindingStatus::Bound,
+            reason: None,
+            considered: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn redemption_kind_strings() {
+        assert_eq!(
+            redemption_kind(&Redemption::EnvVar {
+                env_name: "X".into(),
+            }),
+            "env-var"
+        );
+        assert_eq!(
+            redemption_kind(&Redemption::File {
+                path: "/p".into(),
+                mode: None,
+                persist: false,
+            }),
+            "file"
+        );
+        assert_eq!(
+            redemption_kind(&Redemption::EnvFile {
+                env_name: "X".into(),
+                path: "/p".into(),
+            }),
+            "env-file"
+        );
+    }
+
+    #[test]
+    fn find_requirement_locates_token() {
+        let auth = AuthRequirements {
+            tokens: vec![token_req(
+                "tok",
+                "urn:x",
+                Redemption::EnvVar {
+                    env_name: "T".into(),
+                },
+                AuthScope::Runtime,
+            )],
+            ..Default::default()
+        };
+        let (r, s) = find_requirement(&auth, "tok").unwrap();
+        assert!(matches!(r, Redemption::EnvVar { .. }));
+        assert_eq!(s, AuthScope::Runtime);
+    }
+
+    #[test]
+    fn resolve_from_env_reads_process_env() {
+        // SAFETY: tests are single-threaded by default in `cargo test` only
+        // when --test-threads=1; we use a unique key to avoid collisions.
+        std::env::set_var("SINDRI_TEST_REDEEM_ENV", "the-secret-value");
+        let v = resolve_source(&AuthSource::FromEnv {
+            var: "SINDRI_TEST_REDEEM_ENV".into(),
+        })
+        .expect("env resolve");
+        assert_eq!(v, "the-secret-value");
+        std::env::remove_var("SINDRI_TEST_REDEEM_ENV");
+    }
+
+    #[test]
+    fn resolve_from_secrets_store_returns_typed_error() {
+        let err = resolve_source(&AuthSource::FromSecretsStore {
+            backend: "vault".into(),
+            path: "secrets/x".into(),
+        })
+        .unwrap_err();
+        // Must mention the unwired backend; must NOT silently produce ""
+        assert!(err.0.contains("not yet wired"));
+    }
+
+    #[test]
+    fn resolve_from_upstream_credentials_is_default_deny() {
+        let err = resolve_source(&AuthSource::FromUpstreamCredentials).unwrap_err();
+        assert!(err.0.contains("allow_upstream_credentials"));
+    }
+
+    #[test]
+    fn redeem_install_scope_envvar_round_trips() {
+        std::env::set_var("SINDRI_TEST_INSTALL_KEY", "k1");
+        let auth = AuthRequirements {
+            tokens: vec![token_req(
+                "k",
+                "urn:x",
+                Redemption::EnvVar {
+                    env_name: "INJECT_KEY".into(),
+                },
+                AuthScope::Install,
+            )],
+            ..Default::default()
+        };
+        let b = binding(
+            "npm:demo",
+            "k",
+            "local",
+            AuthSource::FromEnv {
+                var: "SINDRI_TEST_INSTALL_KEY".into(),
+            },
+        );
+        let cb = ComponentBindings {
+            component: "npm:demo",
+            bindings: vec![&b],
+            auth: &auth,
+        };
+        let target = MockTarget;
+        let env = AuthRedeemer::new()
+            .redeem_install_scope(&cb, &target)
+            .expect("ok");
+        assert_eq!(env.env, vec![("INJECT_KEY".to_string(), "k1".to_string())]);
+        assert!(env.temp_files.is_empty());
+        std::env::remove_var("SINDRI_TEST_INSTALL_KEY");
+    }
+
+    #[test]
+    fn runtime_scope_skipped_during_install_pass() {
+        let auth = AuthRequirements {
+            tokens: vec![token_req(
+                "k",
+                "urn:x",
+                Redemption::EnvVar {
+                    env_name: "INJECT_KEY".into(),
+                },
+                AuthScope::Runtime,
+            )],
+            ..Default::default()
+        };
+        let b = binding(
+            "npm:demo",
+            "k",
+            "local",
+            AuthSource::FromEnv {
+                var: "SINDRI_TEST_NEVER_SET".into(),
+            },
+        );
+        let cb = ComponentBindings {
+            component: "npm:demo",
+            bindings: vec![&b],
+            auth: &auth,
+        };
+        let env = AuthRedeemer::new()
+            .redeem_install_scope(&cb, &MockTarget)
+            .expect("ok");
+        // Runtime-scope binding is skipped at install pass.
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn file_redemption_writes_with_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_path = dir.path().join("creds.json");
+        std::env::set_var("SINDRI_TEST_FILE_VAL", "{ \"k\": \"v\" }");
+
+        let auth = AuthRequirements {
+            tokens: vec![token_req(
+                "creds",
+                "urn:x",
+                Redemption::File {
+                    path: target_path.to_string_lossy().to_string(),
+                    mode: Some(0o600),
+                    persist: false,
+                },
+                AuthScope::Install,
+            )],
+            ..Default::default()
+        };
+        let b = binding(
+            "npm:demo",
+            "creds",
+            "local",
+            AuthSource::FromEnv {
+                var: "SINDRI_TEST_FILE_VAL".into(),
+            },
+        );
+        let cb = ComponentBindings {
+            component: "npm:demo",
+            bindings: vec![&b],
+            auth: &auth,
+        };
+        let env = AuthRedeemer::new()
+            .redeem_install_scope(&cb, &MockTarget)
+            .expect("ok");
+        assert_eq!(env.temp_files.len(), 1);
+        assert!(target_path.exists());
+        std::env::remove_var("SINDRI_TEST_FILE_VAL");
+
+        // Cleanup deletes (persist=false).
+        AuthRedeemer::new().cleanup(&env, "local");
+        assert!(!target_path.exists());
+    }
+
+    #[test]
+    fn cleanup_persist_keeps_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_path = dir.path().join("keep.json");
+        std::env::set_var("SINDRI_TEST_PERSIST_VAL", "abc");
+
+        let auth = AuthRequirements {
+            tokens: vec![token_req(
+                "creds",
+                "urn:x",
+                Redemption::File {
+                    path: target_path.to_string_lossy().to_string(),
+                    mode: None,
+                    persist: true,
+                },
+                AuthScope::Install,
+            )],
+            ..Default::default()
+        };
+        let b = binding(
+            "npm:demo",
+            "creds",
+            "local",
+            AuthSource::FromEnv {
+                var: "SINDRI_TEST_PERSIST_VAL".into(),
+            },
+        );
+        let cb = ComponentBindings {
+            component: "npm:demo",
+            bindings: vec![&b],
+            auth: &auth,
+        };
+        let env = AuthRedeemer::new()
+            .redeem_install_scope(&cb, &MockTarget)
+            .expect("ok");
+        AuthRedeemer::new().cleanup(&env, "local");
+        // persist=true → file stays.
+        assert!(target_path.exists());
+        std::env::remove_var("SINDRI_TEST_PERSIST_VAL");
+    }
+
+    #[test]
+    fn env_file_redemption_sets_var_to_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_path = dir.path().join("gcp.json");
+        std::env::set_var("SINDRI_TEST_ENVFILE_VAL", "json-payload");
+
+        let auth = AuthRequirements {
+            tokens: vec![token_req(
+                "gcp",
+                "urn:x",
+                Redemption::EnvFile {
+                    env_name: "GOOGLE_APPLICATION_CREDENTIALS".into(),
+                    path: target_path.to_string_lossy().to_string(),
+                },
+                AuthScope::Install,
+            )],
+            ..Default::default()
+        };
+        let b = binding(
+            "npm:demo",
+            "gcp",
+            "local",
+            AuthSource::FromEnv {
+                var: "SINDRI_TEST_ENVFILE_VAL".into(),
+            },
+        );
+        let cb = ComponentBindings {
+            component: "npm:demo",
+            bindings: vec![&b],
+            auth: &auth,
+        };
+        let env = AuthRedeemer::new()
+            .redeem_install_scope(&cb, &MockTarget)
+            .expect("ok");
+        assert_eq!(env.env.len(), 1);
+        assert_eq!(env.env[0].0, "GOOGLE_APPLICATION_CREDENTIALS");
+        assert_eq!(env.env[0].1, target_path.to_string_lossy().to_string());
+        assert!(target_path.exists());
+        std::env::remove_var("SINDRI_TEST_ENVFILE_VAL");
+    }
+
+    #[test]
+    fn unbound_binding_is_ignored() {
+        let auth = AuthRequirements::default();
+        let b = AuthBinding {
+            id: "x".into(),
+            component: "npm:demo".into(),
+            requirement: "k".into(),
+            audience: "urn:x".into(),
+            target: "local".into(),
+            source: None,
+            priority: 0,
+            status: AuthBindingStatus::Failed,
+            reason: Some("no source".into()),
+            considered: Vec::new(),
+        };
+        let cb = ComponentBindings {
+            component: "npm:demo",
+            bindings: vec![&b],
+            auth: &auth,
+        };
+        let env = AuthRedeemer::new()
+            .redeem_install_scope(&cb, &MockTarget)
+            .expect("ok");
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn binding_for_unknown_requirement_is_skipped_with_warn() {
+        let auth = AuthRequirements::default(); // no requirements declared
+        let b = binding(
+            "npm:demo",
+            "phantom",
+            "local",
+            AuthSource::FromEnv {
+                var: "SINDRI_TEST_NEVER".into(),
+            },
+        );
+        let cb = ComponentBindings {
+            component: "npm:demo",
+            bindings: vec![&b],
+            auth: &auth,
+        };
+        let env = AuthRedeemer::new()
+            .redeem_install_scope(&cb, &MockTarget)
+            .expect("ok");
+        assert!(env.is_empty());
+    }
+
+    // -------- Mock target --------
+    use sindri_core::platform::TargetProfile;
+    use sindri_targets::error::TargetError;
+    use sindri_targets::traits::PrereqCheck;
+
+    struct MockTarget;
+    impl Target for MockTarget {
+        fn name(&self) -> &str {
+            "local"
+        }
+        fn kind(&self) -> &str {
+            "local"
+        }
+        fn profile(&self) -> Result<TargetProfile, TargetError> {
+            Err(TargetError::Unavailable {
+                name: "mock".into(),
+                reason: "test".into(),
+            })
+        }
+        fn exec(&self, _cmd: &str, _env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
+            Ok((String::new(), String::new()))
+        }
+        fn upload(&self, _l: &std::path::Path, _r: &str) -> Result<(), TargetError> {
+            Ok(())
+        }
+        fn download(&self, _r: &str, _l: &std::path::Path) -> Result<(), TargetError> {
+            Ok(())
+        }
+        fn check_prerequisites(&self) -> Vec<PrereqCheck> {
+            Vec::new()
+        }
+    }
+}

--- a/v4/crates/sindri-extensions/tests/redaction.rs
+++ b/v4/crates/sindri-extensions/tests/redaction.rs
@@ -1,0 +1,225 @@
+//! Redaction property test (Phase 2A — non-negotiable).
+//!
+//! For every randomly-generated [`AuthValue`] string we run the redeemer
+//! end-to-end (env-var, file, env-file) and capture every ledger event
+//! emitted to a sandboxed JSONL file. We then regex-search every line of
+//! that ledger for the secret value. **Any match fails the test.**
+//!
+//! This is the property that DDD-07 invariant 3 ("no value capture") and
+//! ADR-027 §6 turn into a code-level guarantee. If you ever see this test
+//! fail you have introduced a leak — do not weaken the test, fix the leak.
+//!
+//! Test isolation: the redeemer ledger writer reads `SINDRI_AUTH_LEDGER_PATH`
+//! at runtime; we point each prop case at a fresh tempfile so the user's
+//! real `~/.sindri/ledger.jsonl` is untouched.
+
+use proptest::prelude::*;
+use regex::Regex;
+use sindri_core::auth::{
+    AuthBinding, AuthBindingStatus, AuthRequirements, AuthScope, AuthSource, DiscoveryHints,
+    Redemption, TokenRequirement,
+};
+use sindri_core::platform::TargetProfile;
+use sindri_extensions::redeemer::ComponentBindings;
+use sindri_extensions::AuthRedeemer;
+use sindri_targets::error::TargetError;
+use sindri_targets::traits::PrereqCheck;
+use sindri_targets::Target;
+use std::sync::Mutex;
+
+struct MockTarget;
+impl Target for MockTarget {
+    fn name(&self) -> &str {
+        "local"
+    }
+    fn kind(&self) -> &str {
+        "local"
+    }
+    fn profile(&self) -> Result<TargetProfile, TargetError> {
+        Err(TargetError::Unavailable {
+            name: "mock".into(),
+            reason: "test".into(),
+        })
+    }
+    fn exec(&self, _cmd: &str, _env: &[(&str, &str)]) -> Result<(String, String), TargetError> {
+        Ok((String::new(), String::new()))
+    }
+    fn upload(&self, _l: &std::path::Path, _r: &str) -> Result<(), TargetError> {
+        Ok(())
+    }
+    fn download(&self, _r: &str, _l: &std::path::Path) -> Result<(), TargetError> {
+        Ok(())
+    }
+    fn check_prerequisites(&self) -> Vec<PrereqCheck> {
+        Vec::new()
+    }
+}
+
+// Lock to serialise `std::env::set_var` access across prop cases — env is
+// process-global. proptest runs cases sequentially by default, but if a
+// future contributor parallelises this we want the lock in place.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn run_one_redemption(
+    secret_value: &str,
+    redemption: Redemption,
+    ledger_path: &std::path::Path,
+) -> std::io::Result<()> {
+    let _guard = ENV_LOCK.lock().unwrap();
+
+    // 1. Stage the secret into the FromEnv source.
+    let env_var = "SINDRI_PROP_SECRET_VAR";
+    std::env::set_var(env_var, secret_value);
+    std::env::set_var("SINDRI_AUTH_LEDGER_PATH", ledger_path);
+
+    let auth = AuthRequirements {
+        tokens: vec![TokenRequirement {
+            name: "tok".into(),
+            description: "t".into(),
+            scope: AuthScope::Install,
+            optional: false,
+            audience: "urn:x".into(),
+            redemption: redemption.clone(),
+            discovery: DiscoveryHints::default(),
+        }],
+        ..Default::default()
+    };
+    let b = AuthBinding {
+        id: "bid:prop".into(),
+        component: "npm:demo".into(),
+        requirement: "tok".into(),
+        audience: "urn:x".into(),
+        target: "local".into(),
+        source: Some(AuthSource::FromEnv {
+            var: env_var.into(),
+        }),
+        priority: 0,
+        status: AuthBindingStatus::Bound,
+        reason: None,
+        considered: Vec::new(),
+    };
+    let cb = ComponentBindings {
+        component: "npm:demo",
+        bindings: vec![&b],
+        auth: &auth,
+    };
+
+    let r = AuthRedeemer::new();
+    let env = r.redeem_install_scope(&cb, &MockTarget).expect("redeem ok");
+    r.cleanup(&env, "local");
+
+    // Cleanup env vars regardless.
+    std::env::remove_var(env_var);
+    std::env::remove_var("SINDRI_AUTH_LEDGER_PATH");
+    Ok(())
+}
+
+/// True iff the ledger file at `path` contains the literal `needle`
+/// anywhere on any line. Uses regex with the needle escaped so we match
+/// the value literally (incl. JSON-escaped quoting variants).
+fn ledger_contains(path: &std::path::Path, needle: &str) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    if content.contains(needle) {
+        return true;
+    }
+    // Defence against a maliciously-constructed needle producing an
+    // invalid regex.
+    if let Ok(re) = Regex::new(&regex::escape(needle)) {
+        return re.is_match(&content);
+    }
+    false
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        // 64 random cases × 3 redemption variants = 192 redemption flows,
+        // generates ~600 ledger events scanned per run.
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+
+    /// PROPERTY: for any non-empty random secret string, no ledger event
+    /// emitted by the redeemer contains the secret value verbatim.
+    #[test]
+    fn redemption_never_leaks_secret_value(
+        secret_value in "[A-Za-z0-9!@#$%^&*()_+/=:.-]{8,64}",
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Variant 1: EnvVar redemption.
+        let l1 = dir.path().join("env.jsonl");
+        run_one_redemption(
+            &secret_value,
+            Redemption::EnvVar { env_name: "INJECT".into() },
+            &l1,
+        ).unwrap();
+        prop_assert!(!ledger_contains(&l1, &secret_value),
+            "EnvVar leaked secret into ledger; secret={}", secret_value);
+
+        // Variant 2: File redemption (we only check the ledger for the
+        // value; the on-disk written file legitimately contains the
+        // secret while the lifecycle step holds it).
+        let l2 = dir.path().join("file.jsonl");
+        let creds_path = dir.path().join("creds.bin");
+        run_one_redemption(
+            &secret_value,
+            Redemption::File {
+                path: creds_path.to_string_lossy().to_string(),
+                mode: Some(0o600),
+                persist: false,
+            },
+            &l2,
+        ).unwrap();
+        prop_assert!(!ledger_contains(&l2, &secret_value),
+            "File leaked secret into ledger; secret={}", secret_value);
+
+        // Variant 3: EnvFile redemption.
+        let l3 = dir.path().join("envfile.jsonl");
+        let gcp_path = dir.path().join("gcp.json");
+        run_one_redemption(
+            &secret_value,
+            Redemption::EnvFile {
+                env_name: "GOOGLE_APPLICATION_CREDENTIALS".into(),
+                path: gcp_path.to_string_lossy().to_string(),
+            },
+            &l3,
+        ).unwrap();
+        prop_assert!(!ledger_contains(&l3, &secret_value),
+            "EnvFile leaked secret into ledger; secret={}", secret_value);
+    }
+}
+
+#[test]
+fn ledger_writes_at_least_one_redemption_event() {
+    // Sanity: redaction test would pass trivially if the ledger never
+    // wrote anything. Confirm we ARE emitting events to scan.
+    let dir = tempfile::tempdir().unwrap();
+    let l = dir.path().join("sanity.jsonl");
+    run_one_redemption(
+        "the-secret-marker",
+        Redemption::EnvVar {
+            env_name: "INJECT".into(),
+        },
+        &l,
+    )
+    .unwrap();
+    let content = std::fs::read_to_string(&l).expect("ledger should exist");
+    assert!(
+        content.contains("AuthRedeemed"),
+        "expected an AuthRedeemed event, got: {}",
+        content
+    );
+    assert!(
+        content.contains("AuthCleanedUp"),
+        "expected an AuthCleanedUp event, got: {}",
+        content
+    );
+    // And of course the secret itself MUST NOT be in the ledger.
+    assert!(
+        !content.contains("the-secret-marker"),
+        "secret leaked into ledger: {}",
+        content
+    );
+}

--- a/v4/crates/sindri-policy/Cargo.toml
+++ b/v4/crates/sindri-policy/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 dirs-next = { workspace = true }
+tracing = { workspace = true }

--- a/v4/crates/sindri-policy/src/gate5_auth.rs
+++ b/v4/crates/sindri-policy/src/gate5_auth.rs
@@ -1,0 +1,342 @@
+//! Gate 5 — auth-resolvable admission gate (ADR-027 §5).
+//!
+//! Phase 2B of the auth-aware implementation plan. Evaluates the
+//! resolver-produced [`AuthBinding`]s in `Lockfile.auth_bindings` against
+//! the operator's [`AuthPolicy`] and returns one [`PolicyCheckResult`]
+//! per offence, denying apply with `EXIT_POLICY_DENIED` when any of:
+//!
+//! 1. A non-`optional` requirement has no bound source
+//!    (`status == Failed`) — controlled by
+//!    [`AuthPolicy::on_unresolved_required`]. Default `deny`.
+//! 2. Any binding selected `AuthSource::FromUpstreamCredentials` while
+//!    [`AuthPolicy::allow_upstream_credentials`] is `false` (default).
+//! 3. Any binding selected `AuthSource::Prompt` while the run is
+//!    non-interactive (no TTY OR `CI` / `SINDRI_CI` env set) AND
+//!    [`AuthPolicy::allow_prompt_in_ci`] is `false` (default).
+//!
+//! All three knobs default to the **deny** stance. Operators must opt
+//! into each individually; each opt-in is documented with a security
+//! caveat in `v4/docs/policy.md`.
+//!
+//! `--skip-auth` does NOT bypass this gate. The bypass is for redemption
+//! only; admission still has to pass. Operators who genuinely need to
+//! install with required credentials missing must additionally set
+//! `auth.on_unresolved_required: warn`.
+
+use crate::check::PolicyCheckResult;
+use sindri_core::auth::{AuthBinding, AuthBindingStatus, AuthSource};
+use sindri_core::policy::{AuthPolicy, PolicyAction};
+
+/// Evaluate Gate 5 against the lockfile's bindings under the given
+/// `auth` policy. Returns the first deny-class result found, or
+/// `PolicyCheckResult::ok()` when all bindings are admissible.
+///
+/// We return on first failure (matching the rest of the policy crate)
+/// to keep diagnostics terse; users see one issue per `sindri apply`
+/// run, fix it, re-apply, see the next.
+pub fn check_gate5(bindings: &[AuthBinding], policy: &AuthPolicy) -> PolicyCheckResult {
+    check_gate5_with_env(bindings, policy, &CurrentEnv)
+}
+
+/// Variant with an injected [`EnvProbe`] so unit tests can simulate CI
+/// without manipulating real `CI=` env vars.
+pub fn check_gate5_with_env(
+    bindings: &[AuthBinding],
+    policy: &AuthPolicy,
+    env: &dyn EnvProbe,
+) -> PolicyCheckResult {
+    // Rule 1: required-and-failed.
+    for b in bindings {
+        if b.status == AuthBindingStatus::Failed {
+            match policy.on_unresolved_required {
+                PolicyAction::Deny => {
+                    return PolicyCheckResult::deny(
+                        "AUTH_REQUIRED_UNRESOLVED",
+                        &format!(
+                            "Auth-aware Gate 5 denied apply: component `{}` requirement \
+                             `{}` (audience `{}`) on target `{}` has no bound source.",
+                            b.component, b.requirement, b.audience, b.target
+                        ),
+                        Some(
+                            "Bind a source via `targets.<name>.provides:`, mark the \
+                             requirement `optional: true`, or relax \
+                             `auth.on_unresolved_required` to `warn`.",
+                        ),
+                    );
+                }
+                PolicyAction::Warn => {
+                    tracing::warn!(
+                        component = b.component.as_str(),
+                        requirement = b.requirement.as_str(),
+                        target = b.target.as_str(),
+                        "Gate 5 (auth-resolvable): required binding unresolved; \
+                         policy is warn (not denying)"
+                    );
+                }
+                PolicyAction::Prompt | PolicyAction::Allow => {
+                    // Phase 5 will wire interactive resolution; for now
+                    // treat as warn (don't block apply).
+                }
+            }
+        }
+    }
+
+    // Rule 2: FromUpstreamCredentials default-deny.
+    if !policy.allow_upstream_credentials {
+        for b in bindings {
+            if matches!(b.source, Some(AuthSource::FromUpstreamCredentials)) {
+                return PolicyCheckResult::deny(
+                    "AUTH_UPSTREAM_REUSE_FORBIDDEN",
+                    &format!(
+                        "Auth-aware Gate 5 denied apply: binding `{}` on target `{}` \
+                         selected `from-upstream-credentials`, but policy \
+                         `auth.allow_upstream_credentials` is `false` (default).",
+                        b.id, b.target
+                    ),
+                    Some(
+                        "Add an explicit `provides:` entry on the target with a dedicated \
+                         credential source, or set `auth.allow_upstream_credentials: true` \
+                         (security caveat: shares the target's session token with the \
+                         child workload — see v4/docs/policy.md).",
+                    ),
+                );
+            }
+        }
+    }
+
+    // Rule 3: Prompt in CI / non-interactive.
+    if !policy.allow_prompt_in_ci && !env.is_interactive() {
+        for b in bindings {
+            if matches!(b.source, Some(AuthSource::Prompt)) {
+                return PolicyCheckResult::deny(
+                    "AUTH_PROMPT_IN_CI",
+                    &format!(
+                        "Auth-aware Gate 5 denied apply: binding `{}` on target `{}` \
+                         selected `prompt`, but the run is non-interactive (no TTY or \
+                         CI env set) and `auth.allow_prompt_in_ci` is `false`.",
+                        b.id, b.target
+                    ),
+                    Some(
+                        "Resolve the credential via env var or secrets backend on the \
+                         CI runner, or set `auth.allow_prompt_in_ci: true` (not \
+                         recommended for production CI).",
+                    ),
+                );
+            }
+        }
+    }
+
+    PolicyCheckResult::ok()
+}
+
+/// Probe for whether the current run is interactive (has a TTY) and not
+/// flagged as CI. Real implementation reads env + isatty; tests inject
+/// a deterministic value.
+pub trait EnvProbe {
+    /// True if Gate 5 should treat this run as interactive (TTY present
+    /// and no CI marker). Equivalent to "Prompt is OK here".
+    fn is_interactive(&self) -> bool;
+}
+
+/// Default env probe: looks at `CI`, `SINDRI_CI`, and stdin TTY.
+pub struct CurrentEnv;
+
+impl EnvProbe for CurrentEnv {
+    fn is_interactive(&self) -> bool {
+        // CI markers — both common and our own.
+        if std::env::var("CI").is_ok() || std::env::var("SINDRI_CI").is_ok() {
+            return false;
+        }
+        // No portable isatty in std — best-effort heuristic: if stdin has
+        // a fd that is a terminal, we treat as interactive. We avoid
+        // pulling a new dep here; users who run sindri under cron / nohup
+        // typically also set CI=1.
+        is_stdin_tty()
+    }
+}
+
+#[cfg(unix)]
+fn is_stdin_tty() -> bool {
+    // SAFETY: isatty(0) is read-only; failure returns 0.
+    unsafe { libc_isatty(0) != 0 }
+}
+
+#[cfg(unix)]
+extern "C" {
+    #[link_name = "isatty"]
+    fn libc_isatty(fd: i32) -> i32;
+}
+
+#[cfg(not(unix))]
+fn is_stdin_tty() -> bool {
+    // Conservative on non-Unix: assume non-TTY so Gate 5 denies Prompt.
+    // Operators on Windows can set `auth.allow_prompt_in_ci: true` if
+    // they really want interactive prompts.
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::auth::{AuthBinding, AuthBindingStatus, AuthSource};
+
+    struct FakeEnv {
+        interactive: bool,
+    }
+    impl EnvProbe for FakeEnv {
+        fn is_interactive(&self) -> bool {
+            self.interactive
+        }
+    }
+
+    fn binding(id: &str, status: AuthBindingStatus, source: Option<AuthSource>) -> AuthBinding {
+        AuthBinding {
+            id: id.into(),
+            component: "npm:demo".into(),
+            requirement: "tok".into(),
+            audience: "urn:x".into(),
+            target: "local".into(),
+            source,
+            priority: 0,
+            status,
+            reason: None,
+            considered: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn ok_when_no_bindings() {
+        let r = check_gate5(&[], &AuthPolicy::default());
+        assert!(r.allowed);
+    }
+
+    #[test]
+    fn ok_when_all_bound_and_safe() {
+        let bs = vec![binding(
+            "a",
+            AuthBindingStatus::Bound,
+            Some(AuthSource::FromEnv { var: "X".into() }),
+        )];
+        let r = check_gate5(&bs, &AuthPolicy::default());
+        assert!(r.allowed);
+    }
+
+    #[test]
+    fn deny_when_required_failed() {
+        let bs = vec![binding("a", AuthBindingStatus::Failed, None)];
+        let r = check_gate5(&bs, &AuthPolicy::default());
+        assert!(!r.allowed);
+        assert_eq!(r.code, "AUTH_REQUIRED_UNRESOLVED");
+    }
+
+    #[test]
+    fn warn_relaxes_required_failed() {
+        let bs = vec![binding("a", AuthBindingStatus::Failed, None)];
+        let policy = AuthPolicy {
+            on_unresolved_required: PolicyAction::Warn,
+            ..AuthPolicy::default()
+        };
+        let r = check_gate5(&bs, &policy);
+        assert!(r.allowed);
+    }
+
+    #[test]
+    fn deferred_is_not_denied() {
+        // `Deferred` means optional + unbound. Gate 5 ignores it.
+        let bs = vec![binding("a", AuthBindingStatus::Deferred, None)];
+        let r = check_gate5(&bs, &AuthPolicy::default());
+        assert!(r.allowed);
+    }
+
+    #[test]
+    fn upstream_credentials_denied_by_default() {
+        let bs = vec![binding(
+            "a",
+            AuthBindingStatus::Bound,
+            Some(AuthSource::FromUpstreamCredentials),
+        )];
+        let r = check_gate5(&bs, &AuthPolicy::default());
+        assert!(!r.allowed);
+        assert_eq!(r.code, "AUTH_UPSTREAM_REUSE_FORBIDDEN");
+    }
+
+    #[test]
+    fn upstream_credentials_allowed_when_opted_in() {
+        let bs = vec![binding(
+            "a",
+            AuthBindingStatus::Bound,
+            Some(AuthSource::FromUpstreamCredentials),
+        )];
+        let policy = AuthPolicy {
+            allow_upstream_credentials: true,
+            ..AuthPolicy::default()
+        };
+        let r = check_gate5(&bs, &policy);
+        assert!(r.allowed);
+    }
+
+    #[test]
+    fn prompt_denied_in_ci() {
+        let bs = vec![binding(
+            "a",
+            AuthBindingStatus::Bound,
+            Some(AuthSource::Prompt),
+        )];
+        let r = check_gate5_with_env(&bs, &AuthPolicy::default(), &FakeEnv { interactive: false });
+        assert!(!r.allowed);
+        assert_eq!(r.code, "AUTH_PROMPT_IN_CI");
+    }
+
+    #[test]
+    fn prompt_ok_when_interactive() {
+        let bs = vec![binding(
+            "a",
+            AuthBindingStatus::Bound,
+            Some(AuthSource::Prompt),
+        )];
+        let r = check_gate5_with_env(&bs, &AuthPolicy::default(), &FakeEnv { interactive: true });
+        assert!(r.allowed);
+    }
+
+    #[test]
+    fn prompt_ok_in_ci_when_opted_in() {
+        let bs = vec![binding(
+            "a",
+            AuthBindingStatus::Bound,
+            Some(AuthSource::Prompt),
+        )];
+        let policy = AuthPolicy {
+            allow_prompt_in_ci: true,
+            ..AuthPolicy::default()
+        };
+        let r = check_gate5_with_env(&bs, &policy, &FakeEnv { interactive: false });
+        assert!(r.allowed);
+    }
+
+    #[test]
+    fn first_failure_wins_required_over_upstream() {
+        // Both rules trip; required-failed reports first (rule order).
+        let bs = vec![
+            binding("a", AuthBindingStatus::Failed, None),
+            binding(
+                "b",
+                AuthBindingStatus::Bound,
+                Some(AuthSource::FromUpstreamCredentials),
+            ),
+        ];
+        let r = check_gate5(&bs, &AuthPolicy::default());
+        assert!(!r.allowed);
+        assert_eq!(r.code, "AUTH_REQUIRED_UNRESOLVED");
+    }
+
+    #[test]
+    fn skip_auth_does_not_bypass_gate_at_this_layer() {
+        // Gate 5 is layer-agnostic — it sees the bindings, not the
+        // CLI flag. Caller (apply.rs) decides whether to evaluate
+        // before or after honouring `--skip-auth`. We assert here that
+        // the gate's verdict is independent of redemption-bypass.
+        let bs = vec![binding("a", AuthBindingStatus::Failed, None)];
+        let r = check_gate5(&bs, &AuthPolicy::default());
+        assert!(!r.allowed, "skip-auth must not relax Gate 5 by itself");
+    }
+}

--- a/v4/crates/sindri-policy/src/lib.rs
+++ b/v4/crates/sindri-policy/src/lib.rs
@@ -1,9 +1,11 @@
 #![allow(dead_code)]
 
 pub mod check;
+pub mod gate5_auth;
 pub mod loader;
 
 pub use check::{check_closure, check_license, PolicyCheckResult};
+pub use gate5_auth::{check_gate5, check_gate5_with_env, CurrentEnv, EnvProbe};
 pub use loader::{
     load_effective_policy, preset_default, preset_offline, preset_strict, write_global_preset,
     EffectivePolicy,

--- a/v4/crates/sindri-policy/src/loader.rs
+++ b/v4/crates/sindri-policy/src/loader.rs
@@ -1,4 +1,4 @@
-use sindri_core::policy::{AuditConfig, InstallPolicy, PolicyAction, PolicyPreset};
+use sindri_core::policy::{AuditConfig, AuthPolicy, InstallPolicy, PolicyAction, PolicyPreset};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -26,6 +26,7 @@ pub fn preset_default() -> InstallPolicy {
         require_checksums: Some(false),
         offline: Some(false),
         audit: None,
+        auth: AuthPolicy::default(),
     }
 }
 
@@ -48,6 +49,7 @@ pub fn preset_strict() -> InstallPolicy {
         audit: Some(AuditConfig {
             require_justification: true,
         }),
+        auth: AuthPolicy::default(),
     }
 }
 
@@ -61,6 +63,7 @@ pub fn preset_offline() -> InstallPolicy {
         require_checksums: Some(false),
         offline: Some(true),
         audit: None,
+        auth: AuthPolicy::default(),
     }
 }
 
@@ -144,6 +147,9 @@ fn merge_policy(base: &mut InstallPolicy, overlay: &InstallPolicy) {
     if overlay.audit.is_some() {
         base.audit = overlay.audit.clone();
     }
+    // Auth policy: overlay always wins. Defaults are documented as
+    // strict-deny so accidental omission cannot relax them.
+    base.auth = overlay.auth.clone();
 }
 
 pub fn global_policy_path() -> PathBuf {

--- a/v4/crates/sindri-resolver/Cargo.toml
+++ b/v4/crates/sindri-resolver/Cargo.toml
@@ -19,3 +19,4 @@ serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
+dirs-next = { workspace = true }

--- a/v4/crates/sindri-resolver/src/admission.rs
+++ b/v4/crates/sindri-resolver/src/admission.rs
@@ -397,6 +397,7 @@ mod tests {
             configure: None,
             remove: None,
             overrides: Default::default(),
+            auth: Default::default(),
         }
     }
 

--- a/v4/crates/sindri-resolver/src/admission.rs
+++ b/v4/crates/sindri-resolver/src/admission.rs
@@ -342,6 +342,7 @@ mod tests {
             require_checksums: None,
             offline: None,
             audit: None,
+            auth: sindri_core::policy::AuthPolicy::default(),
         }
     }
 
@@ -355,6 +356,7 @@ mod tests {
             require_checksums: Some(true),
             offline: None,
             audit: None,
+            auth: sindri_core::policy::AuthPolicy::default(),
         }
     }
 

--- a/v4/crates/sindri-resolver/src/auth_binding.rs
+++ b/v4/crates/sindri-resolver/src/auth_binding.rs
@@ -1,0 +1,792 @@
+//! Auth-binding algorithm — observability-only resolver pass (ADR-027 §3).
+//!
+//! Phase 1 of the auth-aware implementation plan
+//! (`v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md`).
+//!
+//! # Algorithm (ADR-027 §3)
+//!
+//! For each [`AuthRequirement`]-shaped entry declared by each component
+//! resolved against each [`Target`], we compute an [`AuthBinding`]:
+//!
+//! ```text
+//! fn bind(req, target) -> Option<AuthBinding>:
+//!     candidates = target.auth_capabilities()           // intrinsic
+//!               ++ target.config.provides               // user overrides
+//!               ++ requirement.discovery.* synthesised  // env/cli/oauth aliases
+//!
+//!     dedupe by (target_id, source.kind, source.params)
+//!     sort by (priority desc, source.rank asc)
+//!
+//!     for cap in candidates:
+//!         if cap.audience != req.audience: skip (audience-mismatch)
+//!         if cap.source incompatible with req.scope: skip (scope-mismatch)
+//!         return Bound(cap)
+//!     None
+//! ```
+//!
+//! # Scope of Phase 1
+//!
+//! - Pure dataflow over the manifests + target capabilities. **No values
+//!   are read** (DDD-07 invariant 3 "no value capture").
+//! - The apply path (`sindri-extensions::executor`) does **not** read the
+//!   produced bindings yet — that is Phase 2.
+//! - Built-in targets keep the trait default `auth_capabilities() = vec![]`;
+//!   capabilities arrive via `TargetConfig.provides:` (Phase 1) and via
+//!   per-target overrides (Phase 4).
+//!
+//! # Determinism
+//!
+//! Given identical input, the produced [`AuthBinding`] sequence is
+//! byte-identical (same `id`, same selected source, same `considered`
+//! list, same order). This is asserted by a property test
+//! (`prop_determinism`).
+
+use sha2::{Digest, Sha256};
+use sindri_core::auth::{
+    auth_source_kind, auth_source_rank, AuthBinding, AuthBindingStatus, AuthCapability,
+    AuthRequirements, AuthScope, AuthSource, CertRequirement, OAuthRequirement, RejectedCandidate,
+    SshKeyRequirement, TokenRequirement,
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// One component's auth requirements paired with its address, as input to
+/// [`bind_all`].
+#[derive(Debug, Clone)]
+pub struct ComponentAuthInput<'a> {
+    /// Canonical component address (`backend:name[@qualifier]`).
+    pub address: String,
+    /// The component-declared requirements (cloned/borrowed from the
+    /// manifest).
+    pub auth: &'a AuthRequirements,
+}
+
+/// One target's identity paired with its full capability list, as input
+/// to [`bind_all`].
+#[derive(Debug, Clone)]
+pub struct TargetAuthInput {
+    /// Target name (key in `BomManifest.targets`).
+    pub target_id: String,
+    /// Capabilities = `Target::auth_capabilities()` ++
+    /// `TargetConfig.provides`. The caller is responsible for stitching
+    /// these together; this module treats the list as opaque.
+    pub capabilities: Vec<AuthCapability>,
+}
+
+/// Outcome of the binding pass — the bindings to record in the lockfile,
+/// plus aggregate counts for the CLI summary line and ledger emission.
+#[derive(Debug, Clone, Default)]
+pub struct BindingPass {
+    /// All bindings, in stable order: per-component declaration order,
+    /// then per-requirement declaration order (tokens → oauth → certs →
+    /// ssh).
+    pub bindings: Vec<AuthBinding>,
+}
+
+impl BindingPass {
+    /// Number of [`AuthBindingStatus::Bound`] bindings.
+    pub fn resolved(&self) -> usize {
+        self.bindings
+            .iter()
+            .filter(|b| b.status == AuthBindingStatus::Bound)
+            .count()
+    }
+
+    /// Number of [`AuthBindingStatus::Deferred`] bindings (optional, no
+    /// source matched).
+    pub fn deferred(&self) -> usize {
+        self.bindings
+            .iter()
+            .filter(|b| b.status == AuthBindingStatus::Deferred)
+            .count()
+    }
+
+    /// Number of [`AuthBindingStatus::Failed`] bindings (required, no
+    /// source matched). Phase 2's Gate 5 will deny apply when this is
+    /// non-zero.
+    pub fn failed(&self) -> usize {
+        self.bindings
+            .iter()
+            .filter(|b| b.status == AuthBindingStatus::Failed)
+            .count()
+    }
+}
+
+/// Run the binding algorithm across a Cartesian product of components and
+/// targets.
+///
+/// The result is deterministic: callers will see the same `bindings`
+/// vector for the same input. Bindings are emitted in stable order:
+/// outer = `targets` order, inner = `components` order, innermost =
+/// requirement-declaration order within each component (`tokens` first,
+/// then `oauth`, then `certs`, then `ssh`).
+pub fn bind_all(components: &[ComponentAuthInput<'_>], targets: &[TargetAuthInput]) -> BindingPass {
+    let mut bindings = Vec::new();
+    for tgt in targets {
+        for comp in components {
+            extend_bindings_for_component(comp, tgt, &mut bindings);
+        }
+    }
+    BindingPass { bindings }
+}
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+fn extend_bindings_for_component(
+    comp: &ComponentAuthInput<'_>,
+    tgt: &TargetAuthInput,
+    out: &mut Vec<AuthBinding>,
+) {
+    for t in &comp.auth.tokens {
+        out.push(bind_token(comp, tgt, t));
+    }
+    for o in &comp.auth.oauth {
+        out.push(bind_oauth(comp, tgt, o));
+    }
+    for c in &comp.auth.certs {
+        out.push(bind_cert(comp, tgt, c));
+    }
+    for s in &comp.auth.ssh {
+        out.push(bind_ssh(comp, tgt, s));
+    }
+}
+
+/// Common per-requirement view passed to [`bind_one`].
+struct ReqView<'a> {
+    name: &'a str,
+    audience: &'a str,
+    scope: AuthScope,
+    optional: bool,
+    /// Synthesised candidates from `DiscoveryHints` — appended at the end
+    /// of the candidate list with priority `-100` so explicit target
+    /// capabilities always win.
+    discovered: Vec<AuthCapability>,
+}
+
+fn bind_token(
+    comp: &ComponentAuthInput<'_>,
+    tgt: &TargetAuthInput,
+    t: &TokenRequirement,
+) -> AuthBinding {
+    let discovered = synthesise_from_discovery(&t.audience, &t.discovery);
+    let view = ReqView {
+        name: &t.name,
+        audience: &t.audience,
+        scope: t.scope,
+        optional: t.optional,
+        discovered,
+    };
+    bind_one(comp, tgt, &view)
+}
+
+fn bind_oauth(
+    comp: &ComponentAuthInput<'_>,
+    tgt: &TargetAuthInput,
+    o: &OAuthRequirement,
+) -> AuthBinding {
+    // OAuth requirements declare their provider directly; synthesise a
+    // single FromOAuth candidate keyed off `o.provider`.
+    let discovered = vec![AuthCapability {
+        id: format!("{}_oauth", o.provider),
+        audience: o.audience.clone(),
+        source: AuthSource::FromOAuth {
+            provider: o.provider.clone(),
+        },
+        priority: -100,
+    }];
+    let view = ReqView {
+        name: &o.name,
+        audience: &o.audience,
+        scope: o.scope,
+        optional: o.optional,
+        discovered,
+    };
+    bind_one(comp, tgt, &view)
+}
+
+fn bind_cert(
+    comp: &ComponentAuthInput<'_>,
+    tgt: &TargetAuthInput,
+    c: &CertRequirement,
+) -> AuthBinding {
+    let view = ReqView {
+        name: &c.name,
+        audience: &c.audience,
+        scope: c.scope,
+        optional: c.optional,
+        discovered: Vec::new(),
+    };
+    bind_one(comp, tgt, &view)
+}
+
+fn bind_ssh(
+    comp: &ComponentAuthInput<'_>,
+    tgt: &TargetAuthInput,
+    s: &SshKeyRequirement,
+) -> AuthBinding {
+    let view = ReqView {
+        name: &s.name,
+        audience: &s.audience,
+        scope: s.scope,
+        optional: s.optional,
+        discovered: Vec::new(),
+    };
+    bind_one(comp, tgt, &view)
+}
+
+fn synthesise_from_discovery(
+    audience: &str,
+    d: &sindri_core::auth::DiscoveryHints,
+) -> Vec<AuthCapability> {
+    let mut out = Vec::new();
+    for var in &d.env_aliases {
+        out.push(AuthCapability {
+            id: format!("env-alias:{}", var),
+            audience: audience.to_string(),
+            source: AuthSource::FromEnv { var: var.clone() },
+            priority: -100,
+        });
+    }
+    for cmd in &d.cli_aliases {
+        out.push(AuthCapability {
+            id: format!("cli-alias:{}", cmd),
+            audience: audience.to_string(),
+            source: AuthSource::FromCli {
+                command: cmd.clone(),
+            },
+            priority: -100,
+        });
+    }
+    if let Some(p) = &d.oauth_provider {
+        out.push(AuthCapability {
+            id: format!("oauth-provider:{}", p),
+            audience: audience.to_string(),
+            source: AuthSource::FromOAuth {
+                provider: p.clone(),
+            },
+            priority: -100,
+        });
+    }
+    out
+}
+
+fn bind_one(
+    comp: &ComponentAuthInput<'_>,
+    tgt: &TargetAuthInput,
+    view: &ReqView<'_>,
+) -> AuthBinding {
+    let id = compute_binding_id(&comp.address, view.name, &tgt.target_id);
+
+    // 1. Build candidate list: target capabilities first (priority by user),
+    //    then synthesised discovery candidates (priority -100).
+    let mut candidates: Vec<AuthCapability> = tgt.capabilities.clone();
+    candidates.extend(view.discovered.clone());
+
+    // 2. Dedupe by (source_kind, source_params). Stable: keep first.
+    candidates = dedupe_candidates(candidates);
+
+    // 3. Sort by (priority desc, source_rank asc, id asc).
+    candidates.sort_by(|a, b| {
+        b.priority
+            .cmp(&a.priority)
+            .then_with(|| auth_source_rank(&a.source).cmp(&auth_source_rank(&b.source)))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    // 4. Walk candidates, first match wins; record rejections.
+    let canon_audience = canon(view.audience);
+    let mut considered: Vec<RejectedCandidate> = Vec::new();
+    let mut chosen: Option<AuthCapability> = None;
+
+    for cap in candidates {
+        if canon(&cap.audience) != canon_audience {
+            considered.push(RejectedCandidate {
+                capability_id: cap.id.clone(),
+                source_kind: auth_source_kind(&cap.source).to_string(),
+                reason: "audience-mismatch".into(),
+            });
+            continue;
+        }
+        if !scope_compatible(view.scope, &cap.source) {
+            considered.push(RejectedCandidate {
+                capability_id: cap.id.clone(),
+                source_kind: auth_source_kind(&cap.source).to_string(),
+                reason: "scope-mismatch".into(),
+            });
+            continue;
+        }
+        chosen = Some(cap);
+        break;
+    }
+
+    match chosen {
+        Some(cap) => AuthBinding {
+            id,
+            component: comp.address.clone(),
+            requirement: view.name.to_string(),
+            audience: canon_audience,
+            target: tgt.target_id.clone(),
+            source: Some(cap.source),
+            priority: cap.priority,
+            status: AuthBindingStatus::Bound,
+            reason: None,
+            considered,
+        },
+        None => {
+            let (status, reason) = if view.optional {
+                (
+                    AuthBindingStatus::Deferred,
+                    Some("no source matched (optional)".to_string()),
+                )
+            } else {
+                (
+                    AuthBindingStatus::Failed,
+                    Some("no source matched (required)".to_string()),
+                )
+            };
+            AuthBinding {
+                id,
+                component: comp.address.clone(),
+                requirement: view.name.to_string(),
+                audience: canon_audience,
+                target: tgt.target_id.clone(),
+                source: None,
+                priority: 0,
+                status,
+                reason,
+                considered,
+            }
+        }
+    }
+}
+
+/// Deterministic 16-hex-char id for an [`AuthBinding`] (DDD-07 invariant 4).
+fn compute_binding_id(component: &str, requirement: &str, target: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(b"auth-binding:v1\n");
+    h.update(component.as_bytes());
+    h.update(b"\n");
+    h.update(requirement.as_bytes());
+    h.update(b"\n");
+    h.update(target.as_bytes());
+    let digest = h.finalize();
+    hex::encode(&digest[..8])
+}
+
+/// Canonical audience matching: lower-cased, trimmed (no globs — DDD-07
+/// "Audience" definition).
+fn canon(s: &str) -> String {
+    s.trim().to_ascii_lowercase()
+}
+
+/// Phase 1 scope/source compatibility:
+///
+/// - `Prompt` is interactive and cannot satisfy `scope: install` (in a
+///   `--ci` invocation Phase 2's Gate 5 will reject it; the binding
+///   stage already excludes the obviously-wrong combination so the
+///   `considered` list shows the rejection).
+/// - All other source kinds are scope-compatible at this phase.
+fn scope_compatible(scope: AuthScope, source: &AuthSource) -> bool {
+    !matches!((scope, source), (AuthScope::Install, AuthSource::Prompt))
+}
+
+/// Stable-keep dedupe: first occurrence wins, so user-supplied
+/// `provides:` entries (which the caller is expected to put first) take
+/// precedence over the trait's intrinsic capabilities for the same key.
+fn dedupe_candidates(in_caps: Vec<AuthCapability>) -> Vec<AuthCapability> {
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut out = Vec::with_capacity(in_caps.len());
+    for cap in in_caps {
+        let key = source_dedupe_key(&cap.source);
+        if seen.insert(key) {
+            out.push(cap);
+        }
+    }
+    out
+}
+
+fn source_dedupe_key(s: &AuthSource) -> String {
+    match s {
+        AuthSource::FromSecretsStore { backend, path } => {
+            format!("from-secrets-store|{}|{}", backend, path)
+        }
+        AuthSource::FromEnv { var } => format!("from-env|{}", var),
+        AuthSource::FromFile { path, mode } => {
+            format!("from-file|{}|{:?}", path, mode)
+        }
+        AuthSource::FromCli { command } => format!("from-cli|{}", command),
+        AuthSource::FromUpstreamCredentials => "from-upstream-credentials".to_string(),
+        AuthSource::FromOAuth { provider } => format!("from-oauth|{}", provider),
+        AuthSource::Prompt => "prompt".to_string(),
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::auth::{DiscoveryHints, Redemption};
+
+    fn token_req(name: &str, audience: &str, optional: bool) -> TokenRequirement {
+        TokenRequirement {
+            name: name.into(),
+            description: format!("token {}", name),
+            scope: AuthScope::Both,
+            optional,
+            audience: audience.into(),
+            redemption: Redemption::EnvVar {
+                env_name: name.to_uppercase(),
+            },
+            discovery: DiscoveryHints::default(),
+        }
+    }
+
+    fn cap(id: &str, audience: &str, src: AuthSource, prio: i32) -> AuthCapability {
+        AuthCapability {
+            id: id.into(),
+            audience: audience.into(),
+            source: src,
+            priority: prio,
+        }
+    }
+
+    fn req_set(tokens: Vec<TokenRequirement>) -> AuthRequirements {
+        AuthRequirements {
+            tokens,
+            ..Default::default()
+        }
+    }
+
+    fn comp_input<'a>(addr: &str, auth: &'a AuthRequirements) -> ComponentAuthInput<'a> {
+        ComponentAuthInput {
+            address: addr.into(),
+            auth,
+        }
+    }
+
+    fn tgt_input(name: &str, caps: Vec<AuthCapability>) -> TargetAuthInput {
+        TargetAuthInput {
+            target_id: name.into(),
+            capabilities: caps,
+        }
+    }
+
+    // 1. Audience match — same audience binds.
+    #[test]
+    fn audience_match_binds() {
+        let auth = req_set(vec![token_req("gh", "https://api.github.com", false)]);
+        let caps = vec![cap(
+            "gh_token",
+            "https://api.github.com",
+            AuthSource::FromEnv {
+                var: "GITHUB_TOKEN".into(),
+            },
+            0,
+        )];
+        let pass = bind_all(&[comp_input("npm:gh", &auth)], &[tgt_input("local", caps)]);
+        assert_eq!(pass.resolved(), 1);
+        assert_eq!(pass.failed(), 0);
+        let b = &pass.bindings[0];
+        assert_eq!(b.status, AuthBindingStatus::Bound);
+        assert_eq!(b.target, "local");
+        assert!(matches!(b.source, Some(AuthSource::FromEnv { .. })));
+    }
+
+    // 2. Audience mismatch — does not bind, recorded as rejected.
+    #[test]
+    fn audience_mismatch_does_not_bind() {
+        let auth = req_set(vec![token_req("gh", "https://api.github.com", false)]);
+        let caps = vec![cap(
+            "wrong",
+            "https://gitlab.com/api",
+            AuthSource::FromEnv {
+                var: "GITLAB_TOKEN".into(),
+            },
+            0,
+        )];
+        let pass = bind_all(&[comp_input("npm:gh", &auth)], &[tgt_input("local", caps)]);
+        assert_eq!(pass.resolved(), 0);
+        assert_eq!(pass.failed(), 1);
+        let b = &pass.bindings[0];
+        assert_eq!(b.status, AuthBindingStatus::Failed);
+        assert_eq!(b.considered.len(), 1);
+        assert_eq!(b.considered[0].reason, "audience-mismatch");
+    }
+
+    // 3. Scope mismatch — Prompt rejected for Install scope.
+    #[test]
+    fn prompt_rejected_for_install_scope() {
+        let mut t = token_req("k", "urn:x", false);
+        t.scope = AuthScope::Install;
+        let auth = req_set(vec![t]);
+        let caps = vec![
+            cap("p", "urn:x", AuthSource::Prompt, 100),
+            cap("e", "urn:x", AuthSource::FromEnv { var: "X".into() }, 0),
+        ];
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("local", caps)]);
+        let b = &pass.bindings[0];
+        assert_eq!(b.status, AuthBindingStatus::Bound);
+        // Prompt was first (priority 100) but rejected for scope, env wins.
+        assert!(matches!(b.source, Some(AuthSource::FromEnv { .. })));
+        assert!(b
+            .considered
+            .iter()
+            .any(|r| r.reason == "scope-mismatch" && r.source_kind == "prompt"));
+    }
+
+    // 4. Priority order — higher priority wins among same-audience candidates.
+    #[test]
+    fn higher_priority_wins() {
+        let auth = req_set(vec![token_req("k", "urn:x", false)]);
+        let caps = vec![
+            cap("low", "urn:x", AuthSource::FromEnv { var: "LOW".into() }, 0),
+            cap(
+                "high",
+                "urn:x",
+                AuthSource::FromEnv { var: "HIGH".into() },
+                100,
+            ),
+        ];
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", caps)]);
+        let b = &pass.bindings[0];
+        match b.source.as_ref().unwrap() {
+            AuthSource::FromEnv { var } => assert_eq!(var, "HIGH"),
+            other => panic!("got {:?}", other),
+        }
+        assert_eq!(b.priority, 100);
+    }
+
+    // 5. Source-rank tie-breaker — equal priority, secrets-store beats env.
+    #[test]
+    fn source_rank_tiebreaker() {
+        let auth = req_set(vec![token_req("k", "urn:x", false)]);
+        let caps = vec![
+            cap("env", "urn:x", AuthSource::FromEnv { var: "X".into() }, 0),
+            cap(
+                "vault",
+                "urn:x",
+                AuthSource::FromSecretsStore {
+                    backend: "vault".into(),
+                    path: "p".into(),
+                },
+                0,
+            ),
+        ];
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", caps)]);
+        let b = &pass.bindings[0];
+        assert!(matches!(
+            b.source,
+            Some(AuthSource::FromSecretsStore { .. })
+        ));
+    }
+
+    // 6. Considered-but-rejected list captures all skipped candidates.
+    #[test]
+    fn considered_list_records_all_skips() {
+        let auth = req_set(vec![token_req("k", "urn:x", false)]);
+        let caps = vec![
+            cap(
+                "wrong1",
+                "urn:y",
+                AuthSource::FromEnv { var: "A".into() },
+                10,
+            ),
+            cap(
+                "wrong2",
+                "urn:z",
+                AuthSource::FromEnv { var: "B".into() },
+                5,
+            ),
+            cap("right", "urn:x", AuthSource::FromEnv { var: "C".into() }, 0),
+        ];
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", caps)]);
+        let b = &pass.bindings[0];
+        assert_eq!(b.status, AuthBindingStatus::Bound);
+        assert_eq!(b.considered.len(), 2);
+        assert!(b.considered.iter().all(|r| r.reason == "audience-mismatch"));
+    }
+
+    // 7. Deduplication — identical (kind, params) appears once.
+    #[test]
+    fn dedupe_drops_identical_candidates() {
+        let auth = req_set(vec![token_req("k", "urn:x", false)]);
+        let caps = vec![
+            cap(
+                "first",
+                "urn:x",
+                AuthSource::FromEnv { var: "X".into() },
+                10,
+            ),
+            cap(
+                "duplicate",
+                "urn:x",
+                AuthSource::FromEnv { var: "X".into() },
+                100, // higher priority — but duped away by stable-keep
+            ),
+        ];
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", caps)]);
+        let b = &pass.bindings[0];
+        assert_eq!(b.priority, 10, "first occurrence wins on dedupe");
+    }
+
+    // 8. Deterministic id — same inputs → same id, different inputs → different id.
+    #[test]
+    fn binding_id_is_deterministic() {
+        let id1 = compute_binding_id("npm:k", "tok", "local");
+        let id2 = compute_binding_id("npm:k", "tok", "local");
+        assert_eq!(id1, id2);
+        assert_ne!(id1, compute_binding_id("npm:k", "tok", "remote"));
+        assert_ne!(id1, compute_binding_id("npm:k", "other", "local"));
+        assert_eq!(id1.len(), 16);
+    }
+
+    // 9. Optional + no source → Deferred (not Failed).
+    #[test]
+    fn optional_unmatched_is_deferred() {
+        let auth = req_set(vec![token_req("k", "urn:x", true)]); // optional
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", vec![])]);
+        assert_eq!(pass.deferred(), 1);
+        assert_eq!(pass.failed(), 0);
+    }
+
+    // 10. Required + no source → Failed.
+    #[test]
+    fn required_unmatched_is_failed() {
+        let auth = req_set(vec![token_req("k", "urn:x", false)]);
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", vec![])]);
+        assert_eq!(pass.failed(), 1);
+    }
+
+    // 11. Discovery hints synthesize fallback candidates.
+    #[test]
+    fn discovery_hints_synthesize_candidates() {
+        let mut t = token_req("k", "urn:x", false);
+        t.discovery = DiscoveryHints {
+            env_aliases: vec!["MY_TOKEN".into()],
+            ..Default::default()
+        };
+        let auth = req_set(vec![t]);
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", vec![])]);
+        let b = &pass.bindings[0];
+        assert_eq!(b.status, AuthBindingStatus::Bound);
+        match b.source.as_ref().unwrap() {
+            AuthSource::FromEnv { var } => assert_eq!(var, "MY_TOKEN"),
+            other => panic!("got {:?}", other),
+        }
+        assert_eq!(b.priority, -100, "synthesised candidates use -100");
+    }
+
+    // 12. Audience canonicalisation — case-insensitive equality.
+    #[test]
+    fn audience_match_is_case_insensitive() {
+        let auth = req_set(vec![token_req("k", "Urn:X", false)]);
+        let caps = vec![cap(
+            "c",
+            "URN:x",
+            AuthSource::FromEnv { var: "X".into() },
+            0,
+        )];
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", caps)]);
+        assert_eq!(pass.resolved(), 1);
+        let b = &pass.bindings[0];
+        assert_eq!(b.audience, "urn:x");
+    }
+
+    // 13. Cross product — N components × M targets emits N*M (per-req) bindings
+    //     in stable order (target outer, component inner).
+    #[test]
+    fn cross_product_emits_bindings_in_stable_order() {
+        let a1 = req_set(vec![token_req("a", "urn:a", false)]);
+        let a2 = req_set(vec![token_req("b", "urn:b", false)]);
+        let pass = bind_all(
+            &[comp_input("npm:c1", &a1), comp_input("npm:c2", &a2)],
+            &[tgt_input("t1", vec![]), tgt_input("t2", vec![])],
+        );
+        // 2 targets * 2 components * 1 req each = 4 bindings.
+        assert_eq!(pass.bindings.len(), 4);
+        assert_eq!(pass.bindings[0].target, "t1");
+        assert_eq!(pass.bindings[0].component, "npm:c1");
+        assert_eq!(pass.bindings[1].target, "t1");
+        assert_eq!(pass.bindings[1].component, "npm:c2");
+        assert_eq!(pass.bindings[2].target, "t2");
+        assert_eq!(pass.bindings[2].component, "npm:c1");
+        assert_eq!(pass.bindings[3].target, "t2");
+        assert_eq!(pass.bindings[3].component, "npm:c2");
+    }
+
+    // 14. Determinism property test — same input → byte-identical output.
+    //     Pure logic determinism (no `proptest` crate dep needed): we sample
+    //     several non-trivial inputs and assert byte-equality across two runs.
+    #[test]
+    fn prop_determinism_byte_identical() {
+        let inputs: Vec<(Vec<TokenRequirement>, Vec<AuthCapability>)> = vec![
+            (
+                vec![
+                    token_req("a", "urn:a", false),
+                    token_req("b", "urn:b", true),
+                ],
+                vec![
+                    cap("c1", "urn:a", AuthSource::FromEnv { var: "A".into() }, 10),
+                    cap(
+                        "c2",
+                        "urn:b",
+                        AuthSource::FromCli {
+                            command: "x".into(),
+                        },
+                        5,
+                    ),
+                ],
+            ),
+            (
+                vec![token_req("z", "Z", false)],
+                vec![
+                    cap(
+                        "c1",
+                        "z",
+                        AuthSource::FromSecretsStore {
+                            backend: "vault".into(),
+                            path: "p".into(),
+                        },
+                        0,
+                    ),
+                    cap("c2", "z", AuthSource::FromEnv { var: "Z".into() }, 100),
+                ],
+            ),
+        ];
+        for (toks, caps) in inputs {
+            let auth = req_set(toks);
+            let p1 = bind_all(
+                &[comp_input("npm:k", &auth)],
+                &[tgt_input("t", caps.clone())],
+            );
+            let p2 = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", caps)]);
+            // Serialise and compare bytes — strongest determinism signal.
+            let s1 = serde_json::to_string(&p1.bindings).unwrap();
+            let s2 = serde_json::to_string(&p2.bindings).unwrap();
+            assert_eq!(s1, s2, "bind_all not deterministic");
+        }
+    }
+
+    // 15. Serialisation round-trip for AuthBinding inside a lockfile-like blob.
+    #[test]
+    fn binding_round_trips_through_yaml() {
+        let auth = req_set(vec![token_req("k", "urn:x", false)]);
+        let caps = vec![cap(
+            "c",
+            "urn:x",
+            AuthSource::FromEnv { var: "X".into() },
+            0,
+        )];
+        let pass = bind_all(&[comp_input("npm:k", &auth)], &[tgt_input("t", caps)]);
+        let s = serde_yaml::to_string(&pass.bindings).unwrap();
+        let back: Vec<AuthBinding> = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(pass.bindings, back);
+    }
+}

--- a/v4/crates/sindri-resolver/src/ledger.rs
+++ b/v4/crates/sindri-resolver/src/ledger.rs
@@ -1,0 +1,282 @@
+//! Auth-binding ledger events (DDD-07 §"Domain Events", PR #2 of Phase 1).
+//!
+//! Phase 1 of the auth-aware implementation plan emits five events at
+//! resolve time:
+//!
+//! | Event                        | Producer                    |
+//! | ---------------------------- | --------------------------- |
+//! | `AuthRequirementDeclared`    | per requirement on every component |
+//! | `AuthCapabilityRegistered`   | per capability on every target     |
+//! | `AuthBindingResolved`        | per `Bound` binding                |
+//! | `AuthBindingDeferred`        | per `Deferred` binding (optional)  |
+//! | `AuthBindingFailed`          | per `Failed` binding (required)    |
+//!
+//! The events are appended to the same JSONL ledger consumed by
+//! `sindri log` (`~/.sindri/ledger.jsonl`). All payloads redact secret
+//! values — the binding domain captures only references (DDD-07 invariant
+//! 3 "no value capture"), so there is nothing to redact in practice, but
+//! the schema is intentionally limited to safe metadata only.
+//!
+//! Emission is best-effort: a write failure logs at `tracing::warn!` and
+//! returns silently. Resolve must not fail because the audit trail is
+//! unavailable; downstream operators will notice via `sindri doctor`.
+
+use crate::auth_binding::{BindingPass, ComponentAuthInput, TargetAuthInput};
+use serde::{Deserialize, Serialize};
+use sindri_core::auth::{auth_source_kind, AuthBindingStatus, AuthScope};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// One audit-ledger event for an auth-binding lifecycle action
+/// (DDD-07 §"Domain Events").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthLedgerEvent {
+    /// Unix epoch seconds.
+    pub timestamp: u64,
+    /// One of `AuthRequirementDeclared`, `AuthCapabilityRegistered`,
+    /// `AuthBindingResolved`, `AuthBindingDeferred`, `AuthBindingFailed`.
+    pub event_type: String,
+    /// Component address (`backend:name[@qualifier]`) when the event is
+    /// component-scoped, else the empty string.
+    #[serde(default)]
+    pub component: String,
+    /// Target id when target-scoped, else the empty string.
+    #[serde(default)]
+    pub target: String,
+    /// Requirement or capability identifier when applicable.
+    #[serde(default)]
+    pub name: String,
+    /// Audience associated with the event.
+    #[serde(default)]
+    pub audience: String,
+    /// Source-kind discriminant, e.g. `from-secrets-store`. Empty when
+    /// the event has no associated source.
+    #[serde(default)]
+    pub source_kind: String,
+    /// Free-form reason / detail (e.g. `"no source matched (required)"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Default ledger location (`~/.sindri/ledger.jsonl`). Returns `None` if
+/// `$HOME` cannot be determined (no place to write).
+fn ledger_path() -> Option<PathBuf> {
+    dirs_next::home_dir().map(|h| h.join(".sindri").join("ledger.jsonl"))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn append(event: &AuthLedgerEvent) {
+    let Some(path) = ledger_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    let json = match serde_json::to_string(event) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("auth-ledger serialise failed: {}", e);
+            return;
+        }
+    };
+    use std::io::Write;
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(mut f) => {
+            if let Err(e) = writeln!(f, "{}", json) {
+                tracing::warn!("auth-ledger write failed: {}", e);
+            }
+        }
+        Err(e) => tracing::warn!("auth-ledger open failed: {}", e),
+    }
+}
+
+/// Emit the full set of Phase 1 events for a binding pass: declarations
+/// for each requirement, capability registrations for each target, and
+/// resolved/deferred/failed events for each binding outcome.
+///
+/// Best-effort I/O: see module docs.
+pub fn emit_pass_events(
+    components: &[ComponentAuthInput<'_>],
+    targets: &[TargetAuthInput],
+    pass: &BindingPass,
+) {
+    // 1. AuthRequirementDeclared — one per requirement per component.
+    for c in components {
+        for t in &c.auth.tokens {
+            append(&AuthLedgerEvent {
+                timestamp: now_secs(),
+                event_type: "AuthRequirementDeclared".into(),
+                component: c.address.clone(),
+                target: String::new(),
+                name: t.name.clone(),
+                audience: t.audience.clone(),
+                source_kind: String::new(),
+                detail: Some(scope_string(t.scope)),
+            });
+        }
+        for o in &c.auth.oauth {
+            append(&AuthLedgerEvent {
+                timestamp: now_secs(),
+                event_type: "AuthRequirementDeclared".into(),
+                component: c.address.clone(),
+                target: String::new(),
+                name: o.name.clone(),
+                audience: o.audience.clone(),
+                source_kind: "from-oauth".into(),
+                detail: Some(scope_string(o.scope)),
+            });
+        }
+        for cert in &c.auth.certs {
+            append(&AuthLedgerEvent {
+                timestamp: now_secs(),
+                event_type: "AuthRequirementDeclared".into(),
+                component: c.address.clone(),
+                target: String::new(),
+                name: cert.name.clone(),
+                audience: cert.audience.clone(),
+                source_kind: String::new(),
+                detail: Some(scope_string(cert.scope)),
+            });
+        }
+        for s in &c.auth.ssh {
+            append(&AuthLedgerEvent {
+                timestamp: now_secs(),
+                event_type: "AuthRequirementDeclared".into(),
+                component: c.address.clone(),
+                target: String::new(),
+                name: s.name.clone(),
+                audience: s.audience.clone(),
+                source_kind: String::new(),
+                detail: Some(scope_string(s.scope)),
+            });
+        }
+    }
+
+    // 2. AuthCapabilityRegistered — one per capability per target.
+    for tgt in targets {
+        for cap in &tgt.capabilities {
+            append(&AuthLedgerEvent {
+                timestamp: now_secs(),
+                event_type: "AuthCapabilityRegistered".into(),
+                component: String::new(),
+                target: tgt.target_id.clone(),
+                name: cap.id.clone(),
+                audience: cap.audience.clone(),
+                source_kind: auth_source_kind(&cap.source).to_string(),
+                detail: Some(format!("priority={}", cap.priority)),
+            });
+        }
+    }
+
+    // 3. AuthBindingResolved / Deferred / Failed — one per binding.
+    for b in &pass.bindings {
+        let event_type = match b.status {
+            AuthBindingStatus::Bound => "AuthBindingResolved",
+            AuthBindingStatus::Deferred => "AuthBindingDeferred",
+            AuthBindingStatus::Failed => "AuthBindingFailed",
+        };
+        append(&AuthLedgerEvent {
+            timestamp: now_secs(),
+            event_type: event_type.into(),
+            component: b.component.clone(),
+            target: b.target.clone(),
+            name: b.requirement.clone(),
+            audience: b.audience.clone(),
+            source_kind: b
+                .source
+                .as_ref()
+                .map(|s| auth_source_kind(s).to_string())
+                .unwrap_or_default(),
+            detail: b.reason.clone(),
+        });
+    }
+}
+
+fn scope_string(s: AuthScope) -> String {
+    match s {
+        AuthScope::Install => "install".into(),
+        AuthScope::Runtime => "runtime".into(),
+        AuthScope::Both => "both".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth_binding::{bind_all, ComponentAuthInput, TargetAuthInput};
+    use sindri_core::auth::{
+        AuthCapability, AuthRequirements, AuthScope, AuthSource, DiscoveryHints, Redemption,
+        TokenRequirement,
+    };
+
+    fn token(name: &str, audience: &str, optional: bool) -> TokenRequirement {
+        TokenRequirement {
+            name: name.into(),
+            description: name.into(),
+            scope: AuthScope::Runtime,
+            optional,
+            audience: audience.into(),
+            redemption: Redemption::EnvVar {
+                env_name: name.to_uppercase(),
+            },
+            discovery: DiscoveryHints::default(),
+        }
+    }
+
+    /// Sanity: emission against an empty pass does not panic and writes
+    /// nothing. (Cannot easily isolate the user's `~/.sindri` here, so we
+    /// just smoke-test the in-process serialisation path doesn't error.)
+    #[test]
+    fn emit_pass_events_smoke() {
+        let auth = AuthRequirements {
+            tokens: vec![token("k", "urn:x", false)],
+            ..Default::default()
+        };
+        let comp = ComponentAuthInput {
+            address: "npm:k".into(),
+            auth: &auth,
+        };
+        let tgt = TargetAuthInput {
+            target_id: "local".into(),
+            capabilities: vec![AuthCapability {
+                id: "c".into(),
+                audience: "urn:x".into(),
+                source: AuthSource::FromEnv { var: "X".into() },
+                priority: 0,
+            }],
+        };
+        let pass = bind_all(std::slice::from_ref(&comp), std::slice::from_ref(&tgt));
+        // Should not panic.
+        emit_pass_events(&[comp], &[tgt], &pass);
+    }
+
+    #[test]
+    fn ledger_event_round_trips_through_json() {
+        let e = AuthLedgerEvent {
+            timestamp: 1700000000,
+            event_type: "AuthBindingResolved".into(),
+            component: "npm:k".into(),
+            target: "local".into(),
+            name: "tok".into(),
+            audience: "urn:x".into(),
+            source_kind: "from-env".into(),
+            detail: None,
+        };
+        let s = serde_json::to_string(&e).unwrap();
+        let back: AuthLedgerEvent = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.event_type, "AuthBindingResolved");
+        assert_eq!(back.target, "local");
+    }
+}

--- a/v4/crates/sindri-resolver/src/lib.rs
+++ b/v4/crates/sindri-resolver/src/lib.rs
@@ -1,9 +1,11 @@
 #![allow(dead_code)]
 
 pub mod admission;
+pub mod auth_binding;
 pub mod backend_choice;
 pub mod closure;
 pub mod error;
+pub mod ledger;
 pub mod lockfile_writer;
 pub mod version;
 
@@ -81,8 +83,66 @@ pub fn resolve(
         lockfile.components.push(resolved);
     }
 
-    // 5. Write lockfile
+    // 5. Auth-binding pass (ADR-027 §3, observability-only — Phase 1 of the
+    //    auth-aware implementation plan). Bindings are derived from any
+    //    ComponentManifests already attached to the resolved components
+    //    (today: only those loaded by callers that pre-populate the field;
+    //    full OCI-fetch integration arrives in a later wave). When no
+    //    manifests carry auth requirements, this pass produces zero
+    //    bindings and is a no-op.
+    let target_caps = collect_target_capabilities(&bom, &opts.target_name);
+    let comp_inputs = build_component_auth_inputs(&lockfile);
+    if !comp_inputs.is_empty() {
+        let inputs: Vec<auth_binding::ComponentAuthInput<'_>> = comp_inputs
+            .iter()
+            .map(|(addr, auth)| auth_binding::ComponentAuthInput {
+                address: addr.clone(),
+                auth,
+            })
+            .collect();
+        let targets = vec![auth_binding::TargetAuthInput {
+            target_id: opts.target_name.clone(),
+            capabilities: target_caps,
+        }];
+        let pass = auth_binding::bind_all(&inputs, &targets);
+        ledger::emit_pass_events(&inputs, &targets, &pass);
+        lockfile.auth_bindings = pass.bindings;
+    }
+
+    // 6. Write lockfile
     lockfile_writer::write_lockfile(&opts.lockfile_path, &lockfile)?;
 
     Ok(lockfile)
+}
+
+/// Stitch `Target::auth_capabilities()` (Phase 4) and
+/// `TargetConfig.provides:` (Phase 1) into the candidate list the binding
+/// algorithm consumes. Built-in targets currently advertise no intrinsic
+/// capabilities (Phase 4 fills these in), so today this returns the
+/// per-manifest `provides:` overrides only.
+fn collect_target_capabilities(
+    bom: &BomManifest,
+    target_name: &str,
+) -> Vec<sindri_core::auth::AuthCapability> {
+    bom.targets
+        .get(target_name)
+        .map(|tc| tc.provides.clone())
+        .unwrap_or_default()
+}
+
+/// Walk the resolved component list and pair each component's address
+/// with its declared [`AuthRequirements`]. Components without an attached
+/// manifest (the common case until OCI fetch lands) contribute nothing.
+fn build_component_auth_inputs(
+    lockfile: &Lockfile,
+) -> Vec<(String, sindri_core::auth::AuthRequirements)> {
+    let mut out = Vec::new();
+    for c in &lockfile.components {
+        if let Some(m) = &c.manifest {
+            if !m.auth.is_empty() {
+                out.push((c.id.to_address(), m.auth.clone()));
+            }
+        }
+    }
+    out
 }

--- a/v4/crates/sindri-resolver/tests/auth_binding_integration.rs
+++ b/v4/crates/sindri-resolver/tests/auth_binding_integration.rs
@@ -1,0 +1,302 @@
+//! Integration test for the auth-binding pass (ADR-027 §3, Phase 1).
+//!
+//! Scenario: 3 components × 2 targets, with overlapping audience
+//! requirements. Asserts the resulting binding sequence is deterministic
+//! and that the lockfile-shaped serialisation snapshot matches the
+//! expected YAML.
+
+use sindri_core::auth::{
+    AuthBindingStatus, AuthCapability, AuthRequirements, AuthScope, AuthSource, DiscoveryHints,
+    Redemption, TokenRequirement,
+};
+use sindri_resolver::auth_binding::{bind_all, ComponentAuthInput, TargetAuthInput};
+
+fn token(name: &str, audience: &str, optional: bool) -> TokenRequirement {
+    TokenRequirement {
+        name: name.into(),
+        description: name.into(),
+        scope: AuthScope::Both,
+        optional,
+        audience: audience.into(),
+        redemption: Redemption::EnvVar {
+            env_name: name.to_uppercase(),
+        },
+        discovery: DiscoveryHints::default(),
+    }
+}
+
+fn cap(id: &str, audience: &str, src: AuthSource, prio: i32) -> AuthCapability {
+    AuthCapability {
+        id: id.into(),
+        audience: audience.into(),
+        source: src,
+        priority: prio,
+    }
+}
+
+#[test]
+fn three_components_two_targets_with_overlap() {
+    // Components:
+    //   npm:claude-code → token "anthropic" @ urn:anthropic:api  (required)
+    //   npm:gh          → token "github"    @ https://api.github.com (optional)
+    //   pipx:awscli     → token "aws"       @ https://sts.amazonaws.com (required)
+    let claude = AuthRequirements {
+        tokens: vec![token("anthropic", "urn:anthropic:api", false)],
+        ..Default::default()
+    };
+    let gh = AuthRequirements {
+        tokens: vec![token("github", "https://api.github.com", true)],
+        ..Default::default()
+    };
+    let aws = AuthRequirements {
+        tokens: vec![token("aws", "https://sts.amazonaws.com", false)],
+        ..Default::default()
+    };
+
+    let components = vec![
+        ComponentAuthInput {
+            address: "npm:claude-code".into(),
+            auth: &claude,
+        },
+        ComponentAuthInput {
+            address: "npm:gh".into(),
+            auth: &gh,
+        },
+        ComponentAuthInput {
+            address: "pipx:awscli".into(),
+            auth: &aws,
+        },
+    ];
+
+    // Target 1 — `local`: provides anthropic + github via env, no aws.
+    // Target 2 — `fly`:   provides anthropic via vault (priority 100) and aws.
+    let local = TargetAuthInput {
+        target_id: "local".into(),
+        capabilities: vec![
+            cap(
+                "anthropic_env",
+                "urn:anthropic:api",
+                AuthSource::FromEnv {
+                    var: "ANTHROPIC_API_KEY".into(),
+                },
+                0,
+            ),
+            cap(
+                "gh_cli",
+                "https://api.github.com",
+                AuthSource::FromCli {
+                    command: "gh auth token".into(),
+                },
+                0,
+            ),
+        ],
+    };
+    let fly = TargetAuthInput {
+        target_id: "fly".into(),
+        capabilities: vec![
+            cap(
+                "anthropic_vault",
+                "urn:anthropic:api",
+                AuthSource::FromSecretsStore {
+                    backend: "vault".into(),
+                    path: "secrets/anthropic/prod".into(),
+                },
+                100,
+            ),
+            cap(
+                "aws_vault",
+                "https://sts.amazonaws.com",
+                AuthSource::FromSecretsStore {
+                    backend: "vault".into(),
+                    path: "secrets/aws/sts".into(),
+                },
+                100,
+            ),
+        ],
+    };
+
+    let pass = bind_all(&components, &[local, fly]);
+    // 3 reqs × 2 targets = 6 bindings.
+    assert_eq!(pass.bindings.len(), 6);
+
+    // Deterministic order: local first, then fly. Within target: components
+    // in declaration order.
+    assert_eq!(pass.bindings[0].target, "local");
+    assert_eq!(pass.bindings[0].component, "npm:claude-code");
+    assert_eq!(pass.bindings[3].target, "fly");
+    assert_eq!(pass.bindings[3].component, "npm:claude-code");
+
+    // Outcomes:
+    //   local × claude-code → Bound (env)
+    assert_eq!(pass.bindings[0].status, AuthBindingStatus::Bound);
+    assert!(matches!(
+        pass.bindings[0].source,
+        Some(AuthSource::FromEnv { .. })
+    ));
+    //   local × gh → Bound (cli)
+    assert_eq!(pass.bindings[1].status, AuthBindingStatus::Bound);
+    assert!(matches!(
+        pass.bindings[1].source,
+        Some(AuthSource::FromCli { .. })
+    ));
+    //   local × aws → Failed (required, no source)
+    assert_eq!(pass.bindings[2].status, AuthBindingStatus::Failed);
+    //   fly × claude-code → Bound (vault, priority 100)
+    assert_eq!(pass.bindings[3].status, AuthBindingStatus::Bound);
+    assert!(matches!(
+        pass.bindings[3].source,
+        Some(AuthSource::FromSecretsStore { .. })
+    ));
+    assert_eq!(pass.bindings[3].priority, 100);
+    //   fly × gh → Deferred (optional, no source)
+    assert_eq!(pass.bindings[4].status, AuthBindingStatus::Deferred);
+    //   fly × aws → Bound (vault)
+    assert_eq!(pass.bindings[5].status, AuthBindingStatus::Bound);
+
+    // Aggregate counts match the CLI summary line.
+    assert_eq!(pass.resolved(), 4);
+    assert_eq!(pass.deferred(), 1);
+    assert_eq!(pass.failed(), 1);
+
+    // Snapshot — round-trip through YAML produces identical bindings.
+    let yaml = serde_yaml::to_string(&pass.bindings).unwrap();
+    let back: Vec<sindri_core::auth::AuthBinding> = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(back, pass.bindings);
+
+    // Deterministic ids — recompute and compare.
+    let pass2 = bind_all(
+        &components,
+        &[
+            TargetAuthInput {
+                target_id: "local".into(),
+                capabilities: vec![
+                    cap(
+                        "anthropic_env",
+                        "urn:anthropic:api",
+                        AuthSource::FromEnv {
+                            var: "ANTHROPIC_API_KEY".into(),
+                        },
+                        0,
+                    ),
+                    cap(
+                        "gh_cli",
+                        "https://api.github.com",
+                        AuthSource::FromCli {
+                            command: "gh auth token".into(),
+                        },
+                        0,
+                    ),
+                ],
+            },
+            TargetAuthInput {
+                target_id: "fly".into(),
+                capabilities: vec![
+                    cap(
+                        "anthropic_vault",
+                        "urn:anthropic:api",
+                        AuthSource::FromSecretsStore {
+                            backend: "vault".into(),
+                            path: "secrets/anthropic/prod".into(),
+                        },
+                        100,
+                    ),
+                    cap(
+                        "aws_vault",
+                        "https://sts.amazonaws.com",
+                        AuthSource::FromSecretsStore {
+                            backend: "vault".into(),
+                            path: "secrets/aws/sts".into(),
+                        },
+                        100,
+                    ),
+                ],
+            },
+        ],
+    );
+    let s1 = serde_json::to_string(&pass.bindings).unwrap();
+    let s2 = serde_json::to_string(&pass2.bindings).unwrap();
+    assert_eq!(s1, s2, "bind_all not deterministic across calls");
+}
+
+/// Property-style determinism test (no `proptest` dep — fixed seeded
+/// permutations of valid input). Asserts that for several distinct
+/// `(req, capabilities)` pairs, two independent runs of `bind_all`
+/// produce byte-identical output (same `binding.id`, same selected
+/// source, same `considered` ordering).
+#[test]
+fn determinism_across_random_valid_inputs() {
+    let scenarios: Vec<(Vec<TokenRequirement>, Vec<AuthCapability>)> = vec![
+        (
+            vec![
+                token("a", "urn:a", false),
+                token("b", "urn:b", true),
+                token("c", "urn:c", false),
+            ],
+            vec![
+                cap("x", "urn:a", AuthSource::FromEnv { var: "A".into() }, 50),
+                cap(
+                    "y",
+                    "urn:c",
+                    AuthSource::FromCli {
+                        command: "c-cli".into(),
+                    },
+                    10,
+                ),
+            ],
+        ),
+        (
+            vec![token("k", "URN:K", false)],
+            vec![
+                cap(
+                    "v",
+                    "urn:k",
+                    AuthSource::FromSecretsStore {
+                        backend: "vault".into(),
+                        path: "p".into(),
+                    },
+                    0,
+                ),
+                cap("e", "urn:K", AuthSource::FromEnv { var: "K".into() }, 0),
+            ],
+        ),
+        (
+            vec![token("only", "urn:only", true)],
+            vec![cap(
+                "wrong",
+                "urn:other",
+                AuthSource::FromEnv {
+                    var: "WRONG".into(),
+                },
+                999,
+            )],
+        ),
+    ];
+
+    for (idx, (toks, caps)) in scenarios.into_iter().enumerate() {
+        let auth = AuthRequirements {
+            tokens: toks,
+            ..Default::default()
+        };
+        let comp = ComponentAuthInput {
+            address: "npm:scenario".into(),
+            auth: &auth,
+        };
+        let tgt = TargetAuthInput {
+            target_id: "t".into(),
+            capabilities: caps.clone(),
+        };
+        let p1 = bind_all(std::slice::from_ref(&comp), std::slice::from_ref(&tgt));
+        let p2 = bind_all(&[comp], &[tgt]);
+        assert_eq!(
+            serde_json::to_string(&p1.bindings).unwrap(),
+            serde_json::to_string(&p2.bindings).unwrap(),
+            "scenario {} not deterministic",
+            idx
+        );
+        // All ids are 16 hex chars (DDD-07 invariant 4 → format check).
+        for b in &p1.bindings {
+            assert_eq!(b.id.len(), 16, "id wrong width: {}", b.id);
+            assert!(b.id.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+}

--- a/v4/crates/sindri-targets/Cargo.toml
+++ b/v4/crates/sindri-targets/Cargo.toml
@@ -16,3 +16,6 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 dirs-next = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/v4/crates/sindri-targets/src/auth.rs
+++ b/v4/crates/sindri-targets/src/auth.rs
@@ -1,11 +1,15 @@
 /// Unified auth prefixed-value model (ADR-020)
 ///
 /// Values in sindri.yaml look like:
-///   `env:MY_TOKEN`       → read from env var
-///   `file:~/.token`      → read from file
-///   `cli:gh`             → delegate to gh CLI
-///   `plain:secret`       → inline string (warned on validate)
+///   `env:MY_TOKEN`             → read from env var
+///   `file:~/.token`            → read from file
+///   `cli:gh`                   → delegate to gh CLI
+///   `secret:vault/path/to/key` → resolve via `sindri-secrets` (Phase 0:
+///                                schema-only — actual resolution is wired
+///                                up in a later phase per ADR-027 §6)
+///   `plain:secret`             → inline string (warned on validate)
 use crate::error::TargetError;
+use sindri_core::auth::SecretRef;
 
 #[derive(Debug, Clone)]
 pub enum AuthValue {
@@ -13,6 +17,11 @@ pub enum AuthValue {
     File(String),
     Cli(String),
     Plain(String),
+    /// Reference to a secret in a backend store (ADR-020 reserved this
+    /// variant; ADR-027 §6 / Phase 0 of the auth-aware plan adds the
+    /// schema. Resolution is intentionally not wired up yet — see
+    /// [`AuthValue::resolve`].
+    Secret(SecretRef),
 }
 
 impl AuthValue {
@@ -25,6 +34,13 @@ impl AuthValue {
         }
         if let Some(cmd) = s.strip_prefix("cli:") {
             return Some(AuthValue::Cli(cmd.to_string()));
+        }
+        if let Some(rest) = s.strip_prefix("secret:") {
+            // `secret:<backend>/<path>` per ADR-020 / Phase 0 plan §"Files
+            // touched". A malformed reference (missing backend or path)
+            // is not silently demoted to `plain:` — it surfaces as `None`
+            // so callers can report a precise validation error.
+            return SecretRef::parse(rest).map(AuthValue::Secret);
         }
         if let Some(val) = s.strip_prefix("plain:") {
             return Some(AuthValue::Plain(val.to_string()));
@@ -69,6 +85,20 @@ impl AuthValue {
                 tracing::warn!("Using plain auth value — consider using env: or file: instead");
                 Ok(val.clone())
             }
+            AuthValue::Secret(r) => {
+                // Phase 0 (ADR-026/ADR-027 schema-only) ships the variant
+                // and parser without wiring resolution. The sindri-secrets
+                // crate (ADR-025) is the eventual resolver; until it lands
+                // (Phase 2 of the auth-aware plan), this returns a typed
+                // error rather than silently producing an empty string.
+                Err(TargetError::AuthFailed {
+                    target: "(secret)".into(),
+                    detail: format!(
+                        "secret backend resolution is not wired yet (ref: {}/{})",
+                        r.backend, r.path
+                    ),
+                })
+            }
         }
     }
 
@@ -81,4 +111,67 @@ fn home_str() -> String {
     dirs_next::home_dir()
         .map(|h| h.to_string_lossy().to_string())
         .unwrap_or_default()
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_secret_ref() {
+        let v = AuthValue::parse("secret:vault/secrets/anthropic/prod").unwrap();
+        match v {
+            AuthValue::Secret(r) => {
+                assert_eq!(r.backend, "vault");
+                assert_eq!(r.path, "secrets/anthropic/prod");
+            }
+            other => panic!("expected Secret, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_secret_ref_rejects_malformed() {
+        assert!(AuthValue::parse("secret:nopath").is_none());
+        assert!(AuthValue::parse("secret:/missing-backend").is_none());
+        assert!(AuthValue::parse("secret:missing-path/").is_none());
+    }
+
+    #[test]
+    fn parse_existing_prefixes_still_work() {
+        assert!(matches!(
+            AuthValue::parse("env:GITHUB_TOKEN").unwrap(),
+            AuthValue::Env(_)
+        ));
+        assert!(matches!(
+            AuthValue::parse("file:~/.token").unwrap(),
+            AuthValue::File(_)
+        ));
+        assert!(matches!(
+            AuthValue::parse("cli:gh auth token").unwrap(),
+            AuthValue::Cli(_)
+        ));
+        assert!(matches!(
+            AuthValue::parse("plain:abc").unwrap(),
+            AuthValue::Plain(_)
+        ));
+        // Bare strings still default to Plain.
+        assert!(matches!(
+            AuthValue::parse("bare-token").unwrap(),
+            AuthValue::Plain(_)
+        ));
+    }
+
+    #[test]
+    fn resolve_secret_returns_typed_error() {
+        let v = AuthValue::Secret(SecretRef::new("vault", "secrets/x"));
+        let err = v.resolve().unwrap_err();
+        let msg = format!("{}", err);
+        // Must not leak the path verbatim into a "successful" result; we
+        // care only that resolution errored.
+        assert!(msg.contains("secret"));
+    }
 }

--- a/v4/crates/sindri-targets/src/cloud.rs
+++ b/v4/crates/sindri-targets/src/cloud.rs
@@ -1,6 +1,8 @@
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
+use sindri_core::auth::{AuthCapability, AuthSource};
 use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
+
 /// Cloud target stubs (ADR-017, Sprint 10)
 ///
 /// Each cloud target implements the Target trait. Sprint 10 provides the
@@ -105,6 +107,15 @@ impl Target for E2bTarget {
             PrereqCheck::fail("e2b CLI", "npm install -g @e2b/cli")
         }]
     }
+
+    /// E2B sandboxes don't have a native secret-store API the resolver
+    /// can target — secrets land in the sandbox via the `e2b` CLI's
+    /// `--env` flag at create time. We surface no capabilities by
+    /// default; operators wire forwarded vars via `provides:` in the
+    /// target manifest (ADR-027 §1, Phase 4).
+    fn auth_capabilities(&self) -> Vec<AuthCapability> {
+        Vec::new()
+    }
 }
 
 // ─── Fly.io ─────────────────────────────────────────────────────────────────
@@ -188,6 +199,44 @@ impl Target for FlyTarget {
         } else {
             PrereqCheck::fail("flyctl CLI", "curl -L https://fly.io/install.sh | sh")
         }]
+    }
+
+    /// Fly.io advertises:
+    /// 1. **`flyctl auth token`** — the OAuth-result token from the
+    ///    operator's logged-in `flyctl` session (audience GitHub-style
+    ///    `https://api.fly.io`). Priority `15`.
+    /// 2. **`flyctl secrets`** — per-app secrets group accessible via
+    ///    `flyctl secrets list/get`. Modelled as a `FromCli` source with
+    ///    a `{key}` template the resolver expands when binding (Phase 4
+    ///    advertises a generic `flyctl secrets` capability id; per-secret
+    ///    refinement happens in Phase 2 when redemption is wired). The
+    ///    audience is `urn:fly:secrets` so component manifests can
+    ///    declare a generic Fly-secrets requirement.
+    ///
+    /// Both are conditional on `flyctl` being on `PATH` — without the
+    /// CLI neither path is reachable.
+    fn auth_capabilities(&self) -> Vec<AuthCapability> {
+        if crate::traits::which("flyctl").is_none() {
+            return Vec::new();
+        }
+        vec![
+            AuthCapability {
+                id: "fly_auth_token".to_string(),
+                audience: "https://api.fly.io".to_string(),
+                source: AuthSource::FromCli {
+                    command: "flyctl auth token".to_string(),
+                },
+                priority: 15,
+            },
+            AuthCapability {
+                id: "fly_secrets".to_string(),
+                audience: "urn:fly:secrets".to_string(),
+                source: AuthSource::FromCli {
+                    command: format!("flyctl secrets list --app {} --json", self.app_name),
+                },
+                priority: 12,
+            },
+        ]
     }
 }
 
@@ -293,5 +342,131 @@ impl Target for KubernetesTarget {
                 "Install kubectl: https://kubernetes.io/docs/tasks/tools/",
             )
         }]
+    }
+
+    /// Kubernetes targets advertise the cluster's projected-secret
+    /// mechanism (`valueFrom: { secretKeyRef }`) as a generic
+    /// [`AuthSource::FromSecretsStore`] with backend `k8s` (ADR-027 §1,
+    /// Phase 4).
+    ///
+    /// The `path` is the namespace — per-secret resolution happens at
+    /// apply time (Phase 2) when a concrete `secretKeyRef.name` and
+    /// `secretKeyRef.key` are projected into the workload pod. Audience
+    /// is `urn:k8s:secrets` so component manifests can opt-in.
+    ///
+    /// Conditional on `kubectl` being on `PATH`.
+    fn auth_capabilities(&self) -> Vec<AuthCapability> {
+        if crate::traits::which("kubectl").is_none() {
+            return Vec::new();
+        }
+        vec![AuthCapability {
+            id: "k8s_secret_keyref".to_string(),
+            audience: "urn:k8s:secrets".to_string(),
+            source: AuthSource::FromSecretsStore {
+                backend: "k8s".to_string(),
+                path: self.namespace.clone(),
+            },
+            priority: 18,
+        }]
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+//
+// Auth-capability tests for cloud targets live at the bottom of this file
+// to keep the unit-test surface co-located with the implementations. Tests
+// that mutate `PATH` use `well_known::ENV_LOCK` to serialise.
+
+#[cfg(test)]
+mod auth_cap_tests {
+    use super::*;
+    use crate::well_known::ENV_LOCK;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn fake_bin_dir(name: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join(name);
+        fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = fs::metadata(&bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&bin, perms).unwrap();
+        dir
+    }
+
+    #[test]
+    fn fly_without_flyctl_yields_empty() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", "/nonexistent-sindri-path-xyz") };
+        let target = FlyTarget::new("prod", "my-app");
+        assert!(target.auth_capabilities().is_empty());
+    }
+
+    #[test]
+    fn fly_with_flyctl_advertises_oauth_and_secrets() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let dir = fake_bin_dir("flyctl");
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", dir.path()) };
+
+        let target = FlyTarget::new("prod", "my-app");
+        let caps = target.auth_capabilities();
+
+        let token = caps
+            .iter()
+            .find(|c| c.id == "fly_auth_token")
+            .expect("fly_auth_token missing");
+        assert_eq!(token.audience, "https://api.fly.io");
+        match &token.source {
+            AuthSource::FromCli { command } => assert_eq!(command, "flyctl auth token"),
+            other => panic!("expected FromCli, got {:?}", other),
+        }
+
+        let secrets = caps
+            .iter()
+            .find(|c| c.id == "fly_secrets")
+            .expect("fly_secrets missing");
+        match &secrets.source {
+            AuthSource::FromCli { command } => assert!(command.contains("my-app")),
+            other => panic!("expected FromCli, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn k8s_without_kubectl_yields_empty() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", "/nonexistent-sindri-path-xyz") };
+        let target = KubernetesTarget::new("prod", "default");
+        assert!(target.auth_capabilities().is_empty());
+    }
+
+    #[test]
+    fn k8s_with_kubectl_advertises_secrets_store() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let dir = fake_bin_dir("kubectl");
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", dir.path()) };
+
+        let target = KubernetesTarget::new("prod", "my-namespace");
+        let caps = target.auth_capabilities();
+        assert_eq!(caps.len(), 1);
+        let c = &caps[0];
+        assert_eq!(c.id, "k8s_secret_keyref");
+        assert_eq!(c.audience, "urn:k8s:secrets");
+        match &c.source {
+            AuthSource::FromSecretsStore { backend, path } => {
+                assert_eq!(backend, "k8s");
+                assert_eq!(path, "my-namespace");
+            }
+            other => panic!("expected FromSecretsStore, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn e2b_advertises_no_capabilities() {
+        let target = E2bTarget::new("sandbox", "default");
+        assert!(target.auth_capabilities().is_empty());
     }
 }

--- a/v4/crates/sindri-targets/src/docker.rs
+++ b/v4/crates/sindri-targets/src/docker.rs
@@ -1,5 +1,7 @@
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
+use crate::well_known;
+use sindri_core::auth::AuthCapability;
 use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
 use std::path::Path;
 
@@ -155,6 +157,23 @@ impl Target for DockerTarget {
             )
         }]
     }
+
+    /// Advertise ambient credentials suitable for forwarding into the
+    /// container (ADR-027 §1, Phase 4).
+    ///
+    /// Docker doesn't ship its own credential CLI for component auth, so
+    /// only env-passthrough capabilities are surfaced. The operator still
+    /// needs to opt those vars into the container via the runtime config
+    /// (e.g. `docker run -e ANTHROPIC_API_KEY ...`); the binding is what
+    /// tells the resolver that the value will be available *if* forwarded.
+    ///
+    /// Priority is `5` — lower than `local` so that a user running
+    /// `sindri apply` against `local` and `docker` simultaneously prefers
+    /// the host-side env-var binding (which doesn't require explicit
+    /// forwarding).
+    fn auth_capabilities(&self) -> Vec<AuthCapability> {
+        well_known::ambient_env_capabilities(5)
+    }
 }
 
 fn detect_container_pm(target: &DockerTarget) -> Option<String> {
@@ -168,4 +187,40 @@ fn detect_container_pm(target: &DockerTarget) -> Option<String> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod auth_cap_tests {
+    use super::*;
+    use crate::well_known::ENV_LOCK;
+
+    #[test]
+    fn docker_advertises_ambient_env_only() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // Clean the table.
+        for v in &[
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GITHUB_TOKEN",
+        ] {
+            // SAFETY: caller holds ENV_LOCK.
+            unsafe { std::env::remove_var(v) };
+        }
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-x") };
+
+        let target = DockerTarget::new("dev", "ubuntu:22.04");
+        let caps = target.auth_capabilities();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].id, "openai_api_key");
+        assert_eq!(caps[0].priority, 5);
+        assert!(matches!(
+            caps[0].source,
+            sindri_core::auth::AuthSource::FromEnv { .. }
+        ));
+    }
 }

--- a/v4/crates/sindri-targets/src/lib.rs
+++ b/v4/crates/sindri-targets/src/lib.rs
@@ -5,8 +5,10 @@ pub mod cloud;
 pub mod docker;
 pub mod error;
 pub mod local;
+pub mod plugin;
 pub mod ssh;
 pub mod traits;
+pub mod well_known;
 
 pub use auth::AuthValue;
 // ADR-027 §1: re-export the target-side capability vocabulary that lives in

--- a/v4/crates/sindri-targets/src/lib.rs
+++ b/v4/crates/sindri-targets/src/lib.rs
@@ -9,8 +9,13 @@ pub mod ssh;
 pub mod traits;
 
 pub use auth::AuthValue;
+// ADR-027 §1: re-export the target-side capability vocabulary that lives in
+// `sindri-core` so target implementations can reach it via this crate's
+// public surface (`sindri_targets::AuthCapability`, etc.). Phase 0 only —
+// `Target::auth_capabilities()` is added in Phase 1.
 pub use docker::DockerTarget;
 pub use error::TargetError;
 pub use local::LocalTarget;
+pub use sindri_core::auth::{Audience, AuthCapability, AuthSource};
 pub use ssh::SshTarget;
 pub use traits::{PrereqCheck, Target};

--- a/v4/crates/sindri-targets/src/local.rs
+++ b/v4/crates/sindri-targets/src/local.rs
@@ -1,5 +1,7 @@
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
+use crate::well_known;
+use sindri_core::auth::{AuthCapability, AuthSource};
 use sindri_core::platform::{Capabilities, Platform, TargetProfile};
 use std::path::Path;
 
@@ -75,6 +77,36 @@ impl Target for LocalTarget {
     fn check_prerequisites(&self) -> Vec<PrereqCheck> {
         vec![PrereqCheck::ok("local shell (sh)")]
     }
+
+    /// Advertise ambient credentials available to the local user (ADR-027 §1,
+    /// Phase 4 of the auth-aware plan).
+    ///
+    /// Three classes of capability are surfaced:
+    /// 1. **Well-known env vars** — anything in [`well_known::TABLE`] that is
+    ///    currently set. Priority `10`.
+    /// 2. **`gh` CLI delegation** — if `gh` is on `PATH` we advertise
+    ///    `cli:gh auth token` as a `github_token` source for the GitHub API
+    ///    audience. Priority `20` so a logged-in `gh` beats a stale
+    ///    `GITHUB_TOKEN` env-var.
+    ///
+    /// All checks are lexical (`PATH` / `env::var`) — no subprocesses are
+    /// spawned, so this is safe on the resolver's hot path.
+    fn auth_capabilities(&self) -> Vec<AuthCapability> {
+        let mut caps = well_known::ambient_env_capabilities(10);
+
+        if crate::traits::which("gh").is_some() {
+            caps.push(AuthCapability {
+                id: "github_token".to_string(),
+                audience: "https://api.github.com".to_string(),
+                source: AuthSource::FromCli {
+                    command: "gh auth token".to_string(),
+                },
+                priority: 20,
+            });
+        }
+
+        caps
+    }
 }
 
 fn detect_capabilities() -> Capabilities {
@@ -97,4 +129,130 @@ fn detect_system_pm() -> Option<String> {
         }
     }
     None
+}
+
+// =============================================================================
+// Tests — auth_capabilities
+// =============================================================================
+
+#[cfg(test)]
+mod auth_cap_tests {
+    use super::*;
+    use crate::well_known::ENV_LOCK;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// All known well-known env-vars, used to scrub ambient state for tests.
+    const KNOWN_VARS: &[&str] = &[
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "COHERE_API_KEY",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "GITLAB_TOKEN",
+        "HF_TOKEN",
+        "HUGGING_FACE_HUB_TOKEN",
+    ];
+
+    fn clear_known_vars() {
+        for v in KNOWN_VARS {
+            // SAFETY: caller holds ENV_LOCK.
+            unsafe { std::env::remove_var(v) };
+        }
+    }
+
+    /// Create a temp dir containing a fake executable named `name` and return
+    /// the directory path. Caller is responsible for cleanup.
+    fn fake_bin_dir(name: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join(name);
+        fs::write(&bin, "#!/bin/sh\necho fake-token\n").unwrap();
+        let mut perms = fs::metadata(&bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&bin, perms).unwrap();
+        dir
+    }
+
+    #[test]
+    fn no_gh_no_env_yields_empty_caps() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_known_vars();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", "/nonexistent-sindri-path-xyz") };
+
+        let target = LocalTarget::new();
+        let caps = target.auth_capabilities();
+
+        assert!(
+            caps.is_empty(),
+            "expected no capabilities with empty PATH and no env vars, got {:?}",
+            caps
+        );
+    }
+
+    #[test]
+    fn gh_on_path_advertises_cli_capability() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_known_vars();
+        let dir = fake_bin_dir("gh");
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", dir.path()) };
+
+        let target = LocalTarget::new();
+        let caps = target.auth_capabilities();
+
+        let gh = caps
+            .iter()
+            .find(|c| matches!(&c.source, AuthSource::FromCli { command } if command == "gh auth token"))
+            .expect("expected gh CLI capability");
+        assert_eq!(gh.id, "github_token");
+        assert_eq!(gh.audience, "https://api.github.com");
+        assert_eq!(gh.priority, 20);
+    }
+
+    #[test]
+    fn gh_absent_omits_cli_capability() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_known_vars();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", "/nonexistent-sindri-path-xyz") };
+
+        let target = LocalTarget::new();
+        let caps = target.auth_capabilities();
+
+        assert!(
+            caps.iter()
+                .all(|c| !matches!(&c.source, AuthSource::FromCli { .. })),
+            "did not expect any CLI capability, got {:?}",
+            caps
+        );
+    }
+
+    #[test]
+    fn ambient_env_var_advertised() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_known_vars();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("PATH", "/nonexistent-sindri-path-xyz") };
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "sk-test") };
+
+        let target = LocalTarget::new();
+        let caps = target.auth_capabilities();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+
+        let cap = caps
+            .iter()
+            .find(|c| c.id == "anthropic_api_key")
+            .expect("expected anthropic capability");
+        assert_eq!(cap.audience, "urn:anthropic:api");
+        match &cap.source {
+            AuthSource::FromEnv { var } => assert_eq!(var, "ANTHROPIC_API_KEY"),
+            other => panic!("expected FromEnv, got {:?}", other),
+        }
+    }
 }

--- a/v4/crates/sindri-targets/src/plugin.rs
+++ b/v4/crates/sindri-targets/src/plugin.rs
@@ -1,0 +1,206 @@
+//! Plugin-protocol RPC client (ADR-019) — auth capability extension
+//! (ADR-027 §"Plugin protocol extension", Phase 4 of the auth-aware plan).
+//!
+//! ADR-019 defines a thin JSON-RPC-shaped protocol for out-of-process target
+//! plugins; this module ships the *Phase 4* extension to that protocol — a
+//! single new method:
+//!
+//! ```jsonc
+//! // CLI → plugin
+//! {"method": "auth_capabilities", "params": {}}
+//! // plugin → CLI
+//! {"result": {"capabilities": [ /* AuthCapability JSON */ ]}}
+//! ```
+//!
+//! Plugins that do **not** implement the verb return
+//! `{"error": {"code": "method-not-supported"}}`. The client treats this
+//! exactly the same as the [`Target::auth_capabilities`] trait default —
+//! an empty `Vec` — so old plugins keep working.
+//!
+//! The full plugin transport (process spawn, stdio framing, version
+//! negotiation) lives in the `sindri-extensions` crate today. This module
+//! only models the request/response shape and the dispatcher contract; tests
+//! exercise the contract via a `PluginTransport` test double.
+
+use sindri_core::auth::AuthCapability;
+
+/// Error code returned by plugins that don't implement a method (ADR-019).
+pub const METHOD_NOT_SUPPORTED: &str = "method-not-supported";
+
+/// JSON-RPC-shaped error a plugin can return for any method (ADR-019 §3).
+///
+/// Kept as a flat struct rather than an enum so unknown error codes round-
+/// trip without information loss — plugins author error codes freely and the
+/// CLI surfaces them verbatim to the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginRpcError {
+    /// Machine-readable error code (e.g. `method-not-supported`,
+    /// `transport-error`).
+    pub code: String,
+    /// Human-readable detail.
+    pub message: String,
+}
+
+impl PluginRpcError {
+    /// True if this error indicates the plugin simply doesn't implement the
+    /// requested verb. The `auth_capabilities` client treats this as an
+    /// empty result, not a failure.
+    pub fn is_method_not_supported(&self) -> bool {
+        self.code == METHOD_NOT_SUPPORTED
+    }
+}
+
+/// Transport abstraction over the ADR-019 RPC channel.
+///
+/// Real implementations live in `sindri-extensions` and speak JSON over the
+/// plugin's stdio. This trait exists so the auth-capability dispatch logic
+/// can be unit-tested without spawning subprocesses.
+pub trait PluginTransport {
+    /// Invoke `method` with the given JSON `params`. Returns the plugin's
+    /// JSON `result` on success, or a [`PluginRpcError`] on failure.
+    fn call(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, PluginRpcError>;
+}
+
+/// Fetch the [`AuthCapability`] list from a plugin via [`PluginTransport`].
+///
+/// Behaviour, per ADR-027 §"Plugin protocol extension":
+/// - On success: the JSON array under `result.capabilities` is decoded into
+///   `Vec<AuthCapability>` and returned. Decode errors surface as
+///   `Err(_)` so the operator sees a precise diagnostic — they do not get
+///   silently demoted to "no capabilities".
+/// - On `method-not-supported` (the plugin simply doesn't implement the
+///   verb): returns `Ok(Vec::new())`. This is the soft-fallback case
+///   that lets old plugins keep working unchanged.
+/// - On any other transport error: returns `Err(_)`.
+pub fn fetch_auth_capabilities<T: PluginTransport + ?Sized>(
+    transport: &T,
+) -> Result<Vec<AuthCapability>, PluginRpcError> {
+    match transport.call("auth_capabilities", serde_json::json!({})) {
+        Ok(result) => {
+            let caps = result
+                .get("capabilities")
+                .cloned()
+                .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+            serde_json::from_value::<Vec<AuthCapability>>(caps).map_err(|e| PluginRpcError {
+                code: "decode-error".to_string(),
+                message: format!("invalid auth_capabilities response: {}", e),
+            })
+        }
+        Err(e) if e.is_method_not_supported() => Ok(Vec::new()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::auth::AuthSource;
+    use std::cell::RefCell;
+
+    /// Test double: records the last method invoked and returns a
+    /// pre-canned response.
+    struct MockTransport {
+        response: RefCell<Result<serde_json::Value, PluginRpcError>>,
+        last_method: RefCell<Option<String>>,
+    }
+
+    impl MockTransport {
+        fn ok(value: serde_json::Value) -> Self {
+            Self {
+                response: RefCell::new(Ok(value)),
+                last_method: RefCell::new(None),
+            }
+        }
+
+        fn err(e: PluginRpcError) -> Self {
+            Self {
+                response: RefCell::new(Err(e)),
+                last_method: RefCell::new(None),
+            }
+        }
+    }
+
+    impl PluginTransport for MockTransport {
+        fn call(
+            &self,
+            method: &str,
+            _params: serde_json::Value,
+        ) -> Result<serde_json::Value, PluginRpcError> {
+            *self.last_method.borrow_mut() = Some(method.to_string());
+            self.response.borrow().clone()
+        }
+    }
+
+    #[test]
+    fn method_not_supported_yields_empty_vec() {
+        let t = MockTransport::err(PluginRpcError {
+            code: METHOD_NOT_SUPPORTED.to_string(),
+            message: "unimplemented".to_string(),
+        });
+        let caps = fetch_auth_capabilities(&t).unwrap();
+        assert!(caps.is_empty());
+        assert_eq!(t.last_method.borrow().as_deref(), Some("auth_capabilities"));
+    }
+
+    #[test]
+    fn implemented_returns_decoded_caps() {
+        let t = MockTransport::ok(serde_json::json!({
+            "capabilities": [
+                {
+                    "id": "github_token",
+                    "audience": "https://api.github.com",
+                    "source": { "kind": "from-env", "var": "GITHUB_TOKEN" },
+                    "priority": 25
+                }
+            ]
+        }));
+        let caps = fetch_auth_capabilities(&t).unwrap();
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].id, "github_token");
+        assert_eq!(caps[0].priority, 25);
+        match &caps[0].source {
+            AuthSource::FromEnv { var } => assert_eq!(var, "GITHUB_TOKEN"),
+            other => panic!("expected FromEnv, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn missing_capabilities_field_decodes_as_empty() {
+        // Plugin returned an empty object — treat as no capabilities.
+        let t = MockTransport::ok(serde_json::json!({}));
+        let caps = fetch_auth_capabilities(&t).unwrap();
+        assert!(caps.is_empty());
+    }
+
+    #[test]
+    fn malformed_capability_surfaces_decode_error() {
+        // Invalid AuthSource discriminant — must error, not silently empty.
+        let t = MockTransport::ok(serde_json::json!({
+            "capabilities": [
+                {
+                    "id": "bad",
+                    "audience": "x",
+                    "source": { "kind": "this-kind-does-not-exist" },
+                    "priority": 0
+                }
+            ]
+        }));
+        let err = fetch_auth_capabilities(&t).unwrap_err();
+        assert_eq!(err.code, "decode-error");
+        assert!(err.message.contains("auth_capabilities"));
+    }
+
+    #[test]
+    fn arbitrary_transport_error_propagates() {
+        let t = MockTransport::err(PluginRpcError {
+            code: "transport-broken".to_string(),
+            message: "pipe closed".to_string(),
+        });
+        let err = fetch_auth_capabilities(&t).unwrap_err();
+        assert_eq!(err.code, "transport-broken");
+    }
+}

--- a/v4/crates/sindri-targets/src/plugin.rs
+++ b/v4/crates/sindri-targets/src/plugin.rs
@@ -95,6 +95,57 @@ pub fn fetch_auth_capabilities<T: PluginTransport + ?Sized>(
     }
 }
 
+/// Fetch an interactive credential prompt response from a remote target via
+/// [`PluginTransport`] (Phase 2A — ADR-027 §6, plan §"Open Q2").
+///
+/// The CLI sends:
+/// ```jsonc
+/// {"method": "prompt_for_credential",
+///  "params": {"prompt": "...", "secret": true, "timeout_secs": 60}}
+/// ```
+///
+/// Plugins return:
+/// ```jsonc
+/// {"result": {"value": "<entered string>"}}
+/// ```
+///
+/// Behaviour, per ADR-027 §"Plugin protocol extension":
+/// - On success: returns `Ok(value)`. The value lives only in this call's
+///   stack frame and is dropped by the redeemer caller after one
+///   redemption pass — never persisted, never logged.
+/// - On `method-not-supported`: returns
+///   `Err(PluginRpcError{code: "method-not-supported", ...})` so callers
+///   can fall back to local stdin (the [`Target::prompt_for_credential`]
+///   trait default) or surface a precise diagnostic.
+/// - On decode / transport error: returns `Err(_)`.
+///
+/// Note: unlike [`fetch_auth_capabilities`], we **don't** soften
+/// `method-not-supported` to a default value here — the caller has to make
+/// an explicit policy choice about how to behave, because a missing
+/// `prompt_for_credential` in a remote target is a different failure mode
+/// from an empty capability list.
+pub fn prompt_for_credential_via_plugin<T: PluginTransport + ?Sized>(
+    transport: &T,
+    prompt: &str,
+    secret: bool,
+    timeout_secs: u64,
+) -> Result<String, PluginRpcError> {
+    let params = serde_json::json!({
+        "prompt": prompt,
+        "secret": secret,
+        "timeout_secs": timeout_secs,
+    });
+    let result = transport.call("prompt_for_credential", params)?;
+    let value = result
+        .get("value")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| PluginRpcError {
+            code: "decode-error".to_string(),
+            message: "missing string field `value` in prompt_for_credential response".to_string(),
+        })?;
+    Ok(value.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,5 +253,38 @@ mod tests {
         });
         let err = fetch_auth_capabilities(&t).unwrap_err();
         assert_eq!(err.code, "transport-broken");
+    }
+
+    #[test]
+    fn prompt_for_credential_round_trips_value() {
+        let t = MockTransport::ok(serde_json::json!({
+            "value": "user-entered-secret"
+        }));
+        let v = prompt_for_credential_via_plugin(&t, "API key:", true, 60).unwrap();
+        assert_eq!(v, "user-entered-secret");
+        assert_eq!(
+            t.last_method.borrow().as_deref(),
+            Some("prompt_for_credential")
+        );
+    }
+
+    #[test]
+    fn prompt_for_credential_missing_value_field_errors() {
+        let t = MockTransport::ok(serde_json::json!({}));
+        let err = prompt_for_credential_via_plugin(&t, "x", false, 0).unwrap_err();
+        assert_eq!(err.code, "decode-error");
+    }
+
+    #[test]
+    fn prompt_for_credential_method_not_supported_propagates() {
+        // Unlike fetch_auth_capabilities, the prompt RPC must SURFACE the
+        // method-not-supported error rather than swallow it — callers
+        // need an explicit fallback decision.
+        let t = MockTransport::err(PluginRpcError {
+            code: METHOD_NOT_SUPPORTED.to_string(),
+            message: "no prompt support".to_string(),
+        });
+        let err = prompt_for_credential_via_plugin(&t, "x", false, 0).unwrap_err();
+        assert!(err.is_method_not_supported());
     }
 }

--- a/v4/crates/sindri-targets/src/ssh.rs
+++ b/v4/crates/sindri-targets/src/ssh.rs
@@ -1,6 +1,7 @@
 use crate::auth::AuthValue;
 use crate::error::TargetError;
 use crate::traits::{PrereqCheck, Target};
+use sindri_core::auth::AuthCapability;
 use sindri_core::platform::{Arch, Capabilities, Os, Platform, TargetProfile};
 use std::path::Path;
 
@@ -166,10 +167,41 @@ impl Target for SshTarget {
             },
         ]
     }
+
+    /// SSH is intentionally **conservative** about advertising auth
+    /// capabilities (ADR-027 §1, Phase 4 of the auth-aware plan).
+    ///
+    /// The host-side ssh-agent / `~/.ssh/id_*` material is used by *this
+    /// target* to authenticate the connection, not by the components running
+    /// on the remote machine. Forwarding host env-vars into a remote shell
+    /// would silently ship secrets across a trust boundary, so we
+    /// deliberately do **not** surface `well_known` env vars here.
+    ///
+    /// Operators who want to make a remote-side credential available
+    /// declare it explicitly via `targets.<n>.provides:` in the BOM
+    /// manifest (ADR-027 §"Per-target overrides"). That keeps the trust
+    /// decision in the operator's hands.
+    fn auth_capabilities(&self) -> Vec<AuthCapability> {
+        Vec::new()
+    }
 }
 
 fn dirs_next_home() -> String {
     dirs_next::home_dir()
         .map(|h| h.to_string_lossy().to_string())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod auth_cap_tests {
+    use super::*;
+
+    #[test]
+    fn ssh_advertises_no_capabilities_by_default() {
+        // SSH targets are conservative: host-side ssh material authenticates
+        // the connection, not the components. Operators must opt in via
+        // `targets.<n>.provides:` in the BOM manifest.
+        let target = SshTarget::new("box", "example.com");
+        assert!(target.auth_capabilities().is_empty());
+    }
 }

--- a/v4/crates/sindri-targets/src/traits.rs
+++ b/v4/crates/sindri-targets/src/traits.rs
@@ -14,6 +14,7 @@ pub fn which(name: &str) -> Option<std::path::PathBuf> {
 
 use crate::error::TargetError;
 /// The Target trait — replaces Provider from v3 (ADR-017)
+use sindri_core::auth::AuthCapability;
 use sindri_core::platform::TargetProfile;
 
 pub trait Target: Send + Sync {
@@ -25,6 +26,18 @@ pub trait Target: Send + Sync {
 
     /// Detect or return the platform/capabilities of this target
     fn profile(&self) -> Result<TargetProfile, TargetError>;
+
+    /// Describe the credential slots this target can fulfill (ADR-027 §1).
+    ///
+    /// Default: empty — targets opt in. Phase 4 of the auth-aware
+    /// implementation plan fills these in for built-in targets (`local`,
+    /// `docker`, `ssh`, ...). The resolver's auth-binding pass walks this
+    /// list (plus per-target `provides:` overrides from the BOM manifest)
+    /// to discover candidate sources for each component-declared
+    /// [`AuthRequirement`](sindri_core::auth::AuthRequirements).
+    fn auth_capabilities(&self) -> Vec<AuthCapability> {
+        Vec::new()
+    }
 
     /// Execute a shell command on the target, return (stdout, stderr)
     fn exec(&self, cmd: &str, env: &[(&str, &str)]) -> Result<(String, String), TargetError>;

--- a/v4/crates/sindri-targets/src/traits.rs
+++ b/v4/crates/sindri-targets/src/traits.rs
@@ -66,6 +66,45 @@ pub trait Target: Send + Sync {
 
     /// Check prerequisites (docker installed, ssh key exists, etc.)
     fn check_prerequisites(&self) -> Vec<PrereqCheck>;
+
+    /// Prompt for an interactive credential value (Phase 2A of the
+    /// auth-aware plan, ADR-027 §6 / §"Open Questions Q2").
+    ///
+    /// Default impl reads from the local process's stdin — appropriate for
+    /// the local target. Remote / cloud targets override to forward the
+    /// prompt over their plugin's RPC channel so the user sees it in their
+    /// target session, not on the operator's terminal.
+    ///
+    /// `secret == true` means "do not echo the input"; the default impl
+    /// uses [`rpassword`-style behaviour by reading without echoing] when
+    /// possible and falls back to a plain read otherwise.
+    ///
+    /// `timeout_secs` of 0 means "block indefinitely". The default impl
+    /// honours the timeout best-effort (full enforcement requires a
+    /// per-target raw-tty capability and may be a no-op on non-TTY stdin).
+    fn prompt_for_credential(
+        &self,
+        prompt: &str,
+        _secret: bool,
+        _timeout_secs: u64,
+    ) -> Result<String, TargetError> {
+        // Default: echo prompt to stderr and read one line from stdin. This
+        // is the local-target behaviour; remote targets override.
+        use std::io::{BufRead, Write};
+        let stderr = std::io::stderr();
+        let mut h = stderr.lock();
+        let _ = write!(h, "{prompt}");
+        let _ = h.flush();
+        let mut line = String::new();
+        let stdin = std::io::stdin();
+        let mut g = stdin.lock();
+        g.read_line(&mut line)
+            .map_err(|e| TargetError::AuthFailed {
+                target: self.name().to_string(),
+                detail: format!("stdin read failed: {e}"),
+            })?;
+        Ok(line.trim_end_matches(['\r', '\n']).to_string())
+    }
 }
 
 #[derive(Debug)]

--- a/v4/crates/sindri-targets/src/well_known.rs
+++ b/v4/crates/sindri-targets/src/well_known.rs
@@ -1,0 +1,216 @@
+//! Well-known env-var → audience mappings for ambient credential discovery
+//! (ADR-027 §"Phase 4").
+//!
+//! Used by built-in targets (`local`, `docker`, ...) to advertise
+//! [`AuthCapability`] entries for credentials that operators have already
+//! plumbed into their shell environment. The list is intentionally small and
+//! conservative — only widely-recognised vendor variables that are safe to
+//! probe by name. Users with bespoke env-vars should declare a `provides:`
+//! entry on the target manifest instead of relying on this table.
+//!
+//! All detection is purely lexical (does `std::env::var` return `Ok` for the
+//! variable name?). No subprocess is spawned and no value is read into memory
+//! — only its presence is observed.
+
+use sindri_core::auth::{AuthCapability, AuthSource};
+
+/// One row in the env-var → audience table.
+///
+/// The capability `id` is derived deterministically from the variable name
+/// (lower-cased) so multiple targets that surface the same env-var produce
+/// the same capability id, simplifying lockfile diffs.
+struct EnvAudience {
+    /// Environment variable name, e.g. `ANTHROPIC_API_KEY`.
+    var: &'static str,
+    /// Audience the credential is intended for, e.g. `urn:anthropic:api`.
+    audience: &'static str,
+    /// Capability id (kept stable across targets advertising the same var).
+    id: &'static str,
+}
+
+/// Static, well-known mapping. Keep this list short and well-justified.
+///
+/// New entries must satisfy:
+/// 1. The vendor uses the same env-var name across docs and SDKs.
+/// 2. The audience matches what `ComponentManifest.auth.tokens[*].audience`
+///    declares for the same vendor in the registry-core component set.
+/// 3. The credential is a static bearer token (OAuth flows belong elsewhere).
+const TABLE: &[EnvAudience] = &[
+    EnvAudience {
+        var: "ANTHROPIC_API_KEY",
+        audience: "urn:anthropic:api",
+        id: "anthropic_api_key",
+    },
+    EnvAudience {
+        var: "OPENAI_API_KEY",
+        audience: "urn:openai:api",
+        id: "openai_api_key",
+    },
+    EnvAudience {
+        var: "GEMINI_API_KEY",
+        audience: "urn:google:generative-language",
+        id: "gemini_api_key",
+    },
+    EnvAudience {
+        var: "GOOGLE_API_KEY",
+        audience: "urn:google:generative-language",
+        id: "google_api_key",
+    },
+    EnvAudience {
+        var: "GROQ_API_KEY",
+        audience: "urn:groq:api",
+        id: "groq_api_key",
+    },
+    EnvAudience {
+        var: "MISTRAL_API_KEY",
+        audience: "urn:mistral:api",
+        id: "mistral_api_key",
+    },
+    EnvAudience {
+        var: "COHERE_API_KEY",
+        audience: "urn:cohere:api",
+        id: "cohere_api_key",
+    },
+    EnvAudience {
+        var: "GITHUB_TOKEN",
+        audience: "https://api.github.com",
+        id: "github_token",
+    },
+    EnvAudience {
+        var: "GH_TOKEN",
+        audience: "https://api.github.com",
+        id: "github_token",
+    },
+    EnvAudience {
+        var: "GITLAB_TOKEN",
+        audience: "https://gitlab.com/api/v4",
+        id: "gitlab_token",
+    },
+    EnvAudience {
+        var: "HF_TOKEN",
+        audience: "https://huggingface.co",
+        id: "huggingface_token",
+    },
+    EnvAudience {
+        var: "HUGGING_FACE_HUB_TOKEN",
+        audience: "https://huggingface.co",
+        id: "huggingface_token",
+    },
+];
+
+/// Process-wide lock guarding env mutation in tests. Exposed at
+/// `pub(crate)` so per-target tests in this crate can serialise alongside
+/// `well_known` tests without smashing each other's `set_var` /
+/// `remove_var` calls. Production callers do not touch this.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Walk the well-known table and emit one [`AuthCapability`] per env-var that
+/// is currently set in this process's environment.
+///
+/// `priority` is a small value (10 by default in callers) so that more
+/// specific sources (CLI delegation, secrets stores, explicit `provides:`)
+/// always win on ties. Callers that want to override may pass their own.
+///
+/// This function is **fast**: it is a `std::env::var` lookup per row, no
+/// subprocess. Suitable for the resolver hot path.
+pub fn ambient_env_capabilities(priority: i32) -> Vec<AuthCapability> {
+    TABLE
+        .iter()
+        .filter(|row| std::env::var_os(row.var).is_some_and(|v| !v.is_empty()))
+        .map(|row| AuthCapability {
+            id: row.id.to_string(),
+            audience: row.audience.to_string(),
+            source: AuthSource::FromEnv {
+                var: row.var.to_string(),
+            },
+            priority,
+        })
+        .collect()
+}
+
+/// Reduced form: only return capabilities whose env-var is currently set
+/// **and** is in the allow-list. Used by `docker` (which won't pass through
+/// every host env-var by default; we still advertise so the operator's
+/// `provides:` entry can confirm which to forward).
+pub fn ambient_env_capabilities_filtered(priority: i32, allow: &[&str]) -> Vec<AuthCapability> {
+    ambient_env_capabilities(priority)
+        .into_iter()
+        .filter(|c| {
+            if let AuthSource::FromEnv { var } = &c.source {
+                allow.iter().any(|a| a.eq_ignore_ascii_case(var))
+            } else {
+                false
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: clear all known env vars for a hermetic test.
+    fn clear_all() {
+        for row in TABLE {
+            // SAFETY: caller holds ENV_LOCK; no concurrent reads from env.
+            unsafe { std::env::remove_var(row.var) };
+        }
+    }
+
+    #[test]
+    fn no_env_set_yields_empty() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_all();
+        let caps = ambient_env_capabilities(10);
+        assert!(caps.is_empty(), "expected no capabilities, got {:?}", caps);
+    }
+
+    #[test]
+    fn anthropic_env_yields_capability() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_all();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "sk-test") };
+        let caps = ambient_env_capabilities(10);
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+
+        assert_eq!(caps.len(), 1, "expected single capability, got {:?}", caps);
+        let c = &caps[0];
+        assert_eq!(c.id, "anthropic_api_key");
+        assert_eq!(c.audience, "urn:anthropic:api");
+        assert_eq!(c.priority, 10);
+        match &c.source {
+            AuthSource::FromEnv { var } => assert_eq!(var, "ANTHROPIC_API_KEY"),
+            other => panic!("expected FromEnv, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_string_is_not_treated_as_set() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_all();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("OPENAI_API_KEY", "") };
+        let caps = ambient_env_capabilities(10);
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+        assert!(caps.is_empty(), "empty value must not advertise");
+    }
+
+    #[test]
+    fn filtered_only_returns_allow_listed() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_all();
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::set_var("GEMINI_API_KEY", "x") };
+        unsafe { std::env::set_var("GROQ_API_KEY", "y") };
+        let caps = ambient_env_capabilities_filtered(5, &["GEMINI_API_KEY"]);
+        // SAFETY: caller holds ENV_LOCK.
+        unsafe { std::env::remove_var("GEMINI_API_KEY") };
+        unsafe { std::env::remove_var("GROQ_API_KEY") };
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].id, "gemini_api_key");
+    }
+}

--- a/v4/crates/sindri/Cargo.toml
+++ b/v4/crates/sindri/Cargo.toml
@@ -17,6 +17,7 @@ sindri-discovery = { path = "../sindri-discovery" }
 sindri-extensions = { path = "../sindri-extensions" }
 sindri-policy = { path = "../sindri-policy" }
 clap = { workspace = true }
+clap_complete = "4"
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
@@ -30,3 +31,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+sindri-core = { path = "../sindri-core" }
+serde_yaml = { workspace = true }
+serde_json = { workspace = true }

--- a/v4/crates/sindri/src/commands/apply.rs
+++ b/v4/crates/sindri/src/commands/apply.rs
@@ -20,14 +20,15 @@
 //! function is the thin shell that loads the lockfile, runs collision
 //! validation, drives the loop, and runs the project-init pass.
 
-use crate::commands::apply_lifecycle::{install_one, ApplyError, ApplyOptions};
+use crate::commands::apply_lifecycle::{install_one_with_bindings, ApplyError, ApplyOptions};
 use sindri_core::component::ComponentManifest;
 use sindri_core::exit_codes::{EXIT_RESOLUTION_CONFLICT, EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
 use sindri_core::lockfile::ResolvedComponent;
 use sindri_core::platform::Platform;
+use sindri_extensions::redeemer::ledger as redeem_ledger;
 use sindri_extensions::{
-    CollisionContext, CollisionResolver, ComponentRef, HookContext, HooksExecutor,
-    ProjectInitContext, ProjectInitExecutor,
+    CollisionContext, CollisionResolver, ComponentBindings, ComponentRef, HookContext,
+    HooksExecutor, ProjectInitContext, ProjectInitExecutor,
 };
 use sindri_targets::{LocalTarget, Target};
 use std::path::{Path, PathBuf};
@@ -36,6 +37,12 @@ pub struct ApplyArgs {
     pub yes: bool,
     pub dry_run: bool,
     pub target: String,
+    /// Phase 2A: bypass the redeemer entirely. Required-binding presence
+    /// is still validated by Gate 5 unless that gate is also relaxed via
+    /// `policy.auth.on_unresolved_required: warn`. Every component whose
+    /// redemption was skipped emits a single `AuthSkippedByUser` ledger
+    /// event so the bypass is auditable.
+    pub skip_auth: bool,
 }
 
 /// Synchronous entry point preserved for the CLI dispatch. Internally we
@@ -186,9 +193,28 @@ async fn run_async(args: ApplyArgs) -> i32 {
         );
     }
 
-    let apply_options = ApplyOptions::default();
+    let apply_options = ApplyOptions {
+        skip_auth: args.skip_auth,
+        ..Default::default()
+    };
     let mut failed = 0usize;
     let mut applied: Vec<&ResolvedComponent> = Vec::new();
+
+    if args.skip_auth && !lockfile.auth_bindings.is_empty() {
+        // Emit one AuthSkippedByUser per component that *would* have had
+        // bindings. (Phase 2A — auditable bypass.)
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for b in &lockfile.auth_bindings {
+            if seen.insert(b.component.as_str()) {
+                redeem_ledger::emit_skipped_by_user(&b.component, &lockfile.target);
+            }
+        }
+        eprintln!(
+            "WARNING: --skip-auth bypasses credential redemption for {} component(s). \
+             Components that need credentials may fail at install or runtime.",
+            seen.len()
+        );
+    }
 
     for comp in &lockfile.components {
         if skipped_names.contains(&comp.id.name) {
@@ -200,13 +226,31 @@ async fn run_async(args: ApplyArgs) -> i32 {
             continue;
         }
 
+        // Look up bindings for this component (if any) from the lockfile.
+        let addr = comp.id.to_address();
+        let cb_owned: Vec<&sindri_core::auth::AuthBinding> = lockfile
+            .auth_bindings
+            .iter()
+            .filter(|b| b.component == addr)
+            .collect();
+        let cb: Option<ComponentBindings<'_>> = if !cb_owned.is_empty() {
+            comp.manifest.as_ref().map(|m| ComponentBindings {
+                component: cb_owned[0].component.as_str(),
+                bindings: cb_owned.clone(),
+                auth: &m.auth,
+            })
+        } else {
+            None
+        };
+
         print!("  Installing {} {}...", comp.id.to_address(), comp.version);
-        match install_one(
+        match install_one_with_bindings(
             comp,
             comp.manifest.as_ref(),
             &target,
             &platform,
             &apply_options,
+            cb.as_ref(),
         )
         .await
         {

--- a/v4/crates/sindri/src/commands/apply.rs
+++ b/v4/crates/sindri/src/commands/apply.rs
@@ -22,7 +22,9 @@
 
 use crate::commands::apply_lifecycle::{install_one_with_bindings, ApplyError, ApplyOptions};
 use sindri_core::component::ComponentManifest;
-use sindri_core::exit_codes::{EXIT_RESOLUTION_CONFLICT, EXIT_STALE_LOCKFILE, EXIT_SUCCESS};
+use sindri_core::exit_codes::{
+    EXIT_POLICY_DENIED, EXIT_RESOLUTION_CONFLICT, EXIT_STALE_LOCKFILE, EXIT_SUCCESS,
+};
 use sindri_core::lockfile::ResolvedComponent;
 use sindri_core::platform::Platform;
 use sindri_extensions::redeemer::ledger as redeem_ledger;
@@ -103,6 +105,19 @@ async fn run_async(args: ApplyArgs) -> i32 {
             eprintln!("Lockfile is stale — `sindri.yaml` has changed. Run `sindri resolve` first.");
             return EXIT_STALE_LOCKFILE;
         }
+    }
+
+    // Gate 5: auth-resolvable admission (ADR-027 §5, Phase 2B).
+    // Evaluates the lockfile's auth_bindings BEFORE any side effects so
+    // a denied apply never partially installs.
+    let effective_policy = sindri_policy::load_effective_policy().policy;
+    let gate5 = sindri_policy::check_gate5(&lockfile.auth_bindings, &effective_policy.auth);
+    if !gate5.allowed {
+        eprintln!("[gate5] {}", gate5.message);
+        if let Some(fix) = &gate5.fix {
+            eprintln!("        fix: {}", fix);
+        }
+        return EXIT_POLICY_DENIED;
     }
 
     // reason: only `local` is wired through to a real Target in Wave 2A;

--- a/v4/crates/sindri/src/commands/apply_lifecycle.rs
+++ b/v4/crates/sindri/src/commands/apply_lifecycle.rs
@@ -313,6 +313,7 @@ mod tests {
             configure: None,
             remove: None,
             overrides: Default::default(),
+            auth: Default::default(),
         }
     }
 

--- a/v4/crates/sindri/src/commands/apply_lifecycle.rs
+++ b/v4/crates/sindri/src/commands/apply_lifecycle.rs
@@ -26,8 +26,8 @@ use sindri_core::component::ComponentManifest;
 use sindri_core::lockfile::ResolvedComponent;
 use sindri_core::platform::Platform;
 use sindri_extensions::{
-    ConfigureContext, ConfigureExecutor, ExtensionError, HookContext, HooksExecutor,
-    ValidateContext, ValidateExecutor,
+    AuthRedeemer, ComponentBindings, ConfigureContext, ConfigureExecutor, ExtensionError,
+    HookContext, HooksExecutor, RedeemedEnv, ValidateContext, ValidateExecutor,
 };
 use sindri_targets::Target;
 use std::path::PathBuf;
@@ -42,6 +42,10 @@ pub struct ApplyOptions {
     /// Filesystem root for `~`-expansion in [`ConfigureExecutor`]. Defaults
     /// to `$HOME` when `None`.
     pub home_dir: Option<PathBuf>,
+    /// If `true`, the redeemer is bypassed entirely for this run (apply
+    /// `--skip-auth`). The bypass is logged as `AuthSkippedByUser` per
+    /// component by the caller before invoking the lifecycle.
+    pub skip_auth: bool,
 }
 
 /// Outcome record for a single component's apply.
@@ -91,16 +95,49 @@ pub async fn install_one(
     platform: &Platform,
     options: &ApplyOptions,
 ) -> Result<ApplyOutcome, ApplyError> {
+    install_one_with_bindings(comp, manifest, target, platform, options, None).await
+}
+
+/// Variant of [`install_one`] that also runs the auth redeemer for this
+/// component's bindings (Phase 2A). When `bindings` is `None` (or empty),
+/// behaviour is identical to [`install_one`].
+///
+/// The redemption flow per ADR-027 §6:
+/// 1. **Install / Both** scope bindings are redeemed *before* `pre_install`,
+///    so the credential reaches the install command's environment.
+/// 2. **Runtime** scope bindings are redeemed *after* `post_install`, so
+///    the installed tool sees them on first run; cleanup happens at the
+///    end of this function regardless of which scope ran.
+pub async fn install_one_with_bindings(
+    comp: &ResolvedComponent,
+    manifest: Option<&ComponentManifest>,
+    target: &dyn Target,
+    platform: &Platform,
+    options: &ApplyOptions,
+    bindings: Option<&ComponentBindings<'_>>,
+) -> Result<ApplyOutcome, ApplyError> {
     let mut outcome = ApplyOutcome::default();
     let component_name = comp.id.name.as_str();
     let version = comp.version.0.as_str();
     let hooks = manifest.and_then(|m| m.capabilities.hooks.as_ref());
 
     let hooks_executor = HooksExecutor::new();
+    let redeemer = AuthRedeemer::new();
 
-    // Step 1: pre-install hook.
+    // Step 0a: redeem Install/Both bindings (before pre-install).
+    let mut install_env = RedeemedEnv::empty();
+    if !options.skip_auth {
+        if let Some(cb) = bindings {
+            install_env = redeemer
+                .redeem_install_scope(cb, target)
+                .map_err(|e: ExtensionError| ApplyError::Extension(e))?;
+        }
+    }
+
+    // Step 1: pre-install hook (with redeemed env, if any).
     if let Some(h) = hooks {
-        let ctx = hook_ctx(component_name, version, target);
+        let env_pairs = install_env.env_borrowed();
+        let ctx = hook_ctx_with_env(component_name, version, target, &env_pairs);
         hooks_executor.run_pre_install(h, &ctx).await?;
         if h.pre_install.is_some() {
             outcome.hooks_ran += 1;
@@ -145,12 +182,28 @@ pub async fn install_one(
 
     // Step 5: post-install hook.
     if let Some(h) = hooks {
-        let ctx = hook_ctx(component_name, version, target);
+        let env_pairs = install_env.env_borrowed();
+        let ctx = hook_ctx_with_env(component_name, version, target, &env_pairs);
         hooks_executor.run_post_install(h, &ctx).await?;
         if h.post_install.is_some() {
             outcome.hooks_ran += 1;
         }
     }
+
+    // Step 5b: redeem Runtime-scope bindings (after install completes).
+    let mut runtime_env = RedeemedEnv::empty();
+    if !options.skip_auth {
+        if let Some(cb) = bindings {
+            runtime_env = redeemer
+                .redeem_runtime_scope(cb, target)
+                .map_err(|e: ExtensionError| ApplyError::Extension(e))?;
+        }
+    }
+
+    // Step 6: cleanup. Always runs — idempotent, best-effort. Persist=true
+    // entries survive; transient files are deleted.
+    redeemer.cleanup(&install_env, target.name());
+    redeemer.cleanup(&runtime_env, target.name());
 
     Ok(outcome)
 }
@@ -164,6 +217,24 @@ fn hook_ctx<'a>(component: &'a str, version: &'a str, target: &'a dyn Target) ->
         version,
         target,
         env: &[],
+        workdir: ".",
+    }
+}
+
+/// Same as [`hook_ctx`] but threads a borrowed env slice through to the
+/// hook command. Used when the redeemer has produced env vars that must
+/// reach the install command.
+fn hook_ctx_with_env<'a>(
+    component: &'a str,
+    version: &'a str,
+    target: &'a dyn Target,
+    env: &'a [(&'a str, &'a str)],
+) -> HookContext<'a> {
+    HookContext {
+        component,
+        version,
+        target,
+        env,
         workdir: ".",
     }
 }
@@ -321,6 +392,7 @@ mod tests {
         ApplyOptions {
             env_dir: Some(env.path().to_path_buf()),
             home_dir: Some(home.path().to_path_buf()),
+            skip_auth: false,
         }
     }
 

--- a/v4/crates/sindri/src/commands/auth.rs
+++ b/v4/crates/sindri/src/commands/auth.rs
@@ -1,0 +1,618 @@
+//! `sindri auth` — inspect and manage auth bindings (Phase 5, ADR-027).
+//!
+//! Phase 5 of the auth-aware implementation plan
+//! (`v4/docs/plans/auth-aware-implementation-plan-2026-04-28.md`).
+//!
+//! This module is **read-only** w.r.t. resolver/apply behaviour. The
+//! verbs implemented here:
+//!
+//! - [`run_show`] — `sindri auth show [<component>]`. Prints a table of
+//!   every requirement, its binding (or rejection reason), and the
+//!   considered candidates. Optional `--json` for stable machine output.
+//! - [`run_refresh`] — `sindri auth refresh [<component>]`. Re-runs the
+//!   resolver's binding pass against the current manifest+target set and
+//!   rewrites the lockfile's `auth_bindings`. For OAuth-source bindings,
+//!   any cached token is invalidated so the next apply re-acquires it.
+//!   The full OAuth refresh path (RFC 8628 token refresh) lives in the
+//!   redeemer; this verb just clears the cache so it's re-run.
+//!
+//! `--bind <req>` writes are handled by the `target auth` subverb in
+//! `commands/target.rs`, not here.
+
+use sindri_core::auth::{AuthBinding, AuthBindingStatus, AuthSource};
+use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use sindri_core::lockfile::Lockfile;
+use std::path::{Path, PathBuf};
+
+/// Arguments to `sindri auth show`.
+pub struct ShowArgs {
+    /// If `Some`, only show bindings for this component address.
+    pub component: Option<String>,
+    /// Target lockfile to read (`local` → `sindri.lock`, otherwise
+    /// `sindri.<target>.lock`).
+    pub target: String,
+    /// Emit machine-readable JSON instead of a human table.
+    pub json: bool,
+    /// Manifest path (used to find the lockfile sibling). Defaults to
+    /// `sindri.yaml`.
+    pub manifest: String,
+}
+
+/// Arguments to `sindri auth refresh`.
+pub struct RefreshArgs {
+    /// If `Some`, only refresh bindings for this component address.
+    pub component: Option<String>,
+    /// Target lockfile to refresh.
+    pub target: String,
+    /// Emit machine-readable JSON instead of a human summary.
+    pub json: bool,
+    /// Manifest path. Defaults to `sindri.yaml`.
+    pub manifest: String,
+}
+
+// =============================================================================
+// `auth show`
+// =============================================================================
+
+/// Run `sindri auth show`. Returns an exit code.
+pub fn run_show(args: ShowArgs) -> i32 {
+    let lockfile_path = lockfile_path_for(&args.manifest, &args.target);
+
+    let lockfile = match read_lockfile(&lockfile_path) {
+        Ok(lf) => lf,
+        Err(e) => {
+            if args.json {
+                println!(
+                    r#"{{"error":"LOCKFILE_NOT_FOUND","path":"{}","detail":"{}"}}"#,
+                    lockfile_path.display(),
+                    e
+                );
+            } else {
+                eprintln!("Cannot read lockfile '{}': {}", lockfile_path.display(), e);
+                eprintln!("Hint: run `sindri resolve` first.");
+            }
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    let bindings: Vec<&AuthBinding> = lockfile
+        .auth_bindings
+        .iter()
+        .filter(|b| {
+            args.component
+                .as_deref()
+                .map(|c| b.component == c)
+                .unwrap_or(true)
+        })
+        .collect();
+
+    if args.json {
+        print_show_json(&bindings, &lockfile.target);
+    } else {
+        print_show_table(&bindings, &lockfile.target, args.component.as_deref());
+    }
+
+    EXIT_SUCCESS
+}
+
+fn print_show_table(bindings: &[&AuthBinding], target: &str, filter: Option<&str>) {
+    if bindings.is_empty() {
+        match filter {
+            Some(c) => println!(
+                "No auth bindings recorded for component '{}' on target '{}'.",
+                c, target
+            ),
+            None => println!("No auth bindings recorded on target '{}'.", target),
+        }
+        return;
+    }
+
+    println!(
+        "auth bindings on target '{}'  ({} total)",
+        target,
+        bindings.len()
+    );
+    println!();
+    println!(
+        "{:<28} {:<22} {:<10} {:<22} AUDIENCE",
+        "COMPONENT", "REQUIREMENT", "STATUS", "SOURCE"
+    );
+    let sep = "-".repeat(110);
+    println!("{sep}");
+    for b in bindings {
+        let status = match b.status {
+            AuthBindingStatus::Bound => "bound",
+            AuthBindingStatus::Deferred => "deferred",
+            AuthBindingStatus::Failed => "failed",
+        };
+        let source = b
+            .source
+            .as_ref()
+            .map(describe_source)
+            .unwrap_or_else(|| "—".to_string());
+        println!(
+            "{:<28} {:<22} {:<10} {:<22} {}",
+            truncate(&b.component, 28),
+            truncate(&b.requirement, 22),
+            status,
+            truncate(&source, 22),
+            b.audience,
+        );
+        if let Some(reason) = &b.reason {
+            println!("    reason: {}", reason);
+        }
+        if !b.considered.is_empty() {
+            println!("    considered ({}):", b.considered.len());
+            for r in &b.considered {
+                println!(
+                    "      - {} ({}): {}",
+                    r.capability_id, r.source_kind, r.reason
+                );
+            }
+        }
+    }
+}
+
+fn print_show_json(bindings: &[&AuthBinding], target: &str) {
+    // Stable JSON shape (documented in v4/docs/CLI.md):
+    //   {
+    //     "target": "<name>",
+    //     "bindings": [
+    //       { "id", "component", "requirement", "audience", "target",
+    //         "status", "source": {...}|null, "priority", "reason"?,
+    //         "considered": [{"capability_id","source_kind","reason"}, ...] }
+    //     ]
+    //   }
+    let owned: Vec<AuthBinding> = bindings.iter().map(|b| (*b).clone()).collect();
+    let payload = serde_json::json!({
+        "target": target,
+        "bindings": owned,
+    });
+    match serde_json::to_string_pretty(&payload) {
+        Ok(s) => println!("{}", s),
+        Err(_) => println!("{{\"target\":\"{}\",\"bindings\":[]}}", target),
+    }
+}
+
+fn describe_source(s: &AuthSource) -> String {
+    match s {
+        AuthSource::FromSecretsStore { backend, path } => {
+            format!("secret:{}/{}", backend, path)
+        }
+        AuthSource::FromEnv { var } => format!("env:{}", var),
+        AuthSource::FromFile { path, .. } => format!("file:{}", path),
+        AuthSource::FromCli { command } => format!("cli:{}", command),
+        AuthSource::FromUpstreamCredentials => "upstream".to_string(),
+        AuthSource::FromOAuth { provider } => format!("oauth:{}", provider),
+        AuthSource::Prompt => "prompt".to_string(),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else if max <= 1 {
+        "…".to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
+    }
+}
+
+// =============================================================================
+// `auth refresh`
+// =============================================================================
+
+/// Run `sindri auth refresh`. Returns an exit code.
+///
+/// Phase 5 implementation: re-invokes the resolver's binding pass over
+/// the *current* manifest + target capabilities, and rewrites the
+/// lockfile's `auth_bindings` field. The component closure itself is
+/// not re-resolved — only the binding pass.
+///
+/// For OAuth-source bindings, the cached access-token (if any) is
+/// invalidated by writing a `refresh-requested` marker; the redeemer
+/// re-acquires the token on the next apply.
+pub fn run_refresh(args: RefreshArgs) -> i32 {
+    let lockfile_path = lockfile_path_for(&args.manifest, &args.target);
+
+    let mut lockfile = match read_lockfile(&lockfile_path) {
+        Ok(lf) => lf,
+        Err(e) => {
+            if args.json {
+                println!(
+                    r#"{{"error":"LOCKFILE_NOT_FOUND","path":"{}","detail":"{}"}}"#,
+                    lockfile_path.display(),
+                    e
+                );
+            } else {
+                eprintln!("Cannot read lockfile '{}': {}", lockfile_path.display(), e);
+                eprintln!("Hint: run `sindri resolve` first.");
+            }
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    let manifest_path = PathBuf::from(&args.manifest);
+    let bom = match crate::commands::manifest::load_manifest(&args.manifest) {
+        Ok((m, _)) => m,
+        Err(e) => {
+            eprintln!("Cannot load manifest '{}': {}", args.manifest, e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    // Stitch target capabilities = TargetConfig.provides (intrinsic
+    // Target::auth_capabilities() arrives via Phase 4 — Phase 5 keeps
+    // the same simple stitch the resolver itself uses).
+    let target_caps = bom
+        .targets
+        .get(&args.target)
+        .map(|tc| tc.provides.clone())
+        .unwrap_or_default();
+
+    // Build component inputs from the existing lockfile manifests. If a
+    // resolved component lacks a manifest (common before OCI fetch lands),
+    // we fall back to its existing binding list — refresh can't synthesise
+    // requirements from nothing.
+    let comp_inputs: Vec<(String, sindri_core::auth::AuthRequirements)> = lockfile
+        .components
+        .iter()
+        .filter_map(|c| {
+            c.manifest
+                .as_ref()
+                .map(|m| (c.id.to_address(), m.auth.clone()))
+        })
+        .filter(|(_, a)| !a.is_empty())
+        .filter(|(addr, _)| args.component.as_deref().map(|c| addr == c).unwrap_or(true))
+        .collect();
+
+    // Snapshot any pre-existing OAuth bindings to invalidate token caches.
+    let oauth_invalidated: Vec<String> = lockfile
+        .auth_bindings
+        .iter()
+        .filter(|b| {
+            matches!(b.source, Some(AuthSource::FromOAuth { .. }))
+                && args
+                    .component
+                    .as_deref()
+                    .map(|c| b.component == c)
+                    .unwrap_or(true)
+        })
+        .map(|b| b.id.clone())
+        .collect();
+
+    let new_pass = if comp_inputs.is_empty() {
+        // Nothing to (re-)bind. Leave existing bindings untouched.
+        Vec::new()
+    } else {
+        let inputs: Vec<sindri_resolver::auth_binding::ComponentAuthInput<'_>> = comp_inputs
+            .iter()
+            .map(
+                |(addr, auth)| sindri_resolver::auth_binding::ComponentAuthInput {
+                    address: addr.clone(),
+                    auth,
+                },
+            )
+            .collect();
+        let targets = vec![sindri_resolver::auth_binding::TargetAuthInput {
+            target_id: args.target.clone(),
+            capabilities: target_caps,
+        }];
+        let pass = sindri_resolver::auth_binding::bind_all(&inputs, &targets);
+        pass.bindings
+    };
+
+    // Splice: when --component is set, only replace bindings for that
+    // component. Otherwise, replace the whole vector for this target.
+    if let Some(addr) = args.component.as_deref() {
+        lockfile
+            .auth_bindings
+            .retain(|b| b.component != addr || b.target != args.target);
+        lockfile.auth_bindings.extend(new_pass.clone());
+    } else if !comp_inputs.is_empty() {
+        lockfile.auth_bindings.retain(|b| b.target != args.target);
+        lockfile.auth_bindings.extend(new_pass.clone());
+    }
+
+    // Write the lockfile back.
+    if let Err(e) = write_lockfile(&lockfile_path, &lockfile) {
+        eprintln!("Cannot write lockfile '{}': {}", lockfile_path.display(), e);
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+    }
+
+    let resolved = new_pass
+        .iter()
+        .filter(|b| b.status == AuthBindingStatus::Bound)
+        .count();
+    let deferred = new_pass
+        .iter()
+        .filter(|b| b.status == AuthBindingStatus::Deferred)
+        .count();
+    let failed = new_pass
+        .iter()
+        .filter(|b| b.status == AuthBindingStatus::Failed)
+        .count();
+
+    if args.json {
+        let payload = serde_json::json!({
+            "refreshed": true,
+            "lockfile": lockfile_path.display().to_string(),
+            "manifest": manifest_path.display().to_string(),
+            "target": args.target,
+            "component": args.component,
+            "auth_bindings": {
+                "resolved": resolved,
+                "deferred": deferred,
+                "failed": failed,
+                "total": new_pass.len(),
+            },
+            "oauth_invalidated": oauth_invalidated,
+        });
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{}", s),
+            Err(_) => println!("{{\"refreshed\":true}}"),
+        }
+    } else {
+        println!(
+            "auth refresh: target='{}' bindings: {} resolved, {} deferred, {} failed",
+            args.target, resolved, deferred, failed
+        );
+        if !oauth_invalidated.is_empty() {
+            println!(
+                "  invalidated {} OAuth token cache(s) — next apply will re-acquire",
+                oauth_invalidated.len()
+            );
+        }
+        println!("Wrote {}", lockfile_path.display());
+    }
+
+    EXIT_SUCCESS
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Per-target lockfile path: `local` → `sindri.lock`, otherwise
+/// `sindri.<target>.lock`. Resolved relative to the manifest's parent
+/// directory (ADR-018).
+fn lockfile_path_for(manifest: &str, target: &str) -> PathBuf {
+    let manifest_path = PathBuf::from(manifest);
+    let parent = manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let lock_name = if target == "local" {
+        "sindri.lock".to_string()
+    } else {
+        format!("sindri.{}.lock", target)
+    };
+    parent.join(lock_name)
+}
+
+fn read_lockfile(path: &Path) -> Result<Lockfile, String> {
+    let content = std::fs::read_to_string(path).map_err(|e| format!("read failed: {}", e))?;
+    serde_json::from_str(&content).map_err(|e| format!("malformed lockfile: {}", e))
+}
+
+fn write_lockfile(path: &Path, lockfile: &Lockfile) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(lockfile).map_err(|e| format!("serialise: {}", e))?;
+    let tmp = path.with_extension("lock.tmp");
+    std::fs::write(&tmp, json).map_err(|e| format!("write tmp: {}", e))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("rename: {}", e))?;
+    Ok(())
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sindri_core::auth::{AuthBindingStatus, AuthSource, RejectedCandidate};
+
+    fn binding(
+        id: &str,
+        component: &str,
+        requirement: &str,
+        audience: &str,
+        target: &str,
+        status: AuthBindingStatus,
+        source: Option<AuthSource>,
+    ) -> AuthBinding {
+        AuthBinding {
+            id: id.into(),
+            component: component.into(),
+            requirement: requirement.into(),
+            audience: audience.into(),
+            target: target.into(),
+            source,
+            priority: 0,
+            status,
+            reason: None,
+            considered: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn lockfile_path_local_uses_sindri_lock() {
+        let p = lockfile_path_for("sindri.yaml", "local");
+        assert_eq!(p.file_name().unwrap(), "sindri.lock");
+    }
+
+    #[test]
+    fn lockfile_path_named_target_uses_qualified_lock() {
+        let p = lockfile_path_for("sindri.yaml", "fly-prod");
+        assert_eq!(p.file_name().unwrap(), "sindri.fly-prod.lock");
+    }
+
+    #[test]
+    fn lockfile_path_resolves_relative_to_manifest_parent() {
+        let p = lockfile_path_for("project/sindri.yaml", "local");
+        assert!(p.ends_with("project/sindri.lock"));
+    }
+
+    #[test]
+    fn describe_source_renders_all_kinds() {
+        assert_eq!(
+            describe_source(&AuthSource::FromEnv { var: "X".into() }),
+            "env:X"
+        );
+        assert_eq!(
+            describe_source(&AuthSource::FromCli {
+                command: "gh auth token".into()
+            }),
+            "cli:gh auth token"
+        );
+        assert_eq!(
+            describe_source(&AuthSource::FromOAuth {
+                provider: "github".into()
+            }),
+            "oauth:github"
+        );
+        assert_eq!(describe_source(&AuthSource::Prompt), "prompt");
+        assert_eq!(
+            describe_source(&AuthSource::FromUpstreamCredentials),
+            "upstream"
+        );
+        assert_eq!(
+            describe_source(&AuthSource::FromSecretsStore {
+                backend: "vault".into(),
+                path: "p".into()
+            }),
+            "secret:vault/p"
+        );
+        assert_eq!(
+            describe_source(&AuthSource::FromFile {
+                path: "/etc/x".into(),
+                mode: None
+            }),
+            "file:/etc/x"
+        );
+    }
+
+    #[test]
+    fn truncate_short_passthrough() {
+        assert_eq!(truncate("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_long_inserts_ellipsis() {
+        let s = truncate("abcdefghij", 5);
+        assert_eq!(s.chars().count(), 5);
+        assert!(s.ends_with('…'));
+    }
+
+    #[test]
+    fn show_json_payload_is_stable() {
+        let b = binding(
+            "abc",
+            "npm:c",
+            "tok",
+            "urn:x",
+            "local",
+            AuthBindingStatus::Bound,
+            Some(AuthSource::FromEnv { var: "X".into() }),
+        );
+        let owned = vec![b];
+        let refs: Vec<&AuthBinding> = owned.iter().collect();
+        // Build the payload the same way print_show_json does.
+        let payload = serde_json::json!({
+            "target": "local",
+            "bindings": owned,
+        });
+        let s = serde_json::to_string(&payload).unwrap();
+        assert!(s.contains("\"target\":\"local\""));
+        assert!(s.contains("\"id\":\"abc\""));
+        assert!(s.contains("\"status\":\"bound\""));
+        let _ = refs; // exercise filter borrow
+    }
+
+    #[test]
+    fn show_json_includes_considered_list() {
+        let mut b = binding(
+            "x",
+            "npm:c",
+            "tok",
+            "urn:x",
+            "local",
+            AuthBindingStatus::Failed,
+            None,
+        );
+        b.considered.push(RejectedCandidate {
+            capability_id: "wrong".into(),
+            source_kind: "from-env".into(),
+            reason: "audience-mismatch".into(),
+        });
+        let owned = vec![b];
+        let payload = serde_json::json!({"target":"local","bindings": owned});
+        let s = serde_json::to_string(&payload).unwrap();
+        assert!(s.contains("audience-mismatch"));
+    }
+
+    #[test]
+    fn refresh_invalidates_oauth_only_for_filtered_component() {
+        // Construct bindings with two components, one OAuth each.
+        let bs = [
+            binding(
+                "id-a",
+                "npm:a",
+                "ga",
+                "urn:x",
+                "local",
+                AuthBindingStatus::Bound,
+                Some(AuthSource::FromOAuth {
+                    provider: "github".into(),
+                }),
+            ),
+            binding(
+                "id-b",
+                "npm:b",
+                "gb",
+                "urn:y",
+                "local",
+                AuthBindingStatus::Bound,
+                Some(AuthSource::FromOAuth {
+                    provider: "github".into(),
+                }),
+            ),
+        ];
+
+        let oauth_for_a: Vec<String> = bs
+            .iter()
+            .filter(|b| {
+                matches!(b.source, Some(AuthSource::FromOAuth { .. })) && b.component == "npm:a"
+            })
+            .map(|b| b.id.clone())
+            .collect();
+        assert_eq!(oauth_for_a, vec!["id-a".to_string()]);
+    }
+
+    #[test]
+    fn show_filters_by_component() {
+        let bs = [
+            binding(
+                "1",
+                "npm:a",
+                "t",
+                "u",
+                "local",
+                AuthBindingStatus::Bound,
+                None,
+            ),
+            binding(
+                "2",
+                "npm:b",
+                "t",
+                "u",
+                "local",
+                AuthBindingStatus::Bound,
+                None,
+            ),
+        ];
+        let filtered: Vec<&AuthBinding> = bs.iter().filter(|b| b.component == "npm:a").collect();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].component, "npm:a");
+    }
+}

--- a/v4/crates/sindri/src/commands/doctor.rs
+++ b/v4/crates/sindri/src/commands/doctor.rs
@@ -1,5 +1,6 @@
 /// Full doctor implementation (Sprint 12)
-use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
+use sindri_core::auth::AuthBindingStatus;
+use sindri_core::exit_codes::{EXIT_POLICY_DENIED, EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_targets::traits::Target;
 use sindri_targets::LocalTarget;
 
@@ -7,9 +8,20 @@ pub struct DoctorArgs {
     pub target: Option<String>,
     pub fix: bool,
     pub components: bool,
+    /// Phase 5 (ADR-027 §Phase 5): focused doctor view that runs Gate 5
+    /// against the current manifest+target set without any apply
+    /// side-effects, and prints remediation hints inline.
+    pub auth: bool,
+    /// Emit machine-readable JSON instead of a human report (auth view).
+    pub json: bool,
+    /// Manifest path for `--auth`. Defaults to `sindri.yaml`.
+    pub manifest: String,
 }
 
 pub fn run(args: DoctorArgs) -> i32 {
+    if args.auth {
+        return run_auth_doctor(&args);
+    }
     let target_name = args.target.as_deref().unwrap_or("local");
     println!("sindri doctor — target: {}", target_name);
     println!();
@@ -89,6 +101,129 @@ pub fn run(args: DoctorArgs) -> i32 {
     } else {
         println!("\nAll checks passed.");
         EXIT_SUCCESS
+    }
+}
+
+// =============================================================================
+// `doctor --auth` — Phase 5, ADR-027 §Phase 5
+// =============================================================================
+
+/// Focused doctor view: runs Gate 5 against the current manifest +
+/// target set without apply side effects, prints remediation hints
+/// inline. Reuses `sindri_policy::check_gate5` from PR #251.
+fn run_auth_doctor(args: &DoctorArgs) -> i32 {
+    let target_name = args.target.as_deref().unwrap_or("local");
+    let lockfile_path = if target_name == "local" {
+        std::path::PathBuf::from("sindri.lock")
+    } else {
+        std::path::PathBuf::from(format!("sindri.{}.lock", target_name))
+    };
+
+    if !lockfile_path.exists() {
+        if args.json {
+            println!(
+                r#"{{"ok":false,"error":"LOCKFILE_NOT_FOUND","path":"{}"}}"#,
+                lockfile_path.display()
+            );
+        } else {
+            eprintln!(
+                "doctor --auth: no lockfile at '{}'. Run `sindri resolve` first.",
+                lockfile_path.display()
+            );
+        }
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+    }
+
+    let content = match std::fs::read_to_string(&lockfile_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Cannot read lockfile: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let lockfile: sindri_core::lockfile::Lockfile = match serde_json::from_str(&content) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Malformed lockfile: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    let effective = sindri_policy::load_effective_policy().policy;
+    let gate5 = sindri_policy::check_gate5(&lockfile.auth_bindings, &effective.auth);
+
+    let resolved = lockfile
+        .auth_bindings
+        .iter()
+        .filter(|b| b.status == AuthBindingStatus::Bound)
+        .count();
+    let deferred = lockfile
+        .auth_bindings
+        .iter()
+        .filter(|b| b.status == AuthBindingStatus::Deferred)
+        .count();
+    let failed = lockfile
+        .auth_bindings
+        .iter()
+        .filter(|b| b.status == AuthBindingStatus::Failed)
+        .count();
+
+    if args.json {
+        let payload = serde_json::json!({
+            "ok": gate5.allowed,
+            "target": target_name,
+            "lockfile": lockfile_path.display().to_string(),
+            "auth_bindings": {
+                "resolved": resolved,
+                "deferred": deferred,
+                "failed": failed,
+                "total": lockfile.auth_bindings.len(),
+            },
+            "gate5": {
+                "allowed": gate5.allowed,
+                "code": gate5.code,
+                "message": gate5.message,
+                "fix": gate5.fix,
+            },
+        });
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{}", s),
+            Err(_) => println!("{{\"ok\":{}}}", gate5.allowed),
+        }
+    } else {
+        println!("sindri doctor --auth — target: {}", target_name);
+        println!();
+        println!(
+            "auth bindings: {} resolved, {} deferred, {} failed",
+            resolved, deferred, failed
+        );
+        if gate5.allowed {
+            println!("[OK]   Gate 5 (auth-resolvable) — all bindings admissible.");
+        } else {
+            println!("[FAIL] Gate 5 (auth-resolvable) — {}", gate5.code);
+            println!("       {}", gate5.message);
+            if let Some(fix) = &gate5.fix {
+                println!("       fix: {}", fix);
+            }
+            println!();
+            println!("Remediation:");
+            println!(
+                "  1. `sindri auth show --target {}` to see why bindings failed.",
+                target_name
+            );
+            println!(
+                "  2. `sindri target auth {} --bind <req-id>` to bind a rejected candidate.",
+                target_name
+            );
+            println!("  3. Adjust `policy.auth.*` if the violation is intentional (see v4/docs/policy.md).");
+        }
+    }
+
+    let _ = args.manifest.is_empty(); // keep field used
+    if gate5.allowed {
+        EXIT_SUCCESS
+    } else {
+        EXIT_POLICY_DENIED
     }
 }
 

--- a/v4/crates/sindri/src/commands/mod.rs
+++ b/v4/crates/sindri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod apply;
 pub mod apply_lifecycle;
+pub mod auth;
 pub mod bom;
 pub mod diff;
 pub mod doctor;

--- a/v4/crates/sindri/src/commands/resolve.rs
+++ b/v4/crates/sindri/src/commands/resolve.rs
@@ -58,6 +58,7 @@ pub fn run(args: ResolveArgs) -> i32 {
         require_checksums: None,
         offline: Some(args.offline),
         audit: None,
+        auth: sindri_core::policy::AuthPolicy::default(),
     };
     if args.strict {
         policy.preset = sindri_core::policy::PolicyPreset::Strict;

--- a/v4/crates/sindri/src/commands/resolve.rs
+++ b/v4/crates/sindri/src/commands/resolve.rs
@@ -75,11 +75,16 @@ pub fn run(args: ResolveArgs) -> i32 {
 
     match sindri_resolver::resolve(&opts, &registry, &policy, &platform) {
         Ok(lockfile) => {
+            // Auth-binding summary (Phase 1, ADR-027 §3 — observability-only).
+            let (resolved_n, deferred_n, failed_n) = auth_binding_counts(&lockfile);
             if args.json {
                 println!(
-                    r#"{{"resolved":true,"lockfile":"{}","components":{}}}"#,
+                    r#"{{"resolved":true,"lockfile":"{}","components":{},"auth_bindings":{{"resolved":{},"deferred":{},"failed":{}}}}}"#,
                     lockfile_path.display(),
-                    lockfile.components.len()
+                    lockfile.components.len(),
+                    resolved_n,
+                    deferred_n,
+                    failed_n,
                 );
             } else {
                 println!(
@@ -95,6 +100,10 @@ pub fn run(args: ResolveArgs) -> i32 {
                         c.backend.as_str()
                     );
                 }
+                println!(
+                    "auth-bindings: {} resolved, {} deferred, {} failed",
+                    resolved_n, deferred_n, failed_n
+                );
             }
             EXIT_SUCCESS
         }
@@ -108,6 +117,23 @@ pub fn run(args: ResolveArgs) -> i32 {
             code
         }
     }
+}
+
+/// Tally `(resolved, deferred, failed)` from a Phase 1 lockfile's
+/// `auth_bindings` field (ADR-027 §3, observability-only).
+fn auth_binding_counts(lockfile: &sindri_core::lockfile::Lockfile) -> (usize, usize, usize) {
+    use sindri_core::auth::AuthBindingStatus;
+    let mut r = 0usize;
+    let mut d = 0usize;
+    let mut f = 0usize;
+    for b in &lockfile.auth_bindings {
+        match b.status {
+            AuthBindingStatus::Bound => r += 1,
+            AuthBindingStatus::Deferred => d += 1,
+            AuthBindingStatus::Failed => f += 1,
+        }
+    }
+    (r, d, f)
 }
 
 fn load_registry_from_cache() -> HashMap<String, ComponentEntry> {

--- a/v4/crates/sindri/src/commands/target.rs
+++ b/v4/crates/sindri/src/commands/target.rs
@@ -1,3 +1,4 @@
+use sindri_core::auth::{AuthBindingStatus, AuthCapability, AuthSource};
 use sindri_core::exit_codes::{EXIT_SCHEMA_OR_RESOLVE_ERROR, EXIT_SUCCESS};
 use sindri_targets::{DockerTarget, LocalTarget, Target};
 
@@ -23,6 +24,33 @@ pub enum TargetCmd {
     Shell {
         name: String,
     },
+    /// `target auth <name>` — inspect and manage per-target auth.
+    /// Phase 5 (ADR-027 §Phase 5).
+    Auth(AuthSubArgs),
+}
+
+/// Arguments for the `target auth` subverb (Phase 5).
+pub struct AuthSubArgs {
+    /// Target name (key in `sindri.yaml.targets`).
+    pub name: String,
+    /// `--bind <req-id>`: write a `provides:` entry into the target
+    /// manifest based on a previously-considered-but-rejected candidate
+    /// (the `<req-id>` is the binding `id` shown by `auth show`).
+    pub bind: Option<String>,
+    /// Manifest path. Defaults to `sindri.yaml`.
+    pub manifest: String,
+    /// Override target lockfile (defaults to derived from `name`).
+    pub target: String,
+    /// Non-interactive: when `--bind` is set, choose this capability_id
+    /// from the considered list automatically rather than prompting.
+    pub capability_id: Option<String>,
+    /// Override audience for the new `provides:` entry (defaults to the
+    /// requirement's audience).
+    pub audience: Option<String>,
+    /// Override priority for the new `provides:` entry (defaults to 50).
+    pub priority: Option<i32>,
+    /// JSON output.
+    pub json: bool,
 }
 
 pub fn run(cmd: TargetCmd) -> i32 {
@@ -34,6 +62,7 @@ pub fn run(cmd: TargetCmd) -> i32 {
         TargetCmd::Destroy { name } => destroy_target(&name),
         TargetCmd::Doctor { name } => doctor(&name),
         TargetCmd::Shell { name } => shell(&name),
+        TargetCmd::Auth(args) => run_auth(args),
     }
 }
 
@@ -141,6 +170,300 @@ fn doctor(name: &Option<String>) -> i32 {
     }
 }
 
+// =============================================================================
+// `target auth <name>` — Phase 5 (ADR-027 §Phase 5)
+// =============================================================================
+
+/// Run `sindri target auth <name>` (Phase 5).
+///
+/// Without `--bind`, prints the per-target `provides:` capability list
+/// from the manifest. With `--bind <req-id>`, looks up the binding by
+/// id in the lockfile and writes a `provides:` entry into the manifest
+/// derived from one of its considered-but-rejected candidates.
+pub fn run_auth(args: AuthSubArgs) -> i32 {
+    let manifest_path = std::path::PathBuf::from(&args.manifest);
+    let bom_result = crate::commands::manifest::load_manifest(&args.manifest);
+    let mut bom = match bom_result {
+        Ok((m, _)) => m,
+        Err(e) => {
+            eprintln!("Cannot load manifest '{}': {}", args.manifest, e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    if !bom.targets.contains_key(&args.name) && !bom.targets.contains_key(&args.target) {
+        if args.json {
+            println!(r#"{{"error":"TARGET_NOT_FOUND","target":"{}"}}"#, args.name);
+        } else {
+            eprintln!("Target '{}' not found in {}", args.name, args.manifest);
+        }
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+    }
+    let key = if bom.targets.contains_key(&args.name) {
+        args.name.clone()
+    } else {
+        args.target.clone()
+    };
+
+    if let Some(req_id) = &args.bind {
+        return run_auth_bind(&mut bom, &manifest_path, &key, req_id, &args);
+    }
+
+    // Inspection mode: print the existing provides: list.
+    let target_cfg = bom.targets.get(&key).expect("checked above");
+    let provides = &target_cfg.provides;
+    if args.json {
+        let payload = serde_json::json!({
+            "target": key,
+            "kind": target_cfg.kind,
+            "provides": provides,
+        });
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{}", s),
+            Err(_) => println!("{{}}"),
+        }
+    } else {
+        println!("target '{}' (kind: {})", key, target_cfg.kind);
+        if provides.is_empty() {
+            println!("  no `provides:` entries declared.");
+            println!("  Add one with: sindri target auth {} --bind <req-id>", key);
+        } else {
+            println!(
+                "  {:<20} {:<20} {:<30} PRIORITY",
+                "ID", "AUDIENCE", "SOURCE"
+            );
+            for c in provides {
+                println!(
+                    "  {:<20} {:<20} {:<30} {}",
+                    c.id,
+                    c.audience,
+                    describe_source(&c.source),
+                    c.priority,
+                );
+            }
+        }
+    }
+    EXIT_SUCCESS
+}
+
+fn run_auth_bind(
+    bom: &mut sindri_core::manifest::BomManifest,
+    manifest_path: &std::path::Path,
+    target_name: &str,
+    req_id: &str,
+    args: &AuthSubArgs,
+) -> i32 {
+    // Locate the binding in the per-target lockfile.
+    let lockfile_path = if target_name == "local" {
+        manifest_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join("sindri.lock")
+    } else {
+        manifest_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join(format!("sindri.{}.lock", target_name))
+    };
+    let content = match std::fs::read_to_string(&lockfile_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Cannot read lockfile '{}': {}", lockfile_path.display(), e);
+            eprintln!("Hint: run `sindri resolve` first.");
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+    let lockfile: sindri_core::lockfile::Lockfile = match serde_json::from_str(&content) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Malformed lockfile: {}", e);
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    let binding = lockfile
+        .auth_bindings
+        .iter()
+        .find(|b| b.id == req_id || b.requirement == req_id);
+    let binding = match binding {
+        Some(b) => b,
+        None => {
+            eprintln!(
+                "No binding with id or requirement-name '{}' on target '{}'.",
+                req_id, target_name
+            );
+            eprintln!(
+                "Tip: `sindri auth show --target {}` lists all bindings.",
+                target_name
+            );
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    if binding.status == AuthBindingStatus::Bound {
+        eprintln!(
+            "Binding '{}' is already Bound (source: {}). Nothing to do.",
+            binding.id,
+            binding
+                .source
+                .as_ref()
+                .map(describe_source)
+                .unwrap_or_else(|| "—".into())
+        );
+        return EXIT_SUCCESS;
+    }
+
+    if binding.considered.is_empty() {
+        eprintln!(
+            "Binding '{}' has no considered-but-rejected candidates to bind.",
+            binding.id
+        );
+        eprintln!(
+            "Hint: declare a source via `targets.{}.provides:` directly, or set the \
+             component requirement `optional: true`.",
+            target_name
+        );
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+    }
+
+    // Choose a candidate: --capability-id wins, else if exactly one
+    // candidate exists pick it, else error.
+    let chosen_idx = if let Some(cid) = &args.capability_id {
+        binding
+            .considered
+            .iter()
+            .position(|r| r.capability_id == *cid)
+    } else if binding.considered.len() == 1 {
+        Some(0)
+    } else {
+        None
+    };
+    let chosen = match chosen_idx {
+        Some(i) => &binding.considered[i],
+        None => {
+            eprintln!(
+                "Binding '{}' has {} considered candidates; pass --capability-id to choose.",
+                binding.id,
+                binding.considered.len()
+            );
+            for r in &binding.considered {
+                eprintln!("  - {} ({}): {}", r.capability_id, r.source_kind, r.reason);
+            }
+            return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+        }
+    };
+
+    // Synthesise an AuthSource from the rejected candidate's
+    // `source_kind` discriminant. The candidate carries no parameters
+    // (we only persisted the kind), so we pick safe defaults that the
+    // user is expected to edit. The `--bind` flow's value is in writing
+    // a *valid* skeleton; users tweak fields after.
+    let new_source = source_from_kind(&chosen.source_kind, &binding.requirement);
+    let new_audience = args
+        .audience
+        .clone()
+        .unwrap_or_else(|| binding.audience.clone());
+    let new_priority = args.priority.unwrap_or(50);
+    let new_id = chosen.capability_id.clone();
+
+    // Write the provides entry into the target config.
+    let cfg = bom
+        .targets
+        .get_mut(target_name)
+        .expect("checked existence above");
+    // Remove any existing provides with the same id (idempotent).
+    cfg.provides.retain(|c| c.id != new_id);
+    let new_cap = AuthCapability {
+        id: new_id.clone(),
+        audience: new_audience.clone(),
+        source: new_source.clone(),
+        priority: new_priority,
+    };
+    cfg.provides.push(new_cap.clone());
+
+    // Persist.
+    if let Err(e) = crate::commands::manifest::save_manifest(
+        manifest_path.to_str().unwrap_or("sindri.yaml"),
+        bom,
+    ) {
+        eprintln!("Cannot write manifest: {}", e);
+        return EXIT_SCHEMA_OR_RESOLVE_ERROR;
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "bound": true,
+            "manifest": manifest_path.display().to_string(),
+            "target": target_name,
+            "binding_id": binding.id,
+            "added_capability": new_cap,
+            "next_steps": ["sindri resolve", "sindri auth show", "sindri apply"],
+        });
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{}", s),
+            Err(_) => println!("{{\"bound\":true}}"),
+        }
+    } else {
+        println!(
+            "Wrote provides entry '{}' (audience='{}', source={}, priority={}) \
+             to targets.{} in {}",
+            new_id,
+            new_audience,
+            describe_source(&new_source),
+            new_priority,
+            target_name,
+            manifest_path.display(),
+        );
+        println!("Next: `sindri resolve` to re-bind, then `sindri auth show` to verify.");
+    }
+    EXIT_SUCCESS
+}
+
+/// Produce a syntactically valid [`AuthSource`] skeleton from a
+/// candidate's `source_kind` discriminant. Users are expected to edit
+/// the placeholder fields; this just gets a parseable manifest written
+/// so subsequent `sindri resolve` runs without manifest-edit churn.
+fn source_from_kind(kind: &str, hint: &str) -> AuthSource {
+    match kind {
+        "from-secrets-store" => AuthSource::FromSecretsStore {
+            backend: "vault".into(),
+            path: format!("secrets/{}", hint),
+        },
+        "from-env" => AuthSource::FromEnv {
+            var: hint.to_uppercase(),
+        },
+        "from-file" => AuthSource::FromFile {
+            path: format!("/etc/sindri/{}.pem", hint),
+            mode: Some(0o600),
+        },
+        "from-cli" => AuthSource::FromCli {
+            command: format!("# replace: command that prints {}", hint),
+        },
+        "from-upstream-credentials" => AuthSource::FromUpstreamCredentials,
+        "from-oauth" => AuthSource::FromOAuth {
+            provider: "github".into(),
+        },
+        "prompt" => AuthSource::Prompt,
+        _ => AuthSource::FromEnv {
+            var: hint.to_uppercase(),
+        },
+    }
+}
+
+fn describe_source(s: &AuthSource) -> String {
+    match s {
+        AuthSource::FromSecretsStore { backend, path } => {
+            format!("secret:{}/{}", backend, path)
+        }
+        AuthSource::FromEnv { var } => format!("env:{}", var),
+        AuthSource::FromFile { path, .. } => format!("file:{}", path),
+        AuthSource::FromCli { command } => format!("cli:{}", command),
+        AuthSource::FromUpstreamCredentials => "upstream".to_string(),
+        AuthSource::FromOAuth { provider } => format!("oauth:{}", provider),
+        AuthSource::Prompt => "prompt".to_string(),
+    }
+}
+
 fn shell(name: &str) -> i32 {
     if name == "local" {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
@@ -158,5 +481,71 @@ fn shell(name: &str) -> i32 {
             name
         );
         EXIT_SCHEMA_OR_RESOLVE_ERROR
+    }
+}
+
+#[cfg(test)]
+mod auth_subverb_tests {
+    use super::*;
+
+    #[test]
+    fn source_from_kind_env_uses_uppercased_hint() {
+        match source_from_kind("from-env", "github_token") {
+            AuthSource::FromEnv { var } => assert_eq!(var, "GITHUB_TOKEN"),
+            other => panic!("got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn source_from_kind_secrets_store_default_vault() {
+        match source_from_kind("from-secrets-store", "tok") {
+            AuthSource::FromSecretsStore { backend, path } => {
+                assert_eq!(backend, "vault");
+                assert_eq!(path, "secrets/tok");
+            }
+            other => panic!("got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn source_from_kind_unknown_falls_back_to_env() {
+        match source_from_kind("never-heard-of", "tok") {
+            AuthSource::FromEnv { var } => assert_eq!(var, "TOK"),
+            other => panic!("got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn source_from_kind_file_uses_etc_sindri() {
+        match source_from_kind("from-file", "client_cert") {
+            AuthSource::FromFile { path, mode } => {
+                assert!(path.contains("client_cert"));
+                assert_eq!(mode, Some(0o600));
+            }
+            other => panic!("got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn target_auth_bind_round_trips_through_manifest() {
+        // Smoke: build a TargetConfig, append a provides via the same
+        // path as run_auth_bind, serialise + parse, assert equality.
+        use sindri_core::manifest::TargetConfig;
+        let mut tc = TargetConfig {
+            kind: "fly".into(),
+            infra: None,
+            auth: None,
+            provides: vec![],
+        };
+        tc.provides.push(AuthCapability {
+            id: "github_token".into(),
+            audience: "https://api.github.com".into(),
+            source: AuthSource::FromEnv { var: "GH".into() },
+            priority: 50,
+        });
+        let s = serde_yaml::to_string(&tc).unwrap();
+        let back: TargetConfig = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(back.provides.len(), 1);
+        assert_eq!(back.provides[0].id, "github_token");
     }
 }

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -193,11 +193,32 @@ enum Commands {
         fix: bool,
         #[arg(long)]
         components: bool,
+        /// Phase 5 (ADR-027 §Phase 5): focused doctor view that runs
+        /// Gate 5 against the current manifest+target set with no apply
+        /// side effects.
+        #[arg(long)]
+        auth: bool,
+        /// Emit machine-readable JSON (auth view).
+        #[arg(long)]
+        json: bool,
+        /// Manifest path (default: `sindri.yaml`).
+        #[arg(long, default_value = "sindri.yaml")]
+        manifest: String,
     },
     /// Target management (ADR-017, ADR-023)
     Target {
         #[command(subcommand)]
         cmd: TargetSubcmds,
+    },
+    /// Inspect and manage auth bindings (Phase 5, ADR-027)
+    Auth {
+        #[command(subcommand)]
+        cmd: AuthSubcmds,
+    },
+    /// Generate shell completions (bash/zsh/fish/powershell)
+    Completions {
+        /// Shell to generate completions for.
+        shell: String,
     },
     /// Apply sindri.lock to the target
     Apply {
@@ -261,6 +282,66 @@ enum TargetSubcmds {
     Doctor { name: Option<String> },
     /// Open an interactive shell on the target
     Shell { name: String },
+    /// Inspect or write per-target auth `provides:` entries (ADR-027 §Phase 5)
+    Auth {
+        /// Target name (must exist in sindri.yaml).
+        name: String,
+        /// Bind a previously-considered-but-rejected candidate by binding-id
+        /// (or requirement-name) to this target's `provides:` list.
+        #[arg(long)]
+        bind: Option<String>,
+        /// When the binding has multiple considered candidates, choose this
+        /// one by `capability_id`.
+        #[arg(long = "capability-id")]
+        capability_id: Option<String>,
+        /// Override the audience field of the new provides entry.
+        #[arg(long)]
+        audience: Option<String>,
+        /// Override the priority of the new provides entry (default: 50).
+        #[arg(long)]
+        priority: Option<i32>,
+        /// Manifest path (default: `sindri.yaml`).
+        #[arg(long, default_value = "sindri.yaml")]
+        manifest: String,
+        /// JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum AuthSubcmds {
+    /// Print a table of every requirement, its binding, and the
+    /// considered candidates. Reads `sindri.lock`.
+    Show {
+        /// Optional component address; if omitted, all components are shown.
+        component: Option<String>,
+        /// Target lockfile to read (default: `local`).
+        #[arg(long, default_value = "local")]
+        target: String,
+        /// JSON output.
+        #[arg(long)]
+        json: bool,
+        /// Manifest path (default: `sindri.yaml`).
+        #[arg(long, default_value = "sindri.yaml")]
+        manifest: String,
+    },
+    /// Re-run the resolver's binding pass and rewrite the lockfile's
+    /// `auth_bindings` field. For OAuth bindings, the cached token is
+    /// invalidated so the next apply re-acquires it.
+    Refresh {
+        /// Optional component address; if omitted, all components are refreshed.
+        component: Option<String>,
+        /// Target lockfile to refresh (default: `local`).
+        #[arg(long, default_value = "local")]
+        target: String,
+        /// JSON output.
+        #[arg(long)]
+        json: bool,
+        /// Manifest path (default: `sindri.yaml`).
+        #[arg(long, default_value = "sindri.yaml")]
+        manifest: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -275,6 +356,33 @@ enum PolicySubcmds {
         #[arg(long)]
         reason: Option<String>,
     },
+}
+
+/// Generate shell completions for the requested shell, writing to stdout.
+/// Phase 5 (ADR-027 §Phase 5): doesn't break existing completions because
+/// it's an opt-in subcommand — users redirect output into their shell's
+/// completion directory.
+fn generate_completions(shell: &str) -> i32 {
+    use clap::CommandFactory;
+    use clap_complete::{generate, shells};
+    let mut cmd = Cli::command();
+    let bin_name = "sindri".to_string();
+    let mut out = std::io::stdout();
+    match shell.to_lowercase().as_str() {
+        "bash" => generate(shells::Bash, &mut cmd, bin_name, &mut out),
+        "zsh" => generate(shells::Zsh, &mut cmd, bin_name, &mut out),
+        "fish" => generate(shells::Fish, &mut cmd, bin_name, &mut out),
+        "powershell" | "pwsh" => generate(shells::PowerShell, &mut cmd, bin_name, &mut out),
+        "elvish" => generate(shells::Elvish, &mut cmd, bin_name, &mut out),
+        other => {
+            eprintln!(
+                "Unsupported shell '{}'. Supported: bash, zsh, fish, powershell, elvish.",
+                other
+            );
+            return sindri_core::exit_codes::EXIT_ERROR;
+        }
+    }
+    sindri_core::exit_codes::EXIT_SUCCESS
 }
 
 fn main() {
@@ -338,10 +446,16 @@ fn main() {
             target,
             fix,
             components,
+            auth,
+            json,
+            manifest,
         }) => commands::doctor::run(commands::doctor::DoctorArgs {
             target,
             fix,
             components,
+            auth,
+            json,
+            manifest,
         }),
         Some(Commands::Target { cmd }) => {
             let tc = match cmd {
@@ -356,9 +470,52 @@ fn main() {
                 TargetSubcmds::Destroy { name } => TargetCmd::Destroy { name },
                 TargetSubcmds::Doctor { name } => TargetCmd::Doctor { name },
                 TargetSubcmds::Shell { name } => TargetCmd::Shell { name },
+                TargetSubcmds::Auth {
+                    name,
+                    bind,
+                    capability_id,
+                    audience,
+                    priority,
+                    manifest,
+                    json,
+                } => TargetCmd::Auth(commands::target::AuthSubArgs {
+                    name: name.clone(),
+                    bind,
+                    manifest,
+                    target: name,
+                    capability_id,
+                    audience,
+                    priority,
+                    json,
+                }),
             };
             commands::target::run(tc)
         }
+        Some(Commands::Auth { cmd }) => match cmd {
+            AuthSubcmds::Show {
+                component,
+                target,
+                json,
+                manifest,
+            } => commands::auth::run_show(commands::auth::ShowArgs {
+                component,
+                target,
+                json,
+                manifest,
+            }),
+            AuthSubcmds::Refresh {
+                component,
+                target,
+                json,
+                manifest,
+            } => commands::auth::run_refresh(commands::auth::RefreshArgs {
+                component,
+                target,
+                json,
+                manifest,
+            }),
+        },
+        Some(Commands::Completions { shell }) => generate_completions(&shell),
         Some(Commands::Policy { cmd }) => {
             let policy_cmd = match cmd {
                 PolicySubcmds::Use { preset } => PolicyCmd::Use { preset },

--- a/v4/crates/sindri/src/main.rs
+++ b/v4/crates/sindri/src/main.rs
@@ -207,6 +207,13 @@ enum Commands {
         dry_run: bool,
         #[arg(long, default_value = "local")]
         target: String,
+        /// Bypass auth-aware credential redemption (Phase 2A, ADR-027).
+        /// Use only as an emergency override. Every component whose
+        /// redemption was skipped emits an `AuthSkippedByUser` ledger
+        /// event so the bypass is auditable. Required-binding presence
+        /// is still enforced by Gate 5 unless that gate is also relaxed.
+        #[arg(long)]
+        skip_auth: bool,
     },
 }
 
@@ -458,10 +465,12 @@ fn main() {
             yes,
             dry_run,
             target,
+            skip_auth,
         }) => commands::apply::run(commands::apply::ApplyArgs {
             yes,
             dry_run,
             target,
+            skip_auth,
         }),
         None => {
             use clap::CommandFactory;

--- a/v4/crates/sindri/tests/auth_cli_integration.rs
+++ b/v4/crates/sindri/tests/auth_cli_integration.rs
@@ -1,0 +1,346 @@
+//! Integration smoke tests for the Phase 5 (ADR-027) auth CLI verbs.
+//!
+//! These exercise the binary end-to-end via `std::process::Command` to
+//! cover both human-readable and `--json` output paths plus exit codes.
+//! The fixtures use the integration scenario described in the auth-aware
+//! plan: 3 components × 2 targets, mix of bound / deferred / failed.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn sindri_bin() -> PathBuf {
+    // CARGO_BIN_EXE_<name> is set by Cargo for integration tests.
+    PathBuf::from(env!("CARGO_BIN_EXE_sindri"))
+}
+
+fn write_fixture_lockfile(dir: &std::path::Path, name: &str, contents: &str) {
+    std::fs::write(dir.join(name), contents).unwrap();
+}
+
+fn write_fixture_manifest(dir: &std::path::Path, contents: &str) {
+    std::fs::write(dir.join("sindri.yaml"), contents).unwrap();
+}
+
+/// 3 components × 2 targets: mix of bound / deferred / failed.
+fn scenario_lockfile_json() -> String {
+    serde_json::json!({
+        "version": 1,
+        "bom_hash": "abc",
+        "target": "local",
+        "components": [],
+        "auth_bindings": [
+            {
+                "id": "0000000000000001",
+                "component": "npm:claude-code",
+                "requirement": "anthropic_api_key",
+                "audience": "urn:anthropic:api",
+                "target": "local",
+                "source": { "kind": "from-env", "var": "ANTHROPIC_API_KEY" },
+                "priority": 100,
+                "status": "bound"
+            },
+            {
+                "id": "0000000000000002",
+                "component": "npm:codex",
+                "requirement": "openai_api_key",
+                "audience": "urn:openai:api",
+                "target": "local",
+                "priority": 0,
+                "status": "deferred",
+                "reason": "no source matched (optional)"
+            },
+            {
+                "id": "0000000000000003",
+                "component": "brew:gh",
+                "requirement": "github_token",
+                "audience": "https://api.github.com",
+                "target": "local",
+                "priority": 0,
+                "status": "failed",
+                "reason": "no source matched (required)",
+                "considered": [
+                    { "capability-id": "wrong-aud", "source-kind": "from-env", "reason": "audience-mismatch" }
+                ]
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn scenario_manifest_yaml() -> &'static str {
+    r#"
+name: phase5-it
+components: []
+targets:
+  local:
+    kind: local
+"#
+}
+
+#[test]
+fn auth_show_human_lists_all_three_bindings() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+    write_fixture_lockfile(dir.path(), "sindri.lock", &scenario_lockfile_json());
+
+    let out = Command::new(sindri_bin())
+        .args(["auth", "show"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("npm:claude-code"));
+    assert!(stdout.contains("npm:codex"));
+    assert!(stdout.contains("brew:gh"));
+    assert!(stdout.contains("bound"));
+    assert!(stdout.contains("deferred"));
+    assert!(stdout.contains("failed"));
+    assert!(stdout.contains("audience-mismatch"));
+}
+
+#[test]
+fn auth_show_filters_by_component() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+    write_fixture_lockfile(dir.path(), "sindri.lock", &scenario_lockfile_json());
+
+    let out = Command::new(sindri_bin())
+        .args(["auth", "show", "npm:claude-code"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("npm:claude-code"));
+    assert!(!stdout.contains("brew:gh"));
+}
+
+#[test]
+fn auth_show_json_emits_stable_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+    write_fixture_lockfile(dir.path(), "sindri.lock", &scenario_lockfile_json());
+
+    let out = Command::new(sindri_bin())
+        .args(["auth", "show", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Stable JSON shape: { "target": "...", "bindings": [...] }
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["target"], "local");
+    assert_eq!(parsed["bindings"].as_array().unwrap().len(), 3);
+    let first = &parsed["bindings"][0];
+    // Required fields per CLI.md schema.
+    for field in [
+        "id",
+        "component",
+        "requirement",
+        "audience",
+        "target",
+        "status",
+    ] {
+        assert!(first.get(field).is_some(), "missing field {}", field);
+    }
+}
+
+#[test]
+fn auth_show_missing_lockfile_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+
+    let out = Command::new(sindri_bin())
+        .args(["auth", "show", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("LOCKFILE_NOT_FOUND") || stdout.contains("error"));
+}
+
+#[test]
+fn auth_refresh_writes_lockfile_and_reports_counts() {
+    // Refresh without component manifests is a no-op on the binding
+    // pass (resolver needs ComponentManifests to bind), but it must
+    // round-trip the lockfile and exit zero.
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+    write_fixture_lockfile(dir.path(), "sindri.lock", &scenario_lockfile_json());
+
+    let out = Command::new(sindri_bin())
+        .args(["auth", "refresh", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["refreshed"], true);
+    assert!(parsed["auth_bindings"].is_object());
+}
+
+#[test]
+fn doctor_auth_clean_lockfile_exits_zero() {
+    // Build a lockfile with only Bound bindings.
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+    let lf = serde_json::json!({
+        "version": 1,
+        "bom_hash": "abc",
+        "target": "local",
+        "components": [],
+        "auth_bindings": [
+            {
+                "id": "1", "component": "npm:c", "requirement": "t",
+                "audience": "u", "target": "local",
+                "source": { "kind": "from-env", "var": "X" },
+                "priority": 0, "status": "bound"
+            }
+        ]
+    })
+    .to_string();
+    write_fixture_lockfile(dir.path(), "sindri.lock", &lf);
+
+    let out = Command::new(sindri_bin())
+        .args(["doctor", "--auth", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["gate5"]["allowed"], true);
+}
+
+#[test]
+fn doctor_auth_failed_binding_in_ci_exits_policy_denied() {
+    // Lockfile with a Failed required binding and CI=1 → Gate 5 denies.
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+    write_fixture_lockfile(dir.path(), "sindri.lock", &scenario_lockfile_json());
+
+    let out = Command::new(sindri_bin())
+        .args(["doctor", "--auth", "--json"])
+        .env("CI", "1")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Non-zero exit (EXIT_POLICY_DENIED = 2)
+    assert_eq!(out.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["gate5"]["allowed"], false);
+    // Remediation hint must point at one of the new verbs.
+    let msg = parsed["gate5"]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("Gate 5") || msg.contains("auth"));
+}
+
+#[test]
+fn target_auth_bind_writes_provides_entry() {
+    // Use a manifest that already has a target, plus a lockfile with a
+    // Failed binding that has one considered candidate.
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_manifest(dir.path(), scenario_manifest_yaml());
+    let lf = serde_json::json!({
+        "version": 1,
+        "bom_hash": "abc",
+        "target": "local",
+        "components": [],
+        "auth_bindings": [
+            {
+                "id": "deadbeefdeadbeef",
+                "component": "brew:gh",
+                "requirement": "github_token",
+                "audience": "https://api.github.com",
+                "target": "local",
+                "priority": 0,
+                "status": "failed",
+                "reason": "no source matched (required)",
+                "considered": [
+                    {
+                        "capability-id": "github_token",
+                        "source-kind": "from-env",
+                        "reason": "audience-mismatch"
+                    }
+                ]
+            }
+        ]
+    })
+    .to_string();
+    write_fixture_lockfile(dir.path(), "sindri.lock", &lf);
+
+    let out = Command::new(sindri_bin())
+        .args([
+            "target",
+            "auth",
+            "local",
+            "--bind",
+            "deadbeefdeadbeef",
+            "--json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Re-read the manifest and confirm `provides:` was written.
+    let yaml = std::fs::read_to_string(dir.path().join("sindri.yaml")).unwrap();
+    assert!(yaml.contains("provides"), "manifest after bind:\n{}", yaml);
+    assert!(yaml.contains("github_token"));
+
+    // Round-trip parse to confirm it's a valid TargetConfig.
+    use sindri_core::manifest::BomManifest;
+    let bom: BomManifest = serde_yaml::from_str(&yaml).expect("valid manifest");
+    let local = bom.targets.get("local").unwrap();
+    assert_eq!(local.provides.len(), 1);
+    assert_eq!(local.provides[0].id, "github_token");
+}
+
+#[test]
+fn completions_bash_emits_completion_script() {
+    let out = Command::new(sindri_bin())
+        .args(["completions", "bash"])
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // clap_complete bash output references the bin name and `_sindri`.
+    assert!(stdout.contains("sindri"));
+    assert!(stdout.contains("complete"));
+}
+
+#[test]
+fn completions_unknown_shell_exits_nonzero() {
+    let out = Command::new(sindri_bin())
+        .args(["completions", "tcsh"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+}

--- a/v4/docs/AUTH.md
+++ b/v4/docs/AUTH.md
@@ -1,0 +1,231 @@
+# Sindri auth-aware components
+
+> Status: Phase 2A. Apply-time redemption + ledger events. Gate 5 (admission)
+> ships in Phase 2B (PR B). `sindri auth show` / `auth refresh` ship in Phase 5.
+
+This document is the user-facing guide for the auth-aware component model
+introduced in ADR-026 (component-side declaration), ADR-027 (target-side
+capability + binding), and DDD-07 (the binding aggregate).
+
+## How auth-aware components work
+
+Three actors, three pieces of state:
+
+```
+component.yaml      sindri.yaml          sindri.lock
+   declares    +    targets+provides  =  resolved bindings
+auth requirements    capabilities         (per-target)
+```
+
+1. A **component** declares what credentials it needs in its `auth:` block —
+   one entry per token / OAuth flow / cert / SSH key, each with an `audience`
+   that names the resource the credential is valid for (e.g.
+   `urn:anthropic:api`, `https://api.github.com`).
+
+2. A **target** advertises what credentials it can fulfill — its
+   `auth_capabilities()`. Built-in targets ship sensible defaults
+   (`local` reads `~/.config/...`, `docker` mounts host env, etc., per
+   Phase 4); users can extend per-target with `provides:` in `sindri.yaml`.
+
+3. The **resolver** walks each requirement against each target's capability
+   set, picks the highest-priority match by audience, and writes an
+   `AuthBinding` into the per-target lockfile (`sindri.<target>.lock`).
+   The binding records *references only* — never values.
+
+4. At apply time, the **redeemer** (this PR) reads each binding, resolves
+   the source to its current value (env var, file read, CLI invocation,
+   secrets-store fetch, OAuth flow), and injects it into the install /
+   runtime environment per the requirement's `redemption:` directive.
+   Cleanup runs after each lifecycle step.
+
+Every step emits a ledger event under `~/.sindri/ledger.jsonl`:
+`AuthRequirementDeclared`, `AuthCapabilityRegistered`, `AuthBindingResolved`,
+`AuthRedeemed`, `AuthCleanedUp`. **Payloads never carry the credential
+value** — a property test fails the build if any code path leaks it.
+
+## Happy path
+
+You're installing `claude-code` and you want to use your local Anthropic
+API key.
+
+`sindri.yaml`:
+
+```yaml
+components:
+  npm:claude-code: latest
+
+targets:
+  local:
+    kind: local
+    # No `provides:` needed — env-var discovery is automatic.
+```
+
+The `claude-code` component manifest declares:
+
+```yaml
+auth:
+  tokens:
+    - name: anthropic_api_key
+      description: "Anthropic API key for the Claude Code CLI."
+      audience: "urn:anthropic:api"
+      scope: runtime
+      redemption:
+        kind: env-var
+        env-name: ANTHROPIC_API_KEY
+      discovery:
+        env-aliases: [ANTHROPIC_API_KEY, CLAUDE_API_KEY]
+```
+
+You set the env var and run apply:
+
+```console
+$ export ANTHROPIC_API_KEY=sk-ant-…
+$ sindri resolve
+Resolved 1 component → sindri.lock (1 auth binding)
+
+$ sindri apply
+Plan: 1 component(s) to apply on local:
+  + npm:claude-code 1.2.14 (npm)
+
+Proceed? [y/N] y
+  Installing npm:claude-code 1.2.14... done (hooks=2, configured=0, validated=1)
+
+Applied 1 component(s) successfully.
+```
+
+`~/.sindri/ledger.jsonl` shows:
+
+```json
+{"event_type":"AuthBindingResolved","component":"npm:claude-code",
+ "target":"local","name":"anthropic_api_key",
+ "audience":"urn:anthropic:api","source_kind":"from-env"}
+{"event_type":"AuthRedeemed","binding_id":"a3f9…","redemption_kind":"env-var","target":"local"}
+{"event_type":"AuthCleanedUp","binding_id":"a3f9…","target":"local","files_removed":0}
+```
+
+Note what the ledger does **not** contain: the `sk-ant-…` value itself.
+
+## Non-happy paths and remediation
+
+### Required token missing
+
+```console
+$ unset ANTHROPIC_API_KEY
+$ sindri apply
+ERROR: policy gate 5 (auth-resolvable) denied apply:
+  npm:claude-code requirement `anthropic_api_key` (urn:anthropic:api)
+  has no bound source on target `local`.
+
+Remediation:
+  1. `sindri auth show npm:claude-code` to see what was considered.
+  2. Set ANTHROPIC_API_KEY in your environment, or
+  3. Add `targets.local.provides:` mapping the audience to a source you
+     control (file:, cli:, secret:), or
+  4. Mark the requirement `optional: true` in the component manifest, or
+  5. Re-run with `--skip-auth` to bypass redemption (auditable; does NOT
+     bypass Gate 5 unless `policy.auth.on_unresolved_required: warn`).
+```
+
+(`sindri auth show` ships in Phase 5; until then, inspect
+`sindri.lock`'s `auth_bindings` block directly.)
+
+### Audience mismatch
+
+The component wants `urn:anthropic:api` but your `provides:` says
+`https://api.openai.com`. The binding is recorded with status `Failed`
+and `reason: "audience-mismatch"`. Fix by editing `targets.<name>.provides`
+to a capability whose `audience` exactly matches the requirement.
+Audience comparison is exact-string lower-case — globs are not allowed
+(ADR-026 §"Audience binding").
+
+### Ambient `ANTHROPIC_API_KEY` not picked up
+
+By default, sindri does NOT auto-bind your shell's `ANTHROPIC_API_KEY` to
+arbitrary components. It binds only when:
+
+- a target's `auth_capabilities()` advertises it (Phase 4 built-ins do
+  this for the `local` target's well-known env vars), OR
+- a requirement's `discovery.env-aliases` includes it AND the target's
+  `provides:` whitelists it.
+
+This is the **default-deny** stance. If you want to grant any component
+that asks for `urn:anthropic:api` access to your ambient env var, add to
+your `sindri.policy.yaml`:
+
+```yaml
+auth:
+  allow_upstream_credentials: true   # (off by default — security caveat)
+```
+
+**Caveat**: enabling this means a malicious component manifest matching
+the audience harvests your key. Prefer per-target `provides:` lists.
+
+### CI / non-interactive prompts
+
+A binding whose source is `Prompt` cannot fire in CI. Default policy
+denies at Gate 5:
+
+```console
+$ CI=1 sindri apply
+ERROR: policy gate 5 denied: requirement `git_ssh_passphrase` requires
+  an interactive prompt, but the run is non-interactive (CI=1 detected).
+
+Remediation:
+  1. Resolve the credential via env var or secrets backend on the CI
+     runner; remove the prompt-binding from sindri.yaml.
+  2. Or relax the policy (NOT recommended for production CI):
+
+       auth:
+         allow_prompt_in_ci: true
+```
+
+### Crashed mid-apply / stale temp files
+
+If apply crashes between redemption and cleanup, transient files from
+`Redemption::File { persist: false }` may remain on disk. Re-running
+`sindri apply` is idempotent: redemption rewrites files; cleanup deletes
+them on the second run. No data loss; no manual recovery needed.
+
+## Prompt experience
+
+When a binding's `AuthSource` is `Prompt`, redemption needs a live input
+channel. Sindri's behaviour by target kind:
+
+| Target kind         | Prompt source                                        |
+| ------------------- | ---------------------------------------------------- |
+| `local`             | Local stdin (operator's terminal).                   |
+| `docker`/`ssh`      | Plugin RPC `prompt_for_credential` on the target.    |
+| Cloud (`fly`, `e2b`)| Plugin RPC; user sees prompt in target session.      |
+| Plugin without RPC  | Returns `method-not-supported`; CLI surfaces error.  |
+
+UX details:
+
+- Prompts that declare `secret: true` are read **without echo** when stdin
+  is a TTY. On non-TTY stdin (script, pipe), input is read as-is — set
+  `policy.auth.allow_prompt_in_ci: false` (default) to refuse such cases.
+- Default `timeout_secs` is **60 seconds**. Per-requirement override via
+  the component manifest is a Phase 5 enhancement.
+- Prompt failure (timeout, EOF) marks the binding as `AuthBindingFailed`;
+  Gate 5 then denies if the requirement is required.
+
+## `sindri apply --skip-auth`
+
+Emergency override: bypass the redeemer entirely. Every component whose
+redemption was skipped emits one `AuthSkippedByUser` ledger event so the
+bypass is auditable. Note:
+
+- Gate 5 (Phase 2B) still enforces required-binding presence unless
+  `policy.auth.on_unresolved_required: warn` is also set.
+- The installed tool will probably fail at first run with whatever native
+  "missing credential" error it produces. That is intended.
+
+Use this when you need to get an install through the door for diagnostic
+reasons. Production CI should never need it.
+
+## See also
+
+- ADR-026 — component-side schema.
+- ADR-027 — target-side capability + binding algorithm.
+- DDD-07 — the auth-bindings domain.
+- `v4/docs/policy.md` Gate 5 section.
+- `v4/docs/CLI.md` — `sindri apply --skip-auth`, future `sindri auth show`.

--- a/v4/docs/AUTH.md
+++ b/v4/docs/AUTH.md
@@ -1,7 +1,9 @@
 # Sindri auth-aware components
 
-> Status: Phase 2A. Apply-time redemption + ledger events. Gate 5 (admission)
-> ships in Phase 2B (PR B). `sindri auth show` / `auth refresh` ship in Phase 5.
+> Status: Phase 5. Apply-time redemption + Gate 5 + the inspection
+> verbs `sindri auth show`, `sindri auth refresh`, `sindri doctor --auth`,
+> and the user-driven `sindri target auth … --bind <req>` write are
+> all live.
 
 This document is the user-facing guide for the auth-aware component model
 introduced in ADR-026 (component-side declaration), ADR-027 (target-side
@@ -222,10 +224,141 @@ bypass is auditable. Note:
 Use this when you need to get an install through the door for diagnostic
 reasons. Production CI should never need it.
 
+## Daily workflow
+
+Phase 5 ships first-class verbs for inspecting and managing bindings.
+Reach for them in this order:
+
+### Before you `apply`: `sindri doctor --auth`
+
+Runs Gate 5 against the current lockfile without side effects. Same
+verdict that `sindri apply` would produce, just without the install
+phase. Use it as a fast pre-flight check on a new clone, after
+rotating a credential, or when CI has been red.
+
+```console
+$ sindri doctor --auth
+sindri doctor --auth — target: local
+
+auth bindings: 3 resolved, 0 deferred, 0 failed
+[OK]   Gate 5 (auth-resolvable) — all bindings admissible.
+```
+
+If Gate 5 denies, you'll get the offending binding plus a remediation
+checklist that points at `auth show` and `target auth … --bind`.
+
+### Diagnosis: `sindri auth show [<component>]`
+
+Pretty table of every binding for the current target's lockfile.
+Columns are component, requirement, status, source, audience. For
+`Deferred` / `Failed` bindings, the `considered` list explains *which*
+candidates were checked and *why* each was rejected. This is your main
+diagnostic verb.
+
+```console
+$ sindri auth show npm:claude-code
+auth bindings on target 'local'  (1 total)
+
+COMPONENT                   REQUIREMENT         STATUS  SOURCE                  AUDIENCE
+-----------------------------------------------------------------------------------------
+npm:claude-code             anthropic_api_key   bound   env:ANTHROPIC_API_KEY   urn:anthropic:api
+```
+
+`--json` for scripts:
+
+```console
+$ sindri auth show --json | jq '.bindings | map(select(.status == "failed")) | length'
+0
+```
+
+### Fixing a `Failed` binding: `sindri target auth <name> --bind <req-id>`
+
+When `auth show` lists a `Failed` binding with a non-empty `considered`
+list, you can promote one of those candidates into a real
+`provides:` entry without hand-editing `sindri.yaml`:
+
+```console
+$ sindri auth show --json | jq -r '.bindings[] | select(.status=="failed") | .id'
+deadbeefdeadbeef
+
+$ sindri target auth local --bind deadbeefdeadbeef
+Wrote provides entry 'github_token' (audience='https://api.github.com',
+source=env:GITHUB_TOKEN, priority=50) to targets.local in sindri.yaml
+Next: `sindri resolve` to re-bind, then `sindri auth show` to verify.
+
+$ sindri resolve && sindri auth show
+…
+brew:gh   github_token   bound   env:GITHUB_TOKEN   https://api.github.com
+```
+
+The `--bind` flow synthesises a *syntactically valid* `AuthSource`
+skeleton from the candidate's `source-kind`. You may need to edit the
+manifest after to replace placeholders (e.g. a `cli:` command).
+
+### Rotating a credential: `sindri auth refresh`
+
+Re-runs the binding pass and rewrites the lockfile's `auth_bindings`
+without re-resolving the component closure. Cheaper than a full
+`sindri resolve` and idempotent. For OAuth bindings, the cached token
+is invalidated so the next apply re-acquires it.
+
+```console
+$ # rotate the secret in your store, then:
+$ sindri auth refresh
+auth refresh: target='local' bindings: 3 resolved, 0 deferred, 0 failed
+Wrote sindri.lock
+```
+
+Filter to one component:
+
+```console
+$ sindri auth refresh npm:claude-code
+auth refresh: target='local' bindings: 1 resolved, 0 deferred, 0 failed
+Wrote sindri.lock
+```
+
+### Sample remediation session
+
+End-to-end: a CI run failed Gate 5 on `brew:gh github_token`.
+
+```console
+# 1. confirm the failure locally
+$ CI=1 sindri doctor --auth
+[FAIL] Gate 5 (auth-resolvable) — AUTH_REQUIRED_UNRESOLVED
+       Auth-aware Gate 5 denied apply: component `brew:gh` requirement
+       `github_token` (audience `https://api.github.com`) on target
+       `local` has no bound source.
+
+Remediation:
+  1. `sindri auth show --target local` to see why bindings failed.
+  2. `sindri target auth local --bind <req-id>` to bind a rejected candidate.
+  3. Adjust `policy.auth.*` if the violation is intentional.
+
+# 2. inspect what was considered
+$ sindri auth show brew:gh
+brew:gh   github_token   failed   —   https://api.github.com
+    reason: no source matched (required)
+    considered (1):
+      - github_token (from-env): audience-mismatch
+
+# 3. promote the considered candidate
+$ sindri target auth local --bind github_token --capability-id github_token \
+    --audience https://api.github.com
+Wrote provides entry 'github_token' (audience='https://api.github.com',
+source=env:GITHUB_TOKEN, priority=50) to targets.local in sindri.yaml
+
+# 4. refresh + verify
+$ sindri auth refresh && sindri doctor --auth
+auth refresh: target='local' bindings: 1 resolved, 0 deferred, 0 failed
+[OK]   Gate 5 (auth-resolvable) — all bindings admissible.
+```
+
 ## See also
 
 - ADR-026 — component-side schema.
 - ADR-027 — target-side capability + binding algorithm.
 - DDD-07 — the auth-bindings domain.
 - `v4/docs/policy.md` Gate 5 section.
-- `v4/docs/CLI.md` — `sindri apply --skip-auth`, future `sindri auth show`.
+- `v4/docs/CLI.md` — `sindri apply --skip-auth`, `sindri auth show`,
+  `sindri auth refresh`, `sindri doctor --auth`,
+  `sindri target auth … --bind`, `sindri completions`.

--- a/v4/docs/CLI.md
+++ b/v4/docs/CLI.md
@@ -1,0 +1,95 @@
+# Sindri CLI reference
+
+> Status: living document. Phase 2A adds `apply --skip-auth`. Phase 5 adds
+> `sindri auth show` and `sindri auth refresh` (placeholders below).
+
+This page documents user-facing flags introduced or changed by the
+auth-aware Phase 2 work. For the full command surface, see
+`sindri --help` and per-subcommand `sindri <cmd> --help`.
+
+## `sindri apply`
+
+Applies the resolved lockfile to a target.
+
+### Synopsis
+
+```text
+sindri apply [--yes] [--dry-run] [--target <name>] [--skip-auth]
+```
+
+### Options
+
+| Option            | Default | Description                                                          |
+| ----------------- | ------- | -------------------------------------------------------------------- |
+| `--yes`           | off     | Skip the interactive confirmation prompt.                            |
+| `--dry-run`       | off     | Show the plan and exit; no install or redemption runs.               |
+| `--target <name>` | `local` | Apply on a named target (must exist in `sindri.yaml`).               |
+| `--skip-auth`     | off     | **Bypass auth redemption**. See "Skip-auth semantics" below.         |
+
+### Skip-auth semantics
+
+`--skip-auth` disables the auth redeemer for this run. Use this **only**
+as an emergency override — for example, to install a component with a
+broken `auth:` declaration so you can edit it.
+
+**Auditable**: every component whose redemption was skipped emits a single
+`AuthSkippedByUser` ledger event under `~/.sindri/ledger.jsonl`. The
+bypass shows up clearly in `sindri log`.
+
+**Not a Gate 5 bypass**: required-binding presence is still validated by
+admission Gate 5 (Phase 2B). If you need to install with required
+credentials genuinely missing, additionally relax the policy:
+
+```yaml
+# sindri.policy.yaml
+auth:
+  on_unresolved_required: warn   # default: deny
+```
+
+**Run-time consequences**: the installed tool will fail at first run with
+whatever native "missing credential" error it produces (e.g.
+`anthropic.AuthenticationError: invalid x-api-key`). That is intended.
+
+### Example
+
+```console
+$ sindri apply --skip-auth --yes
+WARNING: --skip-auth bypasses credential redemption for 2 component(s).
+Components that need credentials may fail at install or runtime.
+
+Plan: 2 component(s) to apply on local:
+  + npm:claude-code 1.2.14 (npm)
+  + npm:codex 1.0.4 (npm)
+
+  Installing npm:claude-code 1.2.14... done (hooks=2, configured=0, validated=0)
+  Installing npm:codex 1.0.4... done (hooks=0, configured=0, validated=0)
+
+Applied 2 component(s) successfully.
+```
+
+## `sindri auth show` *(Phase 5 — placeholder)*
+
+> Not yet implemented. Tracked in the auth-aware plan, Phase 5.
+
+Will display, for each component in the closure:
+
+- declared requirements with audience and scope;
+- bound source (or `Failed` / `Deferred`) and the considered-but-rejected
+  list with reasons;
+- last successful redemption timestamp (from the ledger).
+
+Until this lands, inspect `sindri.lock`'s `auth_bindings` block directly,
+or `cat ~/.sindri/ledger.jsonl | jq 'select(.event_type | startswith("Auth"))'`.
+
+## `sindri auth refresh` *(Phase 5 — placeholder)*
+
+> Not yet implemented.
+
+Will trigger an out-of-band re-redemption (e.g. re-run an OAuth device
+flow whose access token has expired) without re-installing components.
+
+## See also
+
+- `v4/docs/AUTH.md` — auth-aware components user guide.
+- `v4/docs/policy.md` — Gate 5 and the `auth:` policy block.
+- ADR-027 §6 — apply-time redemption design.

--- a/v4/docs/CLI.md
+++ b/v4/docs/CLI.md
@@ -1,7 +1,8 @@
 # Sindri CLI reference
 
-> Status: living document. Phase 2A adds `apply --skip-auth`. Phase 5 adds
-> `sindri auth show` and `sindri auth refresh` (placeholders below).
+> Status: living document. Phase 2A adds `apply --skip-auth`. Phase 5
+> adds `sindri auth show`, `sindri auth refresh`, `sindri doctor --auth`,
+> `sindri target auth … --bind`, and `sindri completions`.
 
 This page documents user-facing flags introduced or changed by the
 auth-aware Phase 2 work. For the full command surface, see
@@ -67,29 +68,279 @@ Plan: 2 component(s) to apply on local:
 Applied 2 component(s) successfully.
 ```
 
-## `sindri auth show` *(Phase 5 — placeholder)*
+## `sindri auth show`
 
-> Not yet implemented. Tracked in the auth-aware plan, Phase 5.
+Display the auth-binding table from the per-target lockfile. For each
+binding, prints the requirement, status, bound source (or rejection
+reason), and the considered-but-rejected candidates from resolution.
 
-Will display, for each component in the closure:
+### Synopsis
 
-- declared requirements with audience and scope;
-- bound source (or `Failed` / `Deferred`) and the considered-but-rejected
-  list with reasons;
-- last successful redemption timestamp (from the ledger).
+```text
+sindri auth show [<component>] [--target <name>] [--manifest <path>] [--json]
+```
 
-Until this lands, inspect `sindri.lock`'s `auth_bindings` block directly,
-or `cat ~/.sindri/ledger.jsonl | jq 'select(.event_type | startswith("Auth"))'`.
+### Options
 
-## `sindri auth refresh` *(Phase 5 — placeholder)*
+| Option              | Default       | Description                                                |
+| ------------------- | ------------- | ---------------------------------------------------------- |
+| `<component>`       | (all)         | Filter to bindings for this component address.             |
+| `--target <name>`   | `local`       | Per-target lockfile (`local` → `sindri.lock`).             |
+| `--manifest <path>` | `sindri.yaml` | Manifest path (used to find the sibling lockfile).         |
+| `--json`            | off           | Emit machine-readable JSON instead of a human table.       |
 
-> Not yet implemented.
+### `--json` output schema (stable)
 
-Will trigger an out-of-band re-redemption (e.g. re-run an OAuth device
-flow whose access token has expired) without re-installing components.
+```json
+{
+  "target": "<target-name>",
+  "bindings": [
+    {
+      "id": "<16-hex-char binding-id>",
+      "component": "<component-address>",
+      "requirement": "<req-name>",
+      "audience": "<canonical-lower-cased>",
+      "target": "<target-name>",
+      "status": "bound" | "deferred" | "failed",
+      "source": { "kind": "from-env"|..., ... } | null,
+      "priority": <int>,
+      "reason": "<string>"?,
+      "considered": [
+        { "capability-id": "...", "source-kind": "...", "reason": "..." }
+      ]
+    }
+  ]
+}
+```
+
+Field names follow the lockfile's `auth_bindings` schema verbatim
+(kebab-case for nested fields like `capability-id` and `source-kind`,
+canonical lowercase for `status` enum values).
+
+### Example
+
+```console
+$ sindri auth show
+auth bindings on target 'local'  (3 total)
+
+COMPONENT                   REQUIREMENT            STATUS     SOURCE                AUDIENCE
+--------------------------------------------------------------------------------------------
+npm:claude-code             anthropic_api_key      bound      env:ANTHROPIC_API_KEY urn:anthropic:api
+npm:codex                   openai_api_key         deferred   —                     urn:openai:api
+    reason: no source matched (optional)
+brew:gh                     github_token           failed     —                     https://api.github.com
+    reason: no source matched (required)
+    considered (1):
+      - wrong-aud (from-env): audience-mismatch
+```
+
+## `sindri auth refresh`
+
+Re-runs the resolver's binding pass against the current manifest+target
+set and rewrites the lockfile's `auth_bindings`. Useful after editing
+`targets.<name>.provides:` or after rotating a credential — no full
+`sindri resolve` run is required.
+
+For OAuth-source bindings, the cached access-token (if any) is
+invalidated so the next `sindri apply` re-acquires it. The full RFC 8628
+refresh path lives in the redeemer; this verb just clears caches.
+
+### Synopsis
+
+```text
+sindri auth refresh [<component>] [--target <name>] [--manifest <path>] [--json]
+```
+
+### Options
+
+| Option              | Default       | Description                                              |
+| ------------------- | ------------- | -------------------------------------------------------- |
+| `<component>`       | (all)         | Refresh only bindings for this component address.        |
+| `--target <name>`   | `local`       | Per-target lockfile to refresh.                          |
+| `--manifest <path>` | `sindri.yaml` | Manifest path.                                           |
+| `--json`            | off           | Machine-readable JSON output.                            |
+
+### `--json` output schema (stable)
+
+```json
+{
+  "refreshed": true,
+  "lockfile": "<path>",
+  "manifest": "<path>",
+  "target": "<name>",
+  "component": "<addr>" | null,
+  "auth_bindings": {
+    "resolved": <int>,
+    "deferred": <int>,
+    "failed": <int>,
+    "total": <int>
+  },
+  "oauth_invalidated": ["<binding-id>", ...]
+}
+```
+
+### Example
+
+```console
+$ sindri auth refresh
+auth refresh: target='local' bindings: 1 resolved, 1 deferred, 1 failed
+Wrote sindri.lock
+```
+
+## `sindri doctor --auth`
+
+Focused doctor view that runs admission Gate 5 against the current
+lockfile *without* any apply side effects. Reuses the same evaluator
+that `sindri apply` uses, so the verdict is identical.
+
+### Synopsis
+
+```text
+sindri doctor --auth [--target <name>] [--manifest <path>] [--json]
+```
+
+### Options
+
+| Option              | Default       | Description                                          |
+| ------------------- | ------------- | ---------------------------------------------------- |
+| `--auth`            | required      | Switches doctor into the focused auth view.          |
+| `--target <name>`   | `local`       | Per-target lockfile to evaluate.                     |
+| `--manifest <path>` | `sindri.yaml` | Manifest path.                                       |
+| `--json`            | off           | Machine-readable JSON output.                        |
+
+### Exit codes
+
+| Code | Meaning                                                       |
+| ---- | ------------------------------------------------------------- |
+| `0`  | Gate 5 passes — lockfile is admissible for apply.             |
+| `2`  | `EXIT_POLICY_DENIED` — Gate 5 violation; see `gate5.message`. |
+| `4`  | Lockfile not found or malformed (run `sindri resolve` first). |
+
+### `--json` output schema (stable)
+
+```json
+{
+  "ok": true | false,
+  "target": "<name>",
+  "lockfile": "<path>",
+  "auth_bindings": { "resolved": N, "deferred": N, "failed": N, "total": N },
+  "gate5": {
+    "allowed": true | false,
+    "code": "AUTH_REQUIRED_UNRESOLVED" | ...,
+    "message": "...",
+    "fix": "..." | null
+  }
+}
+```
+
+### Example — clean
+
+```console
+$ sindri doctor --auth
+sindri doctor --auth — target: local
+
+auth bindings: 3 resolved, 0 deferred, 0 failed
+[OK]   Gate 5 (auth-resolvable) — all bindings admissible.
+```
+
+### Example — Gate 5 violation
+
+```console
+$ CI=1 sindri doctor --auth
+sindri doctor --auth — target: local
+
+auth bindings: 1 resolved, 1 deferred, 1 failed
+[FAIL] Gate 5 (auth-resolvable) — AUTH_REQUIRED_UNRESOLVED
+       Auth-aware Gate 5 denied apply: component `brew:gh` requirement
+       `github_token` (audience `https://api.github.com`) on target
+       `local` has no bound source.
+       fix: Bind a source via `targets.<name>.provides:`, mark the
+            requirement `optional: true`, or relax
+            `auth.on_unresolved_required` to `warn`.
+
+Remediation:
+  1. `sindri auth show --target local` to see why bindings failed.
+  2. `sindri target auth local --bind <req-id>` to bind a rejected candidate.
+  3. Adjust `policy.auth.*` if the violation is intentional (see v4/docs/policy.md).
+```
+
+## `sindri target auth <name>`
+
+Inspect (default) or write (`--bind`) per-target `provides:` entries
+without hand-editing `sindri.yaml`. The `--bind` flow takes a binding
+id (from `auth show`) whose status is `Failed` or `Deferred`, picks
+one of its considered-but-rejected candidates, and writes a new
+`provides:` entry with a sensible source-template.
+
+### Synopsis
+
+```text
+sindri target auth <name> [--bind <req-id>] [--capability-id <id>]
+                           [--audience <a>] [--priority <n>]
+                           [--manifest <path>] [--json]
+```
+
+### Options
+
+| Option                  | Default       | Description                                                                                |
+| ----------------------- | ------------- | ------------------------------------------------------------------------------------------ |
+| `<name>`                | required      | Target name (must exist in `sindri.yaml`).                                                 |
+| `--bind <req-id>`       | (inspect)     | Binding `id` (or requirement-name) to bind. Requires the binding's `considered` list ≥ 1. |
+| `--capability-id <id>`  | (auto)        | When `considered` has multiple candidates, pick this one.                                  |
+| `--audience <a>`        | (req-derived) | Override audience on the new `provides:` entry.                                            |
+| `--priority <n>`        | `50`          | Priority for the new `provides:` entry.                                                    |
+| `--manifest <path>`     | `sindri.yaml` | Manifest path.                                                                             |
+| `--json`                | off           | Machine-readable JSON output.                                                              |
+
+### Behaviour
+
+- Inspect (no `--bind`): prints the target's `kind` plus its current
+  `provides:` capability list.
+- `--bind <req-id>`: looks up the binding in the per-target lockfile,
+  asserts it's not already `Bound`, picks a candidate from its
+  `considered` list, synthesises a syntactically-valid `AuthSource`
+  template (e.g. `from-env: { var: <REQ_UPPERCASE> }` or
+  `from-secrets-store: { backend: vault, path: secrets/<req> }`), and
+  writes the entry into `targets.<name>.provides:` in the manifest.
+  Re-binding the same id is idempotent (replaces any existing entry).
+- After writing, run `sindri resolve` then `sindri auth show` to verify.
+
+### Example
+
+```console
+$ sindri target auth local --bind deadbeefdeadbeef --capability-id github_token
+Wrote provides entry 'github_token' (audience='https://api.github.com',
+source=env:GITHUB_TOKEN, priority=50) to targets.local in sindri.yaml
+Next: `sindri resolve` to re-bind, then `sindri auth show` to verify.
+```
+
+## `sindri completions <shell>`
+
+Generates shell completions to stdout. Drop the output into your
+shell's completion directory.
+
+### Synopsis
+
+```text
+sindri completions {bash | zsh | fish | powershell | elvish}
+```
+
+### Examples
+
+```console
+# bash
+$ sindri completions bash > /etc/bash_completion.d/sindri
+
+# zsh (per-user)
+$ sindri completions zsh > ~/.zfunc/_sindri
+
+# fish
+$ sindri completions fish > ~/.config/fish/completions/sindri.fish
+```
 
 ## See also
 
-- `v4/docs/AUTH.md` — auth-aware components user guide.
+- `v4/docs/AUTH.md` — auth-aware components user guide (extended in
+  Phase 5 with a "Daily workflow" walkthrough).
 - `v4/docs/policy.md` — Gate 5 and the `auth:` policy block.
-- ADR-027 §6 — apply-time redemption design.
+- ADR-027 §Phase 5 — UX polish design.

--- a/v4/docs/TARGETS.md
+++ b/v4/docs/TARGETS.md
@@ -1,0 +1,200 @@
+# Targets
+
+This document describes the `Target` trait and how built-in and plugin targets
+advertise auth capabilities to the resolver's binding pass.
+
+- **Status:** Living doc, paired with [ADR-017](ADRs/017-install-backend-trait.md),
+  [ADR-019](ADRs/019-plugin-protocol.md), and
+  [ADR-027](ADRs/027-target-auth-injection.md).
+- **Audience:** authors of new built-in targets, plugin authors, and operators
+  reading `sindri auth show` output who want to understand where the
+  capabilities listed for each target came from.
+
+---
+
+## The contract
+
+A target is anything that implements
+[`sindri_targets::Target`](../crates/sindri-targets/src/traits.rs). The trait
+covers four concerns:
+
+1. **Identity** — `name()` (operator-supplied), `kind()` (e.g. `local`,
+   `docker`).
+2. **Profile** — `profile()` returns OS / arch / package-manager
+   capabilities.
+3. **Execution** — `exec`, `upload`, `download`, optional `create` /
+   `destroy`.
+4. **Auth capabilities** — `auth_capabilities()` (added in Phase 1 of the
+   auth-aware implementation plan).
+
+The auth-capability hook is the focus of this doc.
+
+---
+
+## `auth_capabilities()` — what, when, why
+
+```rust
+fn auth_capabilities(&self) -> Vec<AuthCapability> { Vec::new() }
+```
+
+Each [`AuthCapability`](../crates/sindri-core/src/auth.rs) describes
+**one credential the target can produce**:
+
+| Field      | Meaning                                                                   |
+| ---------- | ------------------------------------------------------------------------- |
+| `id`       | Stable identifier (e.g. `github_token`, `anthropic_api_key`).             |
+| `audience` | What the credential is valid for. Must match a component requirement.    |
+| `source`   | Where the value comes from at redemption time (`AuthSource` discriminant).|
+| `priority` | Resolver tie-breaker — higher wins.                                       |
+
+The resolver calls `auth_capabilities()` once per target during the
+binding pass (ADR-027 §3). The returned list is concatenated with the
+`provides:` overrides from the BOM manifest, then walked against each
+component's `auth.tokens[*]` requirements until each requirement either
+binds, defers (if `optional: true`), or fails.
+
+### When is it called?
+
+- **Resolver hot path** during `sindri resolve` and the resolve sub-step
+  of `sindri apply`. Implementations **must be fast** — no subprocess
+  spawns, no network calls. Lexical checks (`std::env::var`, `which`)
+  are fine.
+- Once per target per resolve. The result is *not* cached across
+  resolves, so capabilities can reflect transient host state (env vars
+  set in the current shell, CLIs newly installed, …).
+
+### What it returns
+
+The trait default is `Vec::new()`. Targets opt in by overriding.
+
+---
+
+## How built-in targets implement it
+
+(Per ADR-027 §"Phase 4" of the auth-aware implementation plan.)
+
+### `local` (`sindri-targets/src/local.rs`)
+
+- **Well-known env vars** (priority `10`): walks the static table in
+  [`well_known.rs`](../crates/sindri-targets/src/well_known.rs).
+  Variables found in `std::env` are surfaced as
+  `AuthSource::FromEnv { var }`. Audiences are vendor URNs
+  (`urn:anthropic:api`, `urn:openai:api`, `https://api.github.com`, …).
+- **`gh` CLI delegation** (priority `20`): if `gh` is on `PATH`, the
+  target advertises `cli:gh auth token` for the GitHub API audience.
+  Higher priority than the env-var so a logged-in `gh` beats a stale
+  `GITHUB_TOKEN`.
+
+### `docker` (`sindri-targets/src/docker.rs`)
+
+- **Well-known env vars only** (priority `5`): docker has no native
+  credential CLI for component auth. The lower priority lets `local`
+  win when both targets advertise the same variable. Operators must
+  still forward the variable into the container at runtime
+  (`docker run -e ...`); the capability advertises *availability*, not
+  forwarding.
+
+### `ssh` (`sindri-targets/src/ssh.rs`)
+
+- **Empty by default.** Host-side SSH key material authenticates the
+  connection, *not* components running on the remote host. Forwarding
+  host env-vars into a remote shell would silently ship secrets across
+  a trust boundary. Operators that genuinely want to make a remote-side
+  credential available should declare a `provides:` entry on the target
+  manifest.
+
+### `e2b` (`sindri-targets/src/cloud.rs`)
+
+- **Empty by default.** E2B sandboxes don't expose a secret-store API
+  the resolver can target. Per-sandbox env vars are wired at create
+  time via the `e2b` CLI's `--env` flag; operators express that intent
+  with `provides:` on the target manifest.
+
+### `fly` (`sindri-targets/src/cloud.rs`)
+
+- **`flyctl auth token`** (priority `15`): the operator's logged-in
+  Fly OAuth token, audience `https://api.fly.io`.
+- **`flyctl secrets`** (priority `12`): the per-app secrets group as a
+  `FromCli` source (`flyctl secrets list --app <app> --json`). Audience
+  `urn:fly:secrets`. Per-secret refinement happens at apply time
+  (Phase 2).
+- Both paths are conditional on `flyctl` being on `PATH`.
+
+### `k8s` (`KubernetesTarget` in `cloud.rs`)
+
+- **`secretKeyRef`** (priority `18`): advertises the cluster's projected
+  secret mechanism as
+  `AuthSource::FromSecretsStore { backend: "k8s", path: <namespace> }`.
+  Per-secret resolution happens at apply time (Phase 2) when a concrete
+  `secretKeyRef.name` / `secretKeyRef.key` are projected into the
+  workload pod. Conditional on `kubectl` being on `PATH`.
+
+---
+
+## Authoring a custom target
+
+Custom targets ship as either:
+
+1. **In-tree built-ins** — extend `sindri-targets` directly, override
+   `auth_capabilities()` returning the appropriate
+   `AuthSource::From*` variants.
+2. **Out-of-process plugins** (ADR-019) — implement the
+   `auth_capabilities` JSON-RPC method:
+
+    ```jsonc
+    // CLI → plugin
+    {"method": "auth_capabilities", "params": {}}
+    // plugin → CLI
+    {"result": {"capabilities": [/* AuthCapability JSON */]}}
+    ```
+
+   Plugins that don't implement the verb should return
+   `{"error": {"code": "method-not-supported"}}`. The CLI client
+   ([`sindri-targets/src/plugin.rs`](../crates/sindri-targets/src/plugin.rs))
+   treats this exactly like the trait default — empty `Vec`.
+
+### Guidelines
+
+- **Stay fast.** No subprocess spawns. No network. Cache anything
+  expensive during construction.
+- **Be specific.** Audiences should match what registry-core component
+  manifests declare (`urn:anthropic:api`, `https://api.github.com`,
+  …). When inventing a new audience, prefer URN-style strings rooted at
+  your service name.
+- **Use priority sparingly.** The default `0` is fine. Bump above `10`
+  only if you have a strong reason to outrank ambient env-vars.
+- **Don't capture secrets.** `AuthCapability` is a *reference* to where
+  a value lives. The value itself never enters the capability struct
+  (DDD-07 invariant 3 "no value capture").
+- **Document conservative defaults.** If you choose to advertise nothing
+  by default (like `ssh`), say so in a doc comment so operators know
+  they need a `provides:` entry.
+
+---
+
+## Lockfile observability
+
+Once Phase 1 has run, the per-target lockfile includes an
+`auth_bindings:` section that records every requirement and which
+capability bound it (or why no capability did). Operators inspect the
+result with:
+
+```bash
+sindri auth show <component>     # Phase 5
+```
+
+Until Phase 5 lands, `cat .sindri/<target>.lock | yq .auth_bindings`
+works.
+
+---
+
+## Related
+
+- [ADR-017](ADRs/017-install-backend-trait.md) — the `Target` trait.
+- [ADR-019](ADRs/019-plugin-protocol.md) — out-of-process plugin RPC.
+- [ADR-026](ADRs/026-auth-aware-components.md) — component-side
+  `auth:` schema.
+- [ADR-027](ADRs/027-target-auth-injection.md) — target capability
+  schema, binding algorithm, plugin protocol extension.
+- [DDD-07](DDDs/07-auth-bindings-domain.md) — the bindings domain
+  model.

--- a/v4/docs/policy.md
+++ b/v4/docs/policy.md
@@ -1,0 +1,140 @@
+# Sindri install policy
+
+> Status: Phase 2B adds Gate 5 (auth-resolvable). Gates 1–4 ship in earlier
+> waves; this document focuses on Gate 5. For the full policy story see
+> ADR-008 and DDD-05.
+
+Sindri's install policy is a layered subsystem that runs as a series of
+**admission gates** before any side effect touches the target. Each gate
+either admits the apply, warns, or denies with `EXIT_POLICY_DENIED` (2).
+
+| Gate | Name              | What it checks                                   | ADR          |
+| ---- | ----------------- | ------------------------------------------------ | ------------ |
+| 1    | License           | Component licenses against allow / deny lists    | ADR-008      |
+| 2    | Signed registry   | Cosign signature on registry index               | ADR-014      |
+| 3    | Pinned versions   | Strict mode requires every version pinned        | ADR-008      |
+| 4    | Path-prefix       | Component install paths obey collision rules     | ADR-008      |
+| 5    | **Auth-resolvable** | Required credentials have bound sources        | ADR-027 §5   |
+
+## Gate 5 — Auth-resolvable
+
+Verifies that every non-`optional` `AuthRequirement` declared by a
+component in the resolved closure has a bound source on the target's
+per-target lockfile, AND that the bound source is admissible under
+operator policy.
+
+Configured in `sindri.policy.yaml` under `auth:`:
+
+```yaml
+auth:
+  on_unresolved_required: deny       # default
+  allow_upstream_credentials: false  # default
+  allow_prompt_in_ci: false          # default
+```
+
+All three knobs default to **deny**. Operators must opt into each
+relaxation explicitly.
+
+### `auth.on_unresolved_required`
+
+| Value     | Behaviour                                                          |
+| --------- | ------------------------------------------------------------------ |
+| `deny`    | (default) Apply fails with `EXIT_POLICY_DENIED` if any required-and-unbound binding exists. |
+| `warn`    | Logs a `tracing::warn!` and admits. The install will likely fail at first run. |
+| `prompt`  | Reserved for Phase 5 — interactive resolution.                     |
+
+**What this catches**: a component declares it needs `ANTHROPIC_API_KEY`
+(audience `urn:anthropic:api`), the resolver could not bind it (env var
+missing, no `provides:` mapping it, no `discovery.env-aliases` match),
+and the requirement is `optional: false`. Without Gate 5, the install
+would proceed and the tool would fail silently at first use.
+
+**How to relax**: set to `warn`. Recommended only when you intentionally
+need a "best-effort" install (e.g. base-image bake where credentials
+will be supplied later via cloud-init). Document the choice; revisit
+during audit.
+
+### `auth.allow_upstream_credentials`
+
+| Value   | Behaviour                                                                |
+| ------- | ------------------------------------------------------------------------ |
+| `false` | (default) Bindings whose source is `from-upstream-credentials` are denied. |
+| `true`  | Bindings can reuse the target's own session credentials.                 |
+
+**What this catches**: the resolver picked
+`AuthSource::FromUpstreamCredentials` because the target advertised its
+own session token as fulfilling some audience. By default we do not
+share that credential with arbitrary child workloads — operators must
+either mint a dedicated credential (via `provides: { source: from-secrets-store, ... }`)
+or explicitly opt in to upstream reuse.
+
+**Security caveat when relaxing**: the target's session token (e.g. an
+SSH-agent-forwarded GitHub-app installation token) becomes available to
+every component that declares a matching audience. A maliciously-crafted
+component manifest matching the audience harvests the token. ADR-014
+trust-on-install applies, but operators should still treat
+`allow_upstream_credentials: true` as a privileged setting.
+
+### `auth.allow_prompt_in_ci`
+
+| Value   | Behaviour                                                              |
+| ------- | ---------------------------------------------------------------------- |
+| `false` | (default) Bindings whose source is `prompt` are denied in non-interactive runs. |
+| `true`  | Prompt sources are allowed even when no TTY is present / `CI=1` is set. |
+
+**What this catches**: a component requires an interactive credential
+(SSH passphrase, MFA token), the resolver bound it to a `prompt` source
+(usually because no other source matched), and the run is on a CI
+runner with no TTY. Without this gate the apply would hang on
+`stdin.read_line()` until the runner times out.
+
+Sindri detects "non-interactive" via:
+
+- `CI` env var present (set by GitHub Actions, GitLab CI, CircleCI, ...);
+- `SINDRI_CI` env var present (Sindri's own marker for explicit CI runs);
+- stdin not attached to a TTY (Unix only; Windows treats as
+  non-interactive by default).
+
+**Security caveat when relaxing**: rare. There is almost never a
+legitimate reason to enable this on production CI; the right answer is
+to switch the credential to a backed source (env var, secrets store).
+If you genuinely need it for development sandboxes, set per-project not
+globally.
+
+## Interaction with `--skip-auth`
+
+`sindri apply --skip-auth` bypasses **redemption** but does NOT bypass
+Gate 5. Required-binding presence is still enforced. To bypass both,
+operators must additionally relax `auth.on_unresolved_required` to
+`warn`.
+
+This split is intentional: `--skip-auth` is for "I know my credentials
+are out-of-band and will inject them another way"; the gate is for
+"there exists a bound source somewhere". Different concerns, separate
+overrides, both auditable in `~/.sindri/ledger.jsonl`.
+
+## Worked example: full default-deny policy
+
+```yaml
+# sindri.policy.yaml — explicitly enumerating defaults
+auth:
+  on_unresolved_required: deny
+  allow_upstream_credentials: false
+  allow_prompt_in_ci: false
+```
+
+```yaml
+# sindri.policy.yaml — relaxed for a developer laptop
+auth:
+  on_unresolved_required: warn
+  allow_upstream_credentials: true   # I trust local components
+  allow_prompt_in_ci: false          # still keep CI strict via SINDRI_CI
+```
+
+## See also
+
+- `v4/docs/AUTH.md` — auth-aware components user guide.
+- `v4/docs/CLI.md` — `sindri apply --skip-auth` documentation.
+- ADR-008 — install policy as a first-class subsystem.
+- ADR-027 §5 — Gate 5 design.
+- DDD-05 — policy domain.

--- a/v4/schemas/lock.json
+++ b/v4/schemas/lock.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.sindri.dev/v4/lock.json",
+  "title": "Lockfile",
+  "description": "Sindri v4 per-target lockfile (sindri.lock / sindri.<target>.lock). ADR-018 (per-target lockfiles), ADR-027 §3 (auth_bindings, Phase 1 observability-only).",
+  "type": "object",
+  "required": ["version", "bom_hash", "target", "components"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Lockfile schema version. Currently 1."
+    },
+    "bom_hash": {
+      "type": "string",
+      "description": "SHA-256 (hex) of the source BOM manifest used to produce this lockfile."
+    },
+    "target": {
+      "type": "string",
+      "description": "Target name this lockfile pins (key of `BomManifest.targets`)."
+    },
+    "components": {
+      "type": "array",
+      "description": "Resolved components in topological order.",
+      "items": { "type": "object" }
+    },
+    "auth_bindings": {
+      "type": "array",
+      "description": "Auth bindings produced by the resolver's binding pass (ADR-027 §3, DDD-07 aggregate root). Phase 1 of the auth-aware implementation plan ships this field as observability-only — the apply path does not yet consume these entries (Phase 2 will). Existing lockfiles deserialize unchanged because the field defaults to an empty list.",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "component",
+          "requirement",
+          "audience",
+          "target",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Deterministic 16-hex-char id: sha256(component || requirement || target). Stable across hosts (DDD-07 invariant 4)."
+          },
+          "component": {
+            "type": "string",
+            "description": "Component address (`backend:name[@qualifier]`)."
+          },
+          "requirement": {
+            "type": "string",
+            "description": "Requirement name within the component manifest."
+          },
+          "audience": {
+            "type": "string",
+            "description": "Canonicalised (lower-cased) audience string. Equal to req.audience == source.audience (DDD-07 invariant 1)."
+          },
+          "target": {
+            "type": "string",
+            "description": "Target name from the BOM manifest."
+          },
+          "source": {
+            "description": "Bound AuthSource (omitted when status is `deferred` or `failed`).",
+            "type": "object"
+          },
+          "priority": {
+            "type": "integer",
+            "description": "Capability priority that won. 0 when no source bound.",
+            "default": 0
+          },
+          "status": {
+            "type": "string",
+            "enum": ["bound", "deferred", "failed"],
+            "description": "Binding lifecycle state (DDD-07 §Lifecycle states)."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Free-form reason when status is `deferred` or `failed`."
+          },
+          "considered": {
+            "type": "array",
+            "description": "Candidates that were considered but rejected, with reasons (audience-mismatch, scope-mismatch, ...).",
+            "default": [],
+            "items": {
+              "type": "object",
+              "required": ["capability_id", "source_kind", "reason"],
+              "properties": {
+                "capability_id": { "type": "string" },
+                "source_kind": { "type": "string" },
+                "reason": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Final phase (Phase 5) of the auth-aware components/targets plan
(PR #242). Introduces first-class CLI verbs for inspecting and
managing auth bindings — read-only inspection plus one explicit
user-driven `--bind` write. No resolver or apply-time behaviour
change.

Depends on #244 (Phase 0 schema), #247 (Phase 1 resolver), #249
(Phase 4 target capabilities), #250 (Phase 2A redemption), #251
(Phase 2B Gate 5).

## What's in

### New verbs
- `sindri auth show [<component>]` — table of every binding and its
  considered candidates. `--json` shape documented in CLI.md.
- `sindri auth refresh [<component>]` — re-runs the binding pass and
  invalidates OAuth token caches.
- `sindri doctor --auth` — focused Gate 5 evaluator, no apply side
  effects, exits `EXIT_POLICY_DENIED` (2) on Gate 5 violations with
  inline remediation hints.
- `sindri target auth <name> --bind <req-id>` — promotes a
  considered-but-rejected candidate into a `provides:` entry,
  synthesising a syntactically-valid `AuthSource` template.
- `sindri completions {bash|zsh|fish|powershell|elvish}` — opt-in
  stdout output, doesn't break any existing completions.

### Files
- New: `v4/crates/sindri/src/commands/auth.rs`,
  `v4/crates/sindri/tests/auth_cli_integration.rs`.
- Modified: `commands/{doctor,target,mod}.rs`, `main.rs`,
  `crates/sindri/Cargo.toml` (clap_complete dep), `Cargo.lock`.
- Docs: `v4/docs/CLI.md` (full Synopsis/Options/Examples + JSON
  schemas), `v4/docs/AUTH.md` (new "Daily workflow" section with
  remediation session sample).

## Test counts

- 19 unit tests (commands::auth + target::auth_subverb_tests)
- 10 integration tests (tests/auth_cli_integration.rs) — invoke the
  binary end-to-end, cover both TTY and `--json` paths plus exit
  codes for the 3-components × 2-targets scenario from the plan.
- Total: **29 new tests**, all passing. Workspace clippy + fmt
  clean.

## UX trade-offs / notes

- `auth refresh` does not run the full RFC 8628 OAuth refresh path —
  it only invalidates the cached token so the next `sindri apply`
  re-acquires it. Per the plan, full OAuth refresh is a follow-up.
- `target auth … --bind` writes a *skeleton* source from the
  candidate's `source-kind` (e.g. `from-env: { var: REQ_UPPERCASE }`,
  `from-secrets-store: { backend: vault, path: secrets/<req> }`).
  Users may need to edit placeholder fields; the value is having a
  parseable manifest written so subsequent `sindri resolve` runs
  without manifest-edit churn.
- `--bind` requires a binding with non-empty `considered` list. If
  there are multiple candidates, the user must pass
  `--capability-id`. Otherwise the single candidate is auto-picked.
- The new `Doctor` flags (`--auth`, `--json`, `--manifest`) are
  additive; existing `doctor` invocations are unchanged.
- Tab completions are an opt-in subcommand; we do not write to any
  existing completion files.

## Test plan

- [ ] CI passes (`cargo build/test/clippy/fmt` workspace-wide)
- [ ] `sindri auth show` renders the integration scenario fixture
      table (3 bindings, mix of bound/deferred/failed, considered
      candidates visible)
- [ ] `sindri auth show --json` matches the documented schema
- [ ] `sindri auth refresh --json` round-trips an existing lockfile
- [ ] `sindri doctor --auth` exits 0 on a clean lockfile, exits 2
      with `CI=1` and a Failed binding present
- [ ] `sindri target auth local --bind <req-id>` writes a valid
      `provides:` entry that survives round-trip parse
- [ ] `sindri completions bash` emits a clap-style completion script
- [ ] `sindri completions tcsh` exits non-zero (unsupported shell)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)