### PR TITLE
ci(v2): ubuntu 24.04 → 26.04 (Dockerfile + script docs)

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -5,7 +5,7 @@
 # =============================================================================
 # Stage 1: Builder - Download and prepare external tools
 # =============================================================================
-FROM ubuntu:24.04 AS builder
+FROM ubuntu:26.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -27,7 +27,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # =============================================================================
 # Stage 2: Final - Production image
 # =============================================================================
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.title="Sindri Development Environment"
 LABEL org.opencontainers.image.description="Provider-agnostic cloud dev environment with extensible tooling and pre-configured runtimes"

--- a/v2/docker/lib/extensions/dotnet/install.sh
+++ b/v2/docker/lib/extensions/dotnet/install.sh
@@ -29,7 +29,7 @@ if command_exists dotnet; then
   exit 0
 fi
 
-# Add .NET backports PPA if requested (for .NET 9 or older versions on Ubuntu 24.04)
+# Add .NET backports PPA if requested (for .NET 9 or older versions on Ubuntu 24.04/26.04)
 if [[ "${EXT_USE_DOTNET_BACKPORTS:-false}" == "true" ]]; then
   print_status "Adding Ubuntu .NET backports PPA..."
   $SUDO add-apt-repository -y ppa:dotnet/backports 2>/dev/null || print_warning "Backports PPA failed"

--- a/v2/scripts/setup-sysbox-host.sh
+++ b/v2/scripts/setup-sysbox-host.sh
@@ -16,7 +16,7 @@
 #   ./scripts/setup-sysbox-host.sh --version v0.6.7  # Install specific version
 #
 # Requirements:
-#   - Ubuntu 18.04-24.04 or Debian 10-11
+#   - Ubuntu 18.04-26.04 or Debian 10-11
 #   - Docker installed (not via snap)
 #   - Linux kernel 5.12+ recommended (5.19+ optimal)
 #   - Root/sudo access


### PR DESCRIPTION
## Summary

Applies ubuntu 26.04 across all v2 version references.

**Changes:**
- `v2/Dockerfile`: `FROM ubuntu:24.04` → `FROM ubuntu:26.04` (builder + final stages) — from dependabot PR #290
- `v2/scripts/setup-sysbox-host.sh`: supported range `18.04–24.04` → `18.04–26.04`
- `v2/docker/lib/extensions/dotnet/install.sh`: backports PPA comment notes `24.04/26.04`

**Slides checked:** `v2/docs/slides/*.html` — no hard ubuntu version references (uses "jammy" apt sources only).

## Test plan

- [x] `yamllint` on extension YAMLs — passes
- [x] `shellcheck` on modified scripts — info-level only (pre-existing, none from our changes)
- [ ] Docker build validation via CI

**Closes:** #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)