### PR TITLE
ci: rollup of GitHub Actions bumps + cargo-audit SARIF upload

### DIFF
--- a/.github/workflows/_ci-rust.yml
+++ b/.github/workflows/_ci-rust.yml
@@ -143,7 +143,7 @@ jobs:
           cargo build --release --workspace $target_arg $features_arg
       - name: Upload release binary
         if: ${{ inputs.target == 'x86_64-unknown-linux-musl' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sindri-${{ inputs.workspace_dir }}-binaries-${{ github.sha }}
           path: ${{ inputs.workspace_dir }}/target/${{ inputs.target }}/release/sindri

--- a/.github/workflows/_release-cargo-dist.yml
+++ b/.github/workflows/_release-cargo-dist.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Cache cargo registry + target
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/_release-cargo-dist.yml
+++ b/.github/workflows/_release-cargo-dist.yml
@@ -93,7 +93,7 @@ jobs:
           }
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: binary-${{ matrix.platform }}
           path: |

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore lychee cache
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore lychee cache
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: .lycheecache
           key: cache-lychee-external-${{ github.sha }}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload internal link report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: lychee-internal-report
           path: lychee-internal.md
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload external link report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: lychee-external-report
           path: lychee-external.md

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -184,7 +184,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-lcov-${{ github.sha }}
           path: |
@@ -726,7 +726,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: provider-test-results-${{ matrix.provider }}-${{ github.sha }}
           path: v3/provider-test-results.txt

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           workspaces: v3 -> target
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.18.1
+        uses: cargo-bins/cargo-binstall@v1.19.0
       - name: Install cargo-machete
         run: cargo binstall cargo-machete --no-confirm
       - name: Scan for unused dependencies
@@ -110,7 +110,7 @@ jobs:
           workspaces: v3 -> target
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.18.1
+        uses: cargo-bins/cargo-binstall@v1.19.0
 
       - name: Install cargo-llvm-cov
         run: cargo binstall cargo-llvm-cov --no-confirm --force
@@ -405,7 +405,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.18.1
+        uses: cargo-bins/cargo-binstall@v1.19.0
 
       - name: Install cargo-audit
         run: cargo binstall cargo-audit --no-confirm

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Attest build provenance
         if: steps.build.outputs.digest != ''
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/ci-v4.yml
+++ b/.github/workflows/ci-v4.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci-v4.yml
+++ b/.github/workflows/ci-v4.yml
@@ -91,10 +91,122 @@ jobs:
   audit:
     name: Security audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v6
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
-      - name: Run audit
+
+      # `cargo audit --json` honors v4/.cargo/audit.toml ignores, so SARIF
+      # output below reflects the same advisory set the human-readable
+      # `cargo audit` step would surface. The SARIF upload routes findings
+      # to the GitHub Security tab keyed to refs/heads/v4 (since this
+      # workflow only triggers on the v4 branch), keeping advisories
+      # attributed to the right branch after the April 2026 reorg.
+      - name: Run audit (JSON)
+        id: audit
         working-directory: v4
-        run: cargo audit
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo audit --json > "$RUNNER_TEMP/audit.json"
+
+      - name: Convert audit JSON to SARIF
+        if: always() && hashFiles(format('{0}/audit.json', runner.temp)) != ''
+        run: |
+          jq '
+            def sev_to_level:
+              ascii_downcase
+              | if   . == "critical" then "error"
+                elif . == "high"     then "error"
+                elif . == "medium"   then "warning"
+                elif . == "low"      then "note"
+                else "warning" end;
+            {
+              "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+              "version": "2.1.0",
+              "runs": [{
+                "tool": {
+                  "driver": {
+                    "name": "cargo-audit",
+                    "informationUri": "https://github.com/rustsec/rustsec/tree/main/cargo-audit",
+                    "rules": (
+                      [.vulnerabilities.list[]?
+                        | .advisory as $a
+                        | {
+                            "id": $a.id,
+                            "name": $a.id,
+                            "shortDescription": { "text": $a.title },
+                            "fullDescription":  { "text": ($a.description // $a.title) },
+                            "helpUri": ($a.url // "https://rustsec.org/advisories/\($a.id).html"),
+                            "defaultConfiguration": {
+                              "level": (($a.severity // "warning") | sev_to_level)
+                            },
+                            "properties": {
+                              "tags": ["security", "rust", "rustsec"],
+                              "security-severity": (
+                                if   ($a.severity // "" | ascii_downcase) == "critical" then "9.5"
+                                elif ($a.severity // "" | ascii_downcase) == "high"     then "7.5"
+                                elif ($a.severity // "" | ascii_downcase) == "medium"   then "5.0"
+                                elif ($a.severity // "" | ascii_downcase) == "low"      then "3.0"
+                                else "5.0" end
+                              )
+                            }
+                          }
+                      ] | unique_by(.id)
+                    )
+                  }
+                },
+                "results": (
+                  [.vulnerabilities.list[]?
+                    | {
+                        "ruleId": .advisory.id,
+                        "level":  ((.advisory.severity // "warning") | sev_to_level),
+                        "message": {
+                          "text": "\(.package.name) \(.package.version): \(.advisory.title) (\(.advisory.id))"
+                        },
+                        "locations": [{
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "v4/Cargo.lock" },
+                            "region": { "startLine": 1 }
+                          }
+                        }],
+                        "partialFingerprints": {
+                          "advisory/package/version":
+                            "\(.advisory.id)/\(.package.name)/\(.package.version)"
+                        }
+                      }
+                  ]
+                )
+              }]
+            }
+          ' "$RUNNER_TEMP/audit.json" > "$RUNNER_TEMP/audit.sarif"
+          echo "SARIF results:"
+          jq '.runs[0].results | length' "$RUNNER_TEMP/audit.sarif"
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && hashFiles(format('{0}/audit.sarif', runner.temp)) != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ runner.temp }}/audit.sarif
+          category: cargo-audit-v4
+
+      - name: Audit summary
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/audit.json" ]; then
+            COUNT=$(jq '.vulnerabilities.count // 0' "$RUNNER_TEMP/audit.json")
+            echo "## cargo-audit (v4)" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Vulnerabilities reported (post-ignore):** $COUNT" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Ignores honored from:** \`v4/.cargo/audit.toml\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Re-fail the job if cargo audit found anything, so CI status reflects
+      # the audit result even though the JSON step uses continue-on-error.
+      - name: Enforce audit verdict
+        if: steps.audit.outcome == 'failure'
+        run: |
+          echo "::error::cargo audit reported vulnerabilities (see SARIF / Security tab)"
+          exit 1

--- a/.github/workflows/integration-test-providers.yml
+++ b/.github/workflows/integration-test-providers.yml
@@ -58,7 +58,7 @@ jobs:
         run: cd v3 && cargo build --release
 
       - name: Upload binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sindri-integration-binary-${{ github.sha }}
           path: v3/target/release/sindri
@@ -230,7 +230,7 @@ jobs:
           echo "- Destroy: PASS" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: runpod-integration-logs-${{ github.sha }}
@@ -293,7 +293,7 @@ jobs:
           echo "- Destroy: PASS" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: northflank-integration-logs-${{ github.sha }}

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -151,7 +151,7 @@ jobs:
           ref: v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo (sindri build)
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -204,7 +204,7 @@ jobs:
           ref: v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo (sindri build)
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -283,7 +283,7 @@ jobs:
           python-version: "3.12"
 
       - name: Cache ScanCode pip install
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-scancode-32.x
@@ -421,7 +421,7 @@ jobs:
           ref: v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo (sindri build)
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -175,7 +175,7 @@ jobs:
           fi
       - name: Upload lint report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: registry-lint-report
           path: v4/lint-report.json
@@ -395,7 +395,7 @@ jobs:
 
       - name: Upload ScanCode report
         if: ${{ always() || github.event.inputs.debug_scancode == 'true' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: scancode-license-report
           path: |
@@ -465,7 +465,7 @@ jobs:
           test -s "$out" || { echo "::error::index.yaml is empty"; exit 1; }
           echo "index-path=v4/$out" >> "$GITHUB_OUTPUT"
       - name: Upload generated index
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: registry-core-index
           path: v4/registry-core/index.yaml
@@ -653,7 +653,7 @@ jobs:
           show-summary: true
 
       - name: Upload attestation bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: slsa-provenance-bundle
           path: ${{ steps.attest.outputs.bundle-path }}
@@ -757,7 +757,7 @@ jobs:
 
       - name: Upload verification result
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: attestation-verify-result
           path: attestation-verify-result.json

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -483,7 +483,7 @@ jobs:
     if: ${{ needs.resolve-tag.outputs.dry_run == 'false' }}
     steps:
       - name: Install oras
-        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6  # v1.2.4
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
         with:
           version: ${{ env.ORAS_VERSION }}
       - name: Login to ghcr.io (read)
@@ -523,7 +523,7 @@ jobs:
           name: registry-core-index
           path: v4/registry-core/
       - name: Install oras
-        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6  # v1.2.4
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
         with:
           version: ${{ env.ORAS_VERSION }}
       - name: Login to ghcr.io

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -638,7 +638,7 @@ jobs:
 
       - name: Generate SLSA provenance attestation
         id: attest
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           # Subject is the OCI artifact identified by its manifest digest.
           # We provide both the digest (for OCI attestation lookup) and the

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -147,7 +147,7 @@ jobs:
           echo "changelog_file=changelog.md" >> "$GITHUB_OUTPUT"
 
       - name: Upload changelog artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: changelog-v2
           path: changelog.md
@@ -495,7 +495,7 @@ jobs:
           echo "  cosign download sbom ghcr.io/${REPO}:v${{ needs.validate-tag.outputs.version }}"
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sbom-v${{ needs.validate-tag.outputs.version }}
           path: sbom.spdx.json

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -438,7 +438,7 @@ jobs:
           echo "Image digest: $DIGEST_HASH"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -76,7 +76,7 @@ jobs:
           echo "changelog_file=changelog.md" >> "$GITHUB_OUTPUT"
 
       - name: Upload changelog artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: changelog-v3
           path: changelog.md
@@ -167,7 +167,7 @@ jobs:
         shell: pwsh
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: binary-${{ matrix.platform }}
           path: |
@@ -558,7 +558,7 @@ jobs:
           echo "  cosign download sbom ghcr.io/${REPO}:${{ needs.validate-tag.outputs.version }}"
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sbom-v${{ needs.validate-tag.outputs.version }}
           path: sbom.spdx.json

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -121,7 +121,7 @@ jobs:
           cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -501,7 +501,7 @@ jobs:
           echo "Image digest for ${{ matrix.distro }}: $DIGEST_HASH"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/v2-manual-deploy.yml
+++ b/.github/workflows/v2-manual-deploy.yml
@@ -325,7 +325,7 @@ jobs:
           echo "Cleanup configuration saved"
 
       - name: Upload cleanup config
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cleanup-config-${{ env.DEPLOYMENT_ID }}
           path: cleanup-config.json

--- a/.github/workflows/v2-test-extensions.yml
+++ b/.github/workflows/v2-test-extensions.yml
@@ -108,7 +108,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sindri-test-image
           path: /tmp/sindri-image.tar

--- a/.github/workflows/v3-packer-build.yml
+++ b/.github/workflows/v3-packer-build.yml
@@ -140,7 +140,7 @@ jobs:
             --json > build-result.json
 
       - name: Upload Build Manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: aws-build-manifest
           path: |
@@ -196,7 +196,7 @@ jobs:
             --json > build-result.json
 
       - name: Upload Build Manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: azure-build-manifest
           path: |
@@ -253,7 +253,7 @@ jobs:
             --json > build-result.json
 
       - name: Upload Build Manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: gcp-build-manifest
           path: |
@@ -329,7 +329,7 @@ jobs:
           echo "OCI credentials cleaned up"
 
       - name: Upload Build Manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: oci-build-manifest
           path: |
@@ -380,7 +380,7 @@ jobs:
             --json > build-result.json
 
       - name: Upload Build Manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: alibaba-build-manifest
           path: |

--- a/.github/workflows/v3-packer-test.yml
+++ b/.github/workflows/v3-packer-test.yml
@@ -105,7 +105,7 @@ jobs:
           region: ${{ github.event.inputs.region || 'us-west-2' }}
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: aws-test-results
@@ -164,7 +164,7 @@ jobs:
           resource-group: ${{ secrets.AZURE_RESOURCE_GROUP || 'sindri-test' }}
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: azure-test-results
@@ -225,7 +225,7 @@ jobs:
           project-id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: gcp-test-results
@@ -288,7 +288,7 @@ jobs:
           region: ${{ github.event.inputs.region || 'us-ashburn-1' }}
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: oci-test-results
@@ -343,7 +343,7 @@ jobs:
           region: ${{ github.event.inputs.region || 'us-west-1' }}
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: alibaba-test-results

--- a/.github/workflows/v3-provider-devpod.yml
+++ b/.github/workflows/v3-provider-devpod.yml
@@ -250,7 +250,7 @@ jobs:
           cat test-result.json
 
       - name: Upload Test Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: ${{ inputs.artifact-prefix }}devpod-result-${{ matrix.extension }}

--- a/.github/workflows/v3-provider-docker.yml
+++ b/.github/workflows/v3-provider-docker.yml
@@ -59,7 +59,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload CLI
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ inputs.artifact-prefix }}sindri-cli
           path: v3/target/release/sindri
@@ -199,7 +199,7 @@ jobs:
           echo "result=$(cat test-result.json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Upload Test Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: ${{ inputs.artifact-prefix }}docker-result-${{ matrix.extension }}

--- a/.github/workflows/v3-provider-e2b.yml
+++ b/.github/workflows/v3-provider-e2b.yml
@@ -336,7 +336,7 @@ jobs:
           cat test-result.json
 
       - name: Upload Test Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: ${{ inputs.artifact-prefix }}e2b-result-${{ matrix.extension }}

--- a/.github/workflows/v3-provider-fly.yml
+++ b/.github/workflows/v3-provider-fly.yml
@@ -211,7 +211,7 @@ jobs:
           echo "result=$(cat test-result.json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Upload Test Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: ${{ inputs.artifact-prefix }}fly-result-${{ matrix.extension }}

--- a/.github/workflows/v3-provider-northflank.yml
+++ b/.github/workflows/v3-provider-northflank.yml
@@ -274,7 +274,7 @@ jobs:
           echo "result=$(cat test-result.json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Upload Test Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: ${{ inputs.artifact-prefix }}northflank-result-${{ matrix.extension }}

--- a/.github/workflows/v3-provider-packer.yml
+++ b/.github/workflows/v3-provider-packer.yml
@@ -472,7 +472,7 @@ jobs:
           cat test-result.json
 
       - name: Upload Test Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: ${{ inputs.artifact-prefix }}packer-result-${{ matrix.extension }}

--- a/.github/workflows/v3-provider-runpod.yml
+++ b/.github/workflows/v3-provider-runpod.yml
@@ -249,7 +249,7 @@ jobs:
           echo "result=$(cat test-result.json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Upload Test Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: ${{ inputs.artifact-prefix }}runpod-result-${{ matrix.extension }}

--- a/.github/workflows/v3-test-profiles.yml
+++ b/.github/workflows/v3-test-profiles.yml
@@ -89,7 +89,7 @@ jobs:
           cargo build --release
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sindri-cli
           path: v3/target/release/sindri

--- a/.github/workflows/v3-test-profiles.yml
+++ b/.github/workflows/v3-test-profiles.yml
@@ -73,7 +73,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
## Summary

Bulk-applies six related CI/security PRs in one merge.

- 5× Dependabot GitHub Actions version bumps
- 1× hand-written workflow upgrade that routes `cargo audit` findings into the GitHub Security tab as SARIF

All six target `main` and touch only `.github/workflows/*` (plus `.github/dependabot.yml` for some of the bumps). No source-tree changes.

## Rolls up

- Closes #287 — bump `actions/upload-artifact` 4.6.2 → 7.0.1
- Closes #286 — bump `oras-project/setup-oras` 1.2.4 → 2.0.0
- Closes #285 — bump `cargo-bins/cargo-binstall` 1.18.1 → 1.19.0
- Closes #284 — bump `actions/cache` 4.3.0 → 5.0.5
- Closes #283 — bump `actions/attest-build-provenance` 2.4.0 → 4.1.0
- Closes #282 — upload v4 cargo-audit findings to Security tab as SARIF

## Test plan

- [ ] CI green on this rollup branch
- [ ] After merge, confirm `cargo-audit-v4` SARIF category appears under Security → Code scanning
- [ ] No follow-up Dependabot rebases needed for the closed PRs

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)