### PR TITLE
ci(main): consolidate GHA action bumps + ubuntu-26.04 consistency

### DIFF
--- a/.github/workflows/_ci-bash.yml
+++ b/.github/workflows/_ci-bash.yml
@@ -25,7 +25,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Run shellcheck
         run: |
           set -euo pipefail
@@ -40,7 +40,7 @@ jobs:
     name: bats tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install bats
         run: sudo apt-get update && sudo apt-get install -y bats
       - name: Run bats

--- a/.github/workflows/_ci-docker.yml
+++ b/.github/workflows/_ci-docker.yml
@@ -28,7 +28,7 @@ jobs:
     name: docker build (validation)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build (no push)

--- a/.github/workflows/_ci-npm.yml
+++ b/.github/workflows/_ci-npm.yml
@@ -23,7 +23,7 @@ jobs:
     name: pnpm install + test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v4
         with: { node-version: "${{ inputs.node_version }}" }
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/_ci-rust.yml
+++ b/.github/workflows/_ci-rust.yml
@@ -45,7 +45,7 @@ jobs:
     name: Workspace guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Verify Cargo.toml exists at workspace_dir
         run: test -f "${{ inputs.workspace_dir }}/Cargo.toml" || { echo "::error::No Cargo.toml at ${{ inputs.workspace_dir }}"; exit 1; }
 
@@ -54,7 +54,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -67,7 +67,7 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -91,7 +91,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -114,7 +114,7 @@ jobs:
     name: cargo build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install musl tools (if requested)
         if: ${{ inputs.install_musl_tools }}
         run: sudo apt-get update && sudo apt-get install -y musl-tools

--- a/.github/workflows/_release-cargo-dist.yml
+++ b/.github/workflows/_release-cargo-dist.yml
@@ -42,7 +42,7 @@ jobs:
           - { os: macos-latest,   target: aarch64-apple-darwin,      platform: macos-aarch64 }
           - { os: windows-latest, target: x86_64-pc-windows-msvc,    platform: windows-x86_64 }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -23,9 +23,9 @@ on:
         required: false
         default: '1.95'
       ubuntu_version:
-        description: 'Ubuntu version (e.g., 24.04)'
+        description: 'Ubuntu version (e.g., 26.04)'
         required: false
-        default: '24.04'
+        default: '26.04'
       gh_version:
         description: 'GitHub CLI version (e.g., 2.90.0)'
         required: false
@@ -54,7 +54,7 @@ on:
       ubuntu_version:
         description: 'Ubuntu version'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
 
 env:
@@ -78,7 +78,7 @@ jobs:
         id: args
         run: |
           RUST_VERSION="${{ github.event.inputs.rust_version || '1.95' }}"
-          UBUNTU_VERSION="${{ github.event.inputs.ubuntu_version || '24.04' }}"
+          UBUNTU_VERSION="${{ github.event.inputs.ubuntu_version || '26.04' }}"
           GH_VERSION="${{ github.event.inputs.gh_version || '2.90.0' }}"
 
           echo "rust_version=$RUST_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set build arguments
         id: args

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Restore lychee cache
         uses: actions/cache@v5.0.5
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Restore lychee cache
         uses: actions/cache@v5.0.5

--- a/.github/workflows/ci-v1.yml
+++ b/.github/workflows/ci-v1.yml
@@ -24,7 +24,7 @@ jobs:
     name: Markdown lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Lint v1/CHANGELOG.md and root markdown
         uses: DavidAnson/markdownlint-cli2-action@v23
         with:

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -87,7 +87,7 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
       image-ref: ${{ steps.meta.outputs.tags }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -154,7 +154,7 @@ jobs:
     outputs:
       providers: ${{ steps.matrix.outputs.providers }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Generate matrices
         id: matrix
@@ -194,7 +194,7 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Login to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rust]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -213,7 +213,7 @@ jobs:
       image-tag: ${{ steps.build.outputs.tag }}
       image-digest: ${{ steps.build.outputs.digest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1
@@ -313,7 +313,7 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -399,7 +399,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.inputs.run-audit == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -450,7 +450,7 @@ jobs:
     name: Documentation Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -483,7 +483,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.inputs.test-extensions == 'true' || github.event_name != 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Check if v3 extensions exist
         id: check
@@ -523,7 +523,7 @@ jobs:
     needs: [rust]
     continue-on-error: true  # Don't fail CI if k8s tests fail
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1
@@ -568,7 +568,7 @@ jobs:
     needs: [rust]
     continue-on-error: true  # Don't fail CI if k8s tests fail
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1
@@ -622,7 +622,7 @@ jobs:
       matrix:
         provider: [kind, k3d]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1
@@ -700,7 +700,7 @@ jobs:
       matrix:
         provider: [runpod, northflank]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -737,7 +737,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rust]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -762,7 +762,7 @@ jobs:
     needs: [rust]
     continue-on-error: true  # Config validation is informational, don't block PRs
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -274,7 +274,7 @@ jobs:
             github_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign image by digest
         if: steps.build.outputs.digest != ''

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           workspaces: v3 -> target
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.19.0
+        uses: cargo-bins/cargo-binstall@v1.19.1
       - name: Install cargo-machete
         run: cargo binstall cargo-machete --no-confirm
       - name: Scan for unused dependencies
@@ -110,7 +110,7 @@ jobs:
           workspaces: v3 -> target
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.19.0
+        uses: cargo-bins/cargo-binstall@v1.19.1
 
       - name: Install cargo-llvm-cov
         run: cargo binstall cargo-llvm-cov --no-confirm --force
@@ -405,7 +405,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.19.0
+        uses: cargo-bins/cargo-binstall@v1.19.1
 
       - name: Install cargo-audit
         run: cargo binstall cargo-audit --no-confirm

--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-v3-binaries-${{ github.sha }}
           path: ./bin
@@ -526,7 +526,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-v3-binaries-${{ github.sha }}
           path: ./bin
@@ -571,7 +571,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-v3-binaries-${{ github.sha }}
           path: ./bin
@@ -625,7 +625,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-v3-binaries-${{ github.sha }}
           path: ./bin
@@ -765,7 +765,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-v3-binaries-${{ github.sha }}
           path: ./bin

--- a/.github/workflows/ci-v4.yml
+++ b/.github/workflows/ci-v4.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  tier: 1 }
-          - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, tier: 1 }
+          - { os: ubuntu-26.04-arm, target: aarch64-unknown-linux-gnu, tier: 1 }
           - { os: macos-14,         target: aarch64-apple-darwin,      tier: 1 }
           - { os: windows-latest,   target: x86_64-pc-windows-msvc,    tier: 1 }
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-v4.yml
+++ b/.github/workflows/ci-v4.yml
@@ -36,7 +36,7 @@ jobs:
           - { os: windows-latest,   target: x86_64-pc-windows-msvc,    tier: 1 }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -81,7 +81,7 @@ jobs:
     name: Build Windows ARM64 (Tier 2)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: aarch64-pc-windows-msvc }
       - name: Cross-compile (build only)
@@ -95,7 +95,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
 

--- a/.github/workflows/integration-test-providers.yml
+++ b/.github/workflows/integration-test-providers.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build Sindri CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, validate-runpod-configs]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, validate-northflank-configs]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download sindri binary
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/integration-test-providers.yml
+++ b/.github/workflows/integration-test-providers.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-integration-binary-${{ github.sha }}
           path: ./bin
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-integration-binary-${{ github.sha }}
           path: ./bin
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-integration-binary-${{ github.sha }}
           path: ./bin
@@ -249,7 +249,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download sindri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-integration-binary-${{ github.sha }}
           path: ./bin

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -101,7 +101,7 @@ jobs:
       tag: ${{ steps.derive.outputs.tag }}
       dry_run: ${{ steps.derive.outputs.dry_run }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: v4
           fetch-depth: 0
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-tag]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: v4
       - uses: dtolnay/rust-toolchain@stable
@@ -199,7 +199,7 @@ jobs:
           - { os: windows-latest,   runner: windows,     sample-component: "winget:GitHub.cli" }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: v4
       - uses: dtolnay/rust-toolchain@stable
@@ -273,7 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-tag]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: v4
 
@@ -416,7 +416,7 @@ jobs:
     outputs:
       index-path: ${{ steps.gen.outputs.index-path }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: v4
       - uses: dtolnay/rust-toolchain@stable
@@ -514,7 +514,7 @@ jobs:
       reference: ${{ steps.push.outputs.reference }}
       artifact-path: ${{ steps.push.outputs.artifact-path }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: v4
       - name: Download generated index
@@ -621,7 +621,7 @@ jobs:
       attestations: write   # store provenance in GitHub attestation store
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: v4
           sparse-checkout: |

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -518,7 +518,7 @@ jobs:
         with:
           ref: v4
       - name: Download generated index
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: registry-core-index
           path: v4/registry-core/
@@ -631,7 +631,7 @@ jobs:
       # Download the same index.yaml that was pushed, so attest-build-provenance
       # can compute its digest and cross-reference with the OCI manifest digest.
       - name: Download generated index (for attestation subject)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: registry-core-index
           path: attestation-subject/
@@ -678,13 +678,13 @@ jobs:
       packages: read   # read ghcr.io for oci:// reference lookup
     steps:
       - name: Download attestation bundle
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: slsa-provenance-bundle
           path: attestation-bundle/
 
       - name: Download index.yaml subject
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: registry-core-index
           path: attestation-subject/

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -565,7 +565,7 @@ jobs:
       signed-reference: ${{ steps.sign.outputs.signed-reference }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
         with:
           cosign-release: ${{ env.COSIGN_VERSION }}
       - name: Login to ghcr.io (cosign uploads sig as OCI ref)

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -278,7 +278,7 @@ jobs:
           ref: v4
 
       - name: Set up Python for ScanCode
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/registry-core-publish.yml
+++ b/.github/workflows/registry-core-publish.yml
@@ -194,7 +194,7 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-latest,    runner: linux,       sample-component: "mise:nodejs" }
-          - { os: ubuntu-24.04-arm, runner: linux-arm,   sample-component: "mise:nodejs" }
+          - { os: ubuntu-26.04-arm, runner: linux-arm,   sample-component: "mise:nodejs" }
           - { os: macos-14,         runner: macos,       sample-component: "brew:gh" }
           - { os: windows-latest,   runner: windows,     sample-component: "winget:GitHub.cli" }
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -165,7 +165,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download changelog artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: changelog-v2
 
@@ -513,12 +513,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download changelog artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: changelog-v2
 
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sbom-v${{ needs.validate-tag.outputs.version }}
 

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -355,7 +355,7 @@ jobs:
       attestations: write  # Required for provenance attestation
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -461,7 +461,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Get image digest
         id: digest

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -57,7 +57,7 @@ jobs:
       ci_image: ${{ steps.verify.outputs.ci_image }}
       image_digest: ${{ steps.verify.outputs.image_digest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -124,7 +124,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
       changelog_file: ${{ steps.changelog.outputs.changelog_file }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           ref: main
           fetch-depth: 0
@@ -510,7 +510,7 @@ jobs:
     outputs:
       release_url: ${{ steps.release.outputs.url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download changelog artifact
         uses: actions/download-artifact@v8.0.1
@@ -646,7 +646,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Notify success
         if: needs.create-release.result == 'success'

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -581,7 +581,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Download binary artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
 
@@ -683,7 +683,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download changelog artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: changelog-v3
 
@@ -812,17 +812,17 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
 
       - name: Download changelog
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: changelog-v3
 
       - name: Download SBOM
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sbom-v${{ needs.validate-tag.outputs.version }}
 

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -53,7 +53,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
       changelog_file: ${{ steps.changelog.outputs.changelog_file }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -108,7 +108,7 @@ jobs:
             platform: windows-x86_64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -188,7 +188,7 @@ jobs:
       commit_sha: ${{ steps.verify.outputs.commit_sha }}
       all_distros_available: ${{ steps.check-distros.outputs.all_distros_available }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -572,7 +572,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -677,7 +677,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           ref: main
           fetch-depth: 0
@@ -809,7 +809,7 @@ jobs:
     outputs:
       release_url: ${{ steps.release.outputs.url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@v8.0.1
@@ -1034,7 +1034,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Notify success
         if: needs.create-release.result == 'success'

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -438,7 +438,7 @@ jobs:
       attestations: write  # Required for provenance attestation
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -524,7 +524,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Get image digest
         id: digest

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -54,7 +54,7 @@ jobs:
     needs: [validate-tag, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with: { ref: v4 }
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/v2-deploy-sindri.yml
+++ b/.github/workflows/v2-deploy-sindri.yml
@@ -34,7 +34,7 @@ jobs:
       app-url: ${{ steps.deploy.outputs.app-url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: pip install yq

--- a/.github/workflows/v2-manual-deploy.yml
+++ b/.github/workflows/v2-manual-deploy.yml
@@ -89,7 +89,7 @@ jobs:
       region: ${{ steps.validate.outputs.region }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Validate and process inputs
         id: validate
@@ -173,7 +173,7 @@ jobs:
       image-tag: ${{ steps.build.outputs.tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Build image
         id: build
@@ -192,7 +192,7 @@ jobs:
       deployment-status: ${{ steps.deploy.outputs.status }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Generate sindri.yaml
         run: |
@@ -337,7 +337,7 @@ jobs:
     needs: [validate-inputs, deploy]
     if: always() && github.event.inputs.notify-slack == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Prepare notification
         id: notification

--- a/.github/workflows/v2-teardown-sindri.yml
+++ b/.github/workflows/v2-teardown-sindri.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: pip install yq

--- a/.github/workflows/v2-test-extensions.yml
+++ b/.github/workflows/v2-test-extensions.yml
@@ -131,7 +131,7 @@ jobs:
           sparse-checkout: v2/docker/lib/extensions
 
       - name: Download image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-test-image
           path: /tmp

--- a/.github/workflows/v2-test-extensions.yml
+++ b/.github/workflows/v2-test-extensions.yml
@@ -40,7 +40,7 @@ jobs:
       count: ${{ steps.matrix.outputs.count }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: |
@@ -92,7 +92,7 @@ jobs:
     if: needs.generate-matrix.outputs.count > 0
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -126,7 +126,7 @@ jobs:
         extension: ${{ fromJson(needs.generate-matrix.outputs.extensions) }}
     steps:
       - name: Checkout for extension info
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           sparse-checkout: v2/docker/lib/extensions
 

--- a/.github/workflows/v2-test-profiles.yml
+++ b/.github/workflows/v2-test-profiles.yml
@@ -141,7 +141,7 @@ jobs:
       count: ${{ steps.discover.outputs.count }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Discover sindri.yaml files
         id: discover
@@ -178,7 +178,7 @@ jobs:
         config: ${{ fromJson(needs.discover-configs.outputs.configs) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: pip install yq

--- a/.github/workflows/v2-test-provider.yml
+++ b/.github/workflows/v2-test-provider.yml
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       # Workflows live on main but the runner checks out the v2 branch (where
       # this workflow's caller lives). v2 doesn't have .github/actions/ or
@@ -104,7 +104,7 @@ jobs:
       # main's .github/ into _ci-shared/ so the local-action and helper-script
       # references below can resolve.
       - name: Side-checkout main's .github/ for shared actions/scripts
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           ref: main
           sparse-checkout: |

--- a/.github/workflows/v3-discover-extensions.yml
+++ b/.github/workflows/v3-discover-extensions.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Needed for changed detection
 

--- a/.github/workflows/v3-extension-test.yml
+++ b/.github/workflows/v3-extension-test.yml
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/v3-packer-build.yml
+++ b/.github/workflows/v3-packer-build.yml
@@ -45,7 +45,7 @@ jobs:
     name: Validate Packer Templates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -105,7 +105,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -158,7 +158,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Azure Login
         uses: azure/login@v3
@@ -214,7 +214,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -270,7 +270,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Configure OCI Credentials
         run: |
@@ -346,7 +346,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Configure Alibaba Cloud Credentials
         run: |

--- a/.github/workflows/v3-packer-build.yml
+++ b/.github/workflows/v3-packer-build.yml
@@ -394,7 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/v3-packer-test.yml
+++ b/.github/workflows/v3-packer-test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Download Build Manifest
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: aws-build-manifest
           run-id: ${{ github.event.workflow_run.id }}
@@ -356,7 +356,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/v3-packer-test.yml
+++ b/.github/workflows/v3-packer-test.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -119,7 +119,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Azure Login
         uses: azure/login@v3
@@ -178,7 +178,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -244,7 +244,7 @@ jobs:
       OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
       OCI_API_KEY: ${{ secrets.OCI_API_KEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Configure OCI Credentials
         run: |
@@ -305,7 +305,7 @@ jobs:
       ALICLOUD_ACCESS_KEY: ${{ secrets.ALICLOUD_ACCESS_KEY }}
       ALICLOUD_SECRET_KEY: ${{ secrets.ALICLOUD_SECRET_KEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/v3-pre-release-test.yml
+++ b/.github/workflows/v3-pre-release-test.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/v3-provider-devpod.yml
+++ b/.github/workflows/v3-provider-devpod.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Check credentials
         uses: ./.github/actions/shared/check-credentials
         with:
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install DevPod
         run: |

--- a/.github/workflows/v3-provider-devpod.yml
+++ b/.github/workflows/v3-provider-devpod.yml
@@ -273,7 +273,7 @@ jobs:
 
     steps:
       - name: Download All Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: results
           pattern: ${{ inputs.artifact-prefix }}devpod-result-*

--- a/.github/workflows/v3-provider-docker.yml
+++ b/.github/workflows/v3-provider-docker.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download CLI
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.artifact-prefix }}sindri-cli
           path: /tmp/sindri
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: Download All Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: results
           pattern: ${{ inputs.artifact-prefix }}docker-result-*

--- a/.github/workflows/v3-provider-docker.yml
+++ b/.github/workflows/v3-provider-docker.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Download CLI
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/v3-provider-e2b.yml
+++ b/.github/workflows/v3-provider-e2b.yml
@@ -386,7 +386,7 @@ jobs:
 
     steps:
       - name: Download All Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: results
           pattern: ${{ inputs.artifact-prefix }}e2b-result-*

--- a/.github/workflows/v3-provider-e2b.yml
+++ b/.github/workflows/v3-provider-e2b.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Check credentials
         uses: ./.github/actions/shared/check-credentials
         with:
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/v3-provider-fly.yml
+++ b/.github/workflows/v3-provider-fly.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Check credentials
         uses: ./.github/actions/shared/check-credentials
         with:
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/v3-provider-fly.yml
+++ b/.github/workflows/v3-provider-fly.yml
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: Download All Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: results
           pattern: ${{ inputs.artifact-prefix }}fly-result-*

--- a/.github/workflows/v3-provider-k3d.yml
+++ b/.github/workflows/v3-provider-k3d.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install k3d
         run: |

--- a/.github/workflows/v3-provider-northflank.yml
+++ b/.github/workflows/v3-provider-northflank.yml
@@ -298,7 +298,7 @@ jobs:
 
     steps:
       - name: Download All Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: results
           pattern: ${{ inputs.artifact-prefix }}northflank-result-*

--- a/.github/workflows/v3-provider-northflank.yml
+++ b/.github/workflows/v3-provider-northflank.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Check credentials
         uses: ./.github/actions/shared/check-credentials
         with:
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install Northflank CLI
         run: |

--- a/.github/workflows/v3-provider-packer.yml
+++ b/.github/workflows/v3-provider-packer.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Check credentials
         uses: ./.github/actions/shared/check-credentials
         with:
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -323,7 +323,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Configure Cloud CLI
         run: |

--- a/.github/workflows/v3-provider-packer.yml
+++ b/.github/workflows/v3-provider-packer.yml
@@ -495,7 +495,7 @@ jobs:
 
     steps:
       - name: Download All Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: results
           pattern: ${{ inputs.artifact-prefix }}packer-result-*

--- a/.github/workflows/v3-provider-runpod.yml
+++ b/.github/workflows/v3-provider-runpod.yml
@@ -273,7 +273,7 @@ jobs:
 
     steps:
       - name: Download All Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: results
           pattern: ${{ inputs.artifact-prefix }}runpod-result-*

--- a/.github/workflows/v3-provider-runpod.yml
+++ b/.github/workflows/v3-provider-runpod.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Check credentials
         uses: ./.github/actions/shared/check-credentials
         with:
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install runpodctl
         run: |

--- a/.github/workflows/v3-test-profiles.yml
+++ b/.github/workflows/v3-test-profiles.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download CLI artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: sindri-cli
           path: ./bin

--- a/.github/workflows/v3-test-profiles.yml
+++ b/.github/workflows/v3-test-profiles.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -103,7 +103,7 @@ jobs:
       count: ${{ steps.discover.outputs.count }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Discover sindri.yaml files
         id: discover
@@ -140,7 +140,7 @@ jobs:
         config: ${{ fromJson(needs.discover-configs.outputs.configs) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Download CLI artifact
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/validate-shell.yml
+++ b/.github/workflows/validate-shell.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install shellcheck
         run: |
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install shellcheck
         run: |

--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Skip if v2 source not present
         id: gate
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yamllint
         run: pip install yamllint
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yamllint
         run: pip install yamllint
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: |
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: |
@@ -243,7 +243,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: |
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: |
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install yq
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,199 @@
+# Ruflo — Claude Code Configuration
+
+## Rules
+
+- Do what has been asked; nothing more, nothing less
+- NEVER create files unless absolutely necessary — prefer editing existing files
+- NEVER create documentation files unless explicitly requested
+- NEVER save working files or tests to root — use `/src`, `/tests`, `/docs`, `/config`, `/scripts`
+- ALWAYS read a file before editing it
+- NEVER commit secrets, credentials, or .env files
+- Keep files under 500 lines
+- Validate input at system boundaries
+
+## Agent Comms (SendMessage-First Coordination)
+
+Named agents coordinate via `SendMessage`, not polling or shared state.
+
+```
+Lead (you) ←→ architect ←→ developer ←→ tester ←→ reviewer
+              (named agents message each other directly)
+```
+
+### Spawning a Coordinated Team
+
+```javascript
+// ALL agents in ONE message, each knows WHO to message next
+Agent({
+  prompt: "Research the codebase. SendMessage findings to 'architect'.",
+  subagent_type: "researcher",
+  name: "researcher",
+  run_in_background: true,
+});
+Agent({
+  prompt: "Wait for 'researcher'. Design solution. SendMessage to 'coder'.",
+  subagent_type: "system-architect",
+  name: "architect",
+  run_in_background: true,
+});
+Agent({
+  prompt: "Wait for 'architect'. Implement it. SendMessage to 'tester'.",
+  subagent_type: "coder",
+  name: "coder",
+  run_in_background: true,
+});
+Agent({
+  prompt: "Wait for 'coder'. Write tests. SendMessage results to 'reviewer'.",
+  subagent_type: "tester",
+  name: "tester",
+  run_in_background: true,
+});
+Agent({
+  prompt: "Wait for 'tester'. Review code quality and security.",
+  subagent_type: "reviewer",
+  name: "reviewer",
+  run_in_background: true,
+});
+
+// Kick off the pipeline
+SendMessage({ to: "researcher", summary: "Start", message: "[task context]" });
+```
+
+### Patterns
+
+| Pattern        | Flow                  | Use When                                |
+| -------------- | --------------------- | --------------------------------------- |
+| **Pipeline**   | A → B → C → D         | Sequential dependencies (feature dev)   |
+| **Fan-out**    | Lead → A, B, C → Lead | Independent parallel work (research)    |
+| **Supervisor** | Lead ↔ workers        | Ongoing coordination (complex refactor) |
+
+### Rules
+
+- ALWAYS name agents — `name: "role"` makes them addressable
+- ALWAYS include comms instructions in prompts — who to message, what to send
+- Spawn ALL agents in ONE message with `run_in_background: true`
+- After spawning: STOP, tell user what's running, wait for results
+- NEVER poll status — agents message back or complete automatically
+
+## Swarm & Routing
+
+### Config
+
+- **Topology**: hierarchical-mesh (anti-drift)
+- **Max Agents**: 15
+- **Memory**: hybrid
+- **HNSW**: Enabled
+- **Neural**: Enabled
+
+```bash
+npx @claude-flow/cli@latest swarm init --topology hierarchical --max-agents 8 --strategy specialized
+```
+
+### Agent Routing
+
+| Task        | Agents                             | Topology     |
+| ----------- | ---------------------------------- | ------------ |
+| Bug Fix     | researcher, coder, tester          | hierarchical |
+| Feature     | architect, coder, tester, reviewer | hierarchical |
+| Refactor    | architect, coder, reviewer         | hierarchical |
+| Performance | perf-engineer, coder               | hierarchical |
+| Security    | security-architect, auditor        | hierarchical |
+
+### When to Swarm
+
+- **YES**: 3+ files, new features, cross-module refactoring, API changes, security, performance
+- **NO**: single file edits, 1-2 line fixes, docs updates, config changes, questions
+
+### 3-Tier Model Routing
+
+| Tier | Handler              | Use Cases                                       |
+| ---- | -------------------- | ----------------------------------------------- |
+| 1    | Agent Booster (WASM) | Simple transforms — skip LLM, use Edit directly |
+| 2    | Haiku                | Simple tasks, low complexity                    |
+| 3    | Sonnet/Opus          | Architecture, security, complex reasoning       |
+
+## Memory & Learning
+
+### Before Any Task
+
+```bash
+npx @claude-flow/cli@latest memory search --query "[task keywords]" --namespace patterns
+npx @claude-flow/cli@latest hooks route --task "[task description]"
+```
+
+### After Success
+
+```bash
+npx @claude-flow/cli@latest memory store --namespace patterns --key "[name]" --value "[what worked]"
+npx @claude-flow/cli@latest hooks post-task --task-id "[id]" --success true --store-results true
+```
+
+### MCP Tools (use `ToolSearch("keyword")` to discover)
+
+| Category      | Key Tools                                                  |
+| ------------- | ---------------------------------------------------------- |
+| **Memory**    | `memory_store`, `memory_search`, `memory_search_unified`   |
+| **Bridge**    | `memory_import_claude`, `memory_bridge_status`             |
+| **Swarm**     | `swarm_init`, `swarm_status`, `swarm_health`               |
+| **Agents**    | `agent_spawn`, `agent_list`, `agent_status`                |
+| **Hooks**     | `hooks_route`, `hooks_post-task`, `hooks_worker-dispatch`  |
+| **Security**  | `aidefence_scan`, `aidefence_is_safe`, `aidefence_has_pii` |
+| **Hive-Mind** | `hive-mind_init`, `hive-mind_consensus`, `hive-mind_spawn` |
+
+### Background Workers
+
+| Worker     | When                   |
+| ---------- | ---------------------- |
+| `audit`    | After security changes |
+| `optimize` | After performance work |
+| `testgaps` | After adding features  |
+| `map`      | Every 5+ file changes  |
+| `document` | After API changes      |
+
+```bash
+npx @claude-flow/cli@latest hooks worker dispatch --trigger audit
+```
+
+## Agents
+
+**Core**: `coder`, `reviewer`, `tester`, `planner`, `researcher`
+**Architecture**: `system-architect`, `backend-dev`, `mobile-dev`
+**Security**: `security-architect`, `security-auditor`
+**Performance**: `performance-engineer`, `perf-analyzer`
+**Coordination**: `hierarchical-coordinator`, `mesh-coordinator`, `adaptive-coordinator`
+**GitHub**: `pr-manager`, `code-review-swarm`, `issue-tracker`, `release-manager`
+
+Any string works as a custom agent type.
+
+## Build & Test
+
+- ALWAYS run tests after code changes
+- ALWAYS verify build succeeds before committing
+
+```bash
+npm run build && npm test
+```
+
+## CLI Quick Reference
+
+```bash
+npx @claude-flow/cli@latest init --wizard           # Setup
+npx @claude-flow/cli@latest swarm init --v3-mode     # Start swarm
+npx @claude-flow/cli@latest memory search --query "" # Vector search
+npx @claude-flow/cli@latest hooks route --task ""    # Route to agent
+npx @claude-flow/cli@latest doctor --fix             # Diagnostics
+npx @claude-flow/cli@latest security scan            # Security scan
+npx @claude-flow/cli@latest performance benchmark    # Benchmarks
+```
+
+26 commands, 140+ subcommands. Use `--help` on any command for details.
+
+## Setup
+
+```bash
+claude mcp add claude-flow -- npx -y @claude-flow/cli@latest
+npx @claude-flow/cli@latest daemon start
+npx @claude-flow/cli@latest doctor --fix
+```
+
+**Agent tool** handles execution (agents, files, code, git). **MCP tools** handle coordination (swarm, memory, hooks). **CLI** is the same via Bash.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Azure, and other cloud providers using YAML-defined extensions.
 
 ## Pick your version
 
-| Branch                                               | Stack                        | Status                                    | What's there                                                         |
-| ---------------------------------------------------- | ---------------------------- | ----------------------------------------- | -------------------------------------------------------------------- |
+| Branch                                               | Stack                        | Status                                                                             | What's there                                                         |
+| ---------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | **[`v1`](https://github.com/pacphi/sindri-legacy)**  | legacy bash                  | **Archived** — see [pacphi/sindri-legacy](https://github.com/pacphi/sindri-legacy) | Source + 8 release tags live in the legacy repo                      |
-| **[`v2`](https://github.com/pacphi/sindri/tree/v2)** | Bash + Docker                | **Maintenance**                           | CLI, Docker compose, deploy scripts, extensions                      |
-| **[`v3`](https://github.com/pacphi/sindri/tree/v3)** | Rust workspace + npm wrapper | **Active**                                | Cargo workspace, `@pacphi/sindri-cli` packages, full provider matrix |
-| **[`v4`](https://github.com/pacphi/sindri/tree/v4)** | Rust, redesigned             | **Pre-release**                           | New architecture: registry-core, renovate-plugin, tools              |
+| **[`v2`](https://github.com/pacphi/sindri/tree/v2)** | Bash + Docker                | **Maintenance**                                                                    | CLI, Docker compose, deploy scripts, extensions                      |
+| **[`v3`](https://github.com/pacphi/sindri/tree/v3)** | Rust workspace + npm wrapper | **Active**                                                                         | Cargo workspace, `@pacphi/sindri-cli` packages, full provider matrix |
+| **[`v4`](https://github.com/pacphi/sindri/tree/v4)** | Rust, redesigned             | **Pre-release**                                                                    | New architecture: registry-core, renovate-plugin, tools              |
 
 Not sure which to use? Read the [Migration Hub](docs/migration/README.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,12 @@ Pick the version you're using, or read the [Migration Hub](migration/) if you're
 
 ## Versions at a glance
 
-| Branch | Status | Stack | Start here |
-| --- | --- | --- | --- |
-| [`v1`](https://github.com/pacphi/sindri-legacy) | Archived — see [pacphi/sindri-legacy](https://github.com/pacphi/sindri-legacy) | Legacy bash | [Legacy releases](https://github.com/pacphi/sindri-legacy/releases) |
-| [`v2`](https://github.com/pacphi/sindri/tree/v2) | Maintenance | Bash + Docker | [v2 Quickstart](https://github.com/pacphi/sindri/blob/v2/v2/docs/QUICKSTART.md) |
-| [`v3`](https://github.com/pacphi/sindri/tree/v3) | **Active** — recommended for new projects | Rust workspace + npm wrapper | [v3 Getting Started](https://github.com/pacphi/sindri/blob/v3/v3/docs/GETTING_STARTED.md) |
-| [`v4`](https://github.com/pacphi/sindri/tree/v4) | Pre-release | Rust, redesigned | [v4 ADRs](https://github.com/pacphi/sindri/tree/v4/v4/docs/ADRs) |
+| Branch                                           | Status                                                                         | Stack                        | Start here                                                                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------- |
+| [`v1`](https://github.com/pacphi/sindri-legacy)  | Archived — see [pacphi/sindri-legacy](https://github.com/pacphi/sindri-legacy) | Legacy bash                  | [Legacy releases](https://github.com/pacphi/sindri-legacy/releases)                       |
+| [`v2`](https://github.com/pacphi/sindri/tree/v2) | Maintenance                                                                    | Bash + Docker                | [v2 Quickstart](https://github.com/pacphi/sindri/blob/v2/v2/docs/QUICKSTART.md)           |
+| [`v3`](https://github.com/pacphi/sindri/tree/v3) | **Active** — recommended for new projects                                      | Rust workspace + npm wrapper | [v3 Getting Started](https://github.com/pacphi/sindri/blob/v3/v3/docs/GETTING_STARTED.md) |
+| [`v4`](https://github.com/pacphi/sindri/tree/v4) | Pre-release                                                                    | Rust, redesigned             | [v4 ADRs](https://github.com/pacphi/sindri/tree/v4/v4/docs/ADRs)                          |
 
 ## Per-version documentation
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -12,11 +12,11 @@ This guide explains how to create and publish new releases for Sindri.
 
 Sindri uses **automated releases** triggered by Git tags. After the April 2026 reorg, all release workflows live on `main` and are dispatched by tag pattern.
 
-| Tag pattern | Workflow on `main`                       | Source branch | Artifact type                              |
-| ----------- | ---------------------------------------- | ------------- | ------------------------------------------ |
-| `v2.*.*`    | `.github/workflows/release-v2.yml`       | `v2`          | Multi-distro Docker images + GHCR + cosign |
-| `v3.*.*`    | `.github/workflows/release-v3.yml`       | `v3`          | Rust binaries (cargo-dist) + Docker        |
-| `v4.*.*`    | `.github/workflows/release-v4.yml` (uses `_release-cargo-dist.yml`) | `v4` | Rust binaries (cargo-dist) |
+| Tag pattern | Workflow on `main`                                                  | Source branch | Artifact type                              |
+| ----------- | ------------------------------------------------------------------- | ------------- | ------------------------------------------ |
+| `v2.*.*`    | `.github/workflows/release-v2.yml`                                  | `v2`          | Multi-distro Docker images + GHCR + cosign |
+| `v3.*.*`    | `.github/workflows/release-v3.yml`                                  | `v3`          | Rust binaries (cargo-dist) + Docker        |
+| `v4.*.*`    | `.github/workflows/release-v4.yml` (uses `_release-cargo-dist.yml`) | `v4`          | Rust binaries (cargo-dist)                 |
 
 When you push a version tag, GitHub Actions automatically:
 
@@ -98,11 +98,11 @@ gh run watch
 
 Expected jobs (v4 example):
 
-| Job              | Purpose                                                              |
-| ---------------- | -------------------------------------------------------------------- |
-| `validate-tag`   | Confirms tag matches `^v4\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$`         |
-| `build`          | Calls `_release-cargo-dist.yml` to build cross-platform binaries     |
-| `publish`        | Creates the GitHub Release with `v4/RELEASE_NOTES.md` as body        |
+| Job            | Purpose                                                          |
+| -------------- | ---------------------------------------------------------------- |
+| `validate-tag` | Confirms tag matches `^v4\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$`    |
+| `build`        | Calls `_release-cargo-dist.yml` to build cross-platform binaries |
+| `publish`      | Creates the GitHub Release with `v4/RELEASE_NOTES.md` as body    |
 
 For v2 / v3, additional jobs run (changelog generation, Docker image build + GHCR push, cosign signing, SBOM, doc updates for stable releases).
 

--- a/docs/ides/README.md
+++ b/docs/ides/README.md
@@ -273,11 +273,11 @@ Local Docker development runs containers on your machine, with your IDE connecti
 
 Per-version reference docs live on each version branch — pick the version you're running:
 
-| Topic | v2 (Bash + Docker) | v3 (Rust CLI) |
-| --- | --- | --- |
-| Architecture | [v2 ARCHITECTURE](https://github.com/pacphi/sindri/blob/v2/v2/docs/ARCHITECTURE.md) | [v3 ARCHITECTURE](https://github.com/pacphi/sindri/blob/v3/v3/docs/ARCHITECTURE.md) |
-| Deployment | [v2 DEPLOYMENT](https://github.com/pacphi/sindri/blob/v2/v2/docs/DEPLOYMENT.md) | [v3 DEPLOYMENT](https://github.com/pacphi/sindri/blob/v3/v3/docs/DEPLOYMENT.md) |
-| Configuration | [v2 CONFIGURATION](https://github.com/pacphi/sindri/blob/v2/v2/docs/CONFIGURATION.md) | [v3 CONFIGURATION](https://github.com/pacphi/sindri/blob/v3/v3/docs/CONFIGURATION.md) |
+| Topic           | v2 (Bash + Docker)                                                                        | v3 (Rust CLI)                                                                             |
+| --------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Architecture    | [v2 ARCHITECTURE](https://github.com/pacphi/sindri/blob/v2/v2/docs/ARCHITECTURE.md)       | [v3 ARCHITECTURE](https://github.com/pacphi/sindri/blob/v3/v3/docs/ARCHITECTURE.md)       |
+| Deployment      | [v2 DEPLOYMENT](https://github.com/pacphi/sindri/blob/v2/v2/docs/DEPLOYMENT.md)           | [v3 DEPLOYMENT](https://github.com/pacphi/sindri/blob/v3/v3/docs/DEPLOYMENT.md)           |
+| Configuration   | [v2 CONFIGURATION](https://github.com/pacphi/sindri/blob/v2/v2/docs/CONFIGURATION.md)     | [v3 CONFIGURATION](https://github.com/pacphi/sindri/blob/v3/v3/docs/CONFIGURATION.md)     |
 | Troubleshooting | [v2 TROUBLESHOOTING](https://github.com/pacphi/sindri/blob/v2/v2/docs/TROUBLESHOOTING.md) | [v3 TROUBLESHOOTING](https://github.com/pacphi/sindri/blob/v3/v3/docs/TROUBLESHOOTING.md) |
 
 For v4 (pre-release, redesigned), see the [v4 ADRs](https://github.com/pacphi/sindri/tree/v4/v4/docs/ADRs).

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -95,12 +95,12 @@ Step-by-step practical instructions:
 
 These live alongside the code on each version branch — not on `main`.
 
-| Version | Source tree | Top-level docs |
-| --- | --- | --- |
-| v1 | [`pacphi/sindri-legacy`](https://github.com/pacphi/sindri-legacy) (separate repo) | [Legacy releases](https://github.com/pacphi/sindri-legacy/releases) |
-| v2 | [`v2` branch](https://github.com/pacphi/sindri/tree/v2/v2) | [v2 docs](https://github.com/pacphi/sindri/tree/v2/v2/docs) |
-| v3 | [`v3` branch](https://github.com/pacphi/sindri/tree/v3/v3) | [v3 docs](https://github.com/pacphi/sindri/tree/v3/v3/docs) |
-| v4 | [`v4` branch](https://github.com/pacphi/sindri/tree/v4/v4) | [v4 ADRs / DDDs](https://github.com/pacphi/sindri/tree/v4/v4/docs) |
+| Version | Source tree                                                                       | Top-level docs                                                      |
+| ------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| v1      | [`pacphi/sindri-legacy`](https://github.com/pacphi/sindri-legacy) (separate repo) | [Legacy releases](https://github.com/pacphi/sindri-legacy/releases) |
+| v2      | [`v2` branch](https://github.com/pacphi/sindri/tree/v2/v2)                        | [v2 docs](https://github.com/pacphi/sindri/tree/v2/v2/docs)         |
+| v3      | [`v3` branch](https://github.com/pacphi/sindri/tree/v3/v3)                        | [v3 docs](https://github.com/pacphi/sindri/tree/v3/v3/docs)         |
+| v4      | [`v4` branch](https://github.com/pacphi/sindri/tree/v4/v4)                        | [v4 ADRs / DDDs](https://github.com/pacphi/sindri/tree/v4/v4/docs)  |
 
 ### Getting help
 
@@ -112,12 +112,12 @@ These live alongside the code on each version branch — not on `main`.
 
 ## Version support timeline
 
-| Version | Status | Recommendation |
-| --- | --- | --- |
-| **v1** | Archived in [pacphi/sindri-legacy](https://github.com/pacphi/sindri-legacy) | Plan an upgrade |
-| **v2** | Maintenance | Bug/security fixes; no new features |
-| **v3** | Active development | Recommended for new projects |
-| **v4** | Pre-release | New architecture (ADRs/DDDs published); not yet GA |
+| Version | Status                                                                      | Recommendation                                     |
+| ------- | --------------------------------------------------------------------------- | -------------------------------------------------- |
+| **v1**  | Archived in [pacphi/sindri-legacy](https://github.com/pacphi/sindri-legacy) | Plan an upgrade                                    |
+| **v2**  | Maintenance                                                                 | Bug/security fixes; no new features                |
+| **v3**  | Active development                                                          | Recommended for new projects                       |
+| **v4**  | Pre-release                                                                 | New architecture (ADRs/DDDs published); not yet GA |
 
 A v3 → v4 migration guide will land here when v4 reaches a stable surface.
 


### PR DESCRIPTION
## Summary

Consolidates PRs #297, #298, #299, #300, #301 into a single branch and applies ubuntu 26.04 consistency across all main-branch workflows.

**GHA action bumps (replaces individual dependabot PRs):**
- `actions/setup-python`: 5.6.0 → 6.2.0 (#297)
- `cargo-bins/cargo-binstall`: 1.19.0 → 1.19.1 (#298)
- `actions/download-artifact`: 4.3.0 → 8.0.1 (#299)
- `actions/checkout`: 4.3.1 → 6.0.2 (#300)
- `sigstore/cosign-installer`: 3.9.2 → 4.1.2 (#301)

**Ubuntu 26.04 consistency:**
- `ci-v4.yml`, `registry-core-publish.yml`: `ubuntu-24.04-arm` → `ubuntu-26.04-arm`
- `build-base-image.yml`: default `ubuntu_version` `24.04` → `26.04` (dispatch + workflow_call + fallback)

**Formatting:** Applied prettier to governance markdown files (pre-existing drift).

## Test plan

- [x] `make lint-yaml` — yamllint passes
- [x] `make lint-markdown` — markdownlint passes (0 errors)
- [x] `make format-check` — prettier clean
- [ ] CI validation via push

**Closes:** #297, #298, #299, #300, #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)