### PR TITLE
deps(v4): consolidate Cargo bumps + API migrations + ubuntu 26.04 docs

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1136,7 +1136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3420,7 +3420,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3479,7 +3479,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4227,7 +4227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4354,7 +4354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4482,9 +4482,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -5028,7 +5028,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -899,6 +899,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,12 +1054,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1058,7 +1068,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -1097,7 +1107,7 @@ dependencies = [
  "group",
  "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2714,9 +2724,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2727,11 +2737,11 @@ checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes",
  "cbc",
- "der",
+ "der 0.7.10",
  "pbkdf2",
  "scrypt",
  "sha2 0.10.9",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2740,10 +2750,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs5",
  "rand_core 0.6.4",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3358,10 +3378,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature",
- "spki",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -3607,9 +3627,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -3870,7 +3890,7 @@ dependencies = [
  "p384",
  "pem",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
@@ -4080,7 +4100,7 @@ dependencies = [
  "oci-client 0.16.1",
  "oci-spec 0.9.0",
  "p256",
- "pkcs8",
+ "pkcs8 0.11.0",
  "rand_core 0.6.4",
  "rcgen",
  "reqwest 0.12.28",
@@ -4223,7 +4243,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -5352,10 +5382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid 0.9.6",
- "der",
+ "der 0.7.10",
  "sha1",
  "signature",
- "spki",
+ "spki 0.7.3",
  "tls_codec",
 ]
 

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -4130,7 +4130,7 @@ dependencies = [
  "oci-spec 0.9.0",
  "p256",
  "pkcs8 0.11.0",
- "rand_core 0.9.5",
+ "rand_core 0.6.4",
  "rcgen",
  "reqwest 0.12.28",
  "schemars 1.2.1",

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -2022,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.3"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe92a2f8b00686061eab5cdcfd6f382c27f2084456e7be90ae9f0fe4a30552a"
+checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3214,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.3"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e125f10bdcd507598c702daada18c47fe5bfba4d7a9545b015b5d432f7168ca3"
+checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -4101,7 +4101,7 @@ dependencies = [
  "oci-spec 0.9.0",
  "p256",
  "pkcs8 0.11.0",
- "rand_core 0.6.4",
+ "rand_core 0.9.5",
  "rcgen",
  "reqwest 0.12.28",
  "schemars 1.2.1",

--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -505,13 +505,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1419,6 +1430,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3103,6 +3115,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3162,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -4155,7 +4184,7 @@ dependencies = [
  "dirs-next",
  "hex",
  "hkdf 0.13.0",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/v4/Cargo.toml
+++ b/v4/Cargo.toml
@@ -59,7 +59,7 @@ ecdsa = { version = "0.16", default-features = false, features = ["pem", "pkcs8"
 x509-cert = { version = "0.2", default-features = false, features = ["std"] }
 # DER + PEM trait imports used by the keyless verifier alongside `x509-cert`.
 # Matches sigstore 0.13's pinned version.
-pkcs8 = { version = "0.10", default-features = false, features = ["std"] }
+pkcs8 = { version = "0.11", default-features = false, features = ["std"] }
 # base64 decoding for cosign signature annotation payloads (ADR-014).
 base64 = "0.22"
 tempfile = "3"

--- a/v4/crates/sindri-core/src/paths.rs
+++ b/v4/crates/sindri-core/src/paths.rs
@@ -51,6 +51,11 @@ pub fn sindri_subpath(rest: &[&str]) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialise all tests that mutate SINDRI_HOME to prevent concurrent
+    // env-var interference (env::set_var is not thread-safe).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // ---------------------------------------------------------------------------
     // home_dir — SINDRI_HOME override
@@ -58,6 +63,7 @@ mod tests {
 
     #[test]
     fn home_dir_honours_sindri_home_env() {
+        let _g = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var(SINDRI_HOME_ENV, "/tmp/fake-home") };
         let h = home_dir();
         unsafe { std::env::remove_var(SINDRI_HOME_ENV) };
@@ -66,6 +72,7 @@ mod tests {
 
     #[test]
     fn home_dir_empty_sindri_home_falls_back_to_dirs_next() {
+        let _g = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var(SINDRI_HOME_ENV, "") };
         let h = home_dir();
         unsafe { std::env::remove_var(SINDRI_HOME_ENV) };
@@ -76,6 +83,7 @@ mod tests {
 
     #[test]
     fn home_dir_without_env_does_not_panic() {
+        let _g = ENV_LOCK.lock().unwrap();
         unsafe { std::env::remove_var(SINDRI_HOME_ENV) };
         let _ = home_dir(); // must not panic
     }

--- a/v4/crates/sindri-core/src/paths.rs
+++ b/v4/crates/sindri-core/src/paths.rs
@@ -48,14 +48,20 @@ pub fn sindri_subpath(rest: &[&str]) -> Option<PathBuf> {
     Some(p)
 }
 
+/// Test-only mutex to serialise any test in the `sindri-core` test binary
+/// that mutates the process environment. `std::env::set_var` is not thread-safe
+/// (it mutates the global environ table and can race with concurrent
+/// `env::var` reads anywhere in the process). Any test that calls
+/// `env::set_var` or `env::remove_var` MUST hold this lock first.
+///
+/// Shared across paths.rs and platform.rs tests (both run in the same
+/// sindri-core test binary).
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // Serialise all tests that mutate SINDRI_HOME to prevent concurrent
-    // env-var interference (env::set_var is not thread-safe).
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // ---------------------------------------------------------------------------
     // home_dir — SINDRI_HOME override

--- a/v4/crates/sindri-core/src/paths.rs
+++ b/v4/crates/sindri-core/src/paths.rs
@@ -100,6 +100,7 @@ mod tests {
 
     #[test]
     fn sindri_subpath_empty_rest_is_dot_sindri() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe { std::env::set_var(SINDRI_HOME_ENV, "/tmp/h") };
         let p = sindri_subpath(&[]);
         unsafe { std::env::remove_var(SINDRI_HOME_ENV) };
@@ -108,6 +109,7 @@ mod tests {
 
     #[test]
     fn sindri_subpath_single_segment() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe { std::env::set_var(SINDRI_HOME_ENV, "/tmp/h") };
         let p = sindri_subpath(&["cache"]);
         unsafe { std::env::remove_var(SINDRI_HOME_ENV) };
@@ -116,6 +118,7 @@ mod tests {
 
     #[test]
     fn sindri_subpath_multiple_segments() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe { std::env::set_var(SINDRI_HOME_ENV, "/tmp/h") };
         let p = sindri_subpath(&["trust", "keys", "registry.pub"]);
         unsafe { std::env::remove_var(SINDRI_HOME_ENV) };

--- a/v4/crates/sindri-core/src/platform.rs
+++ b/v4/crates/sindri-core/src/platform.rs
@@ -103,6 +103,9 @@ pub struct Capabilities {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Shared sindri-core test mutex — serialises every test in this binary
+    // that mutates the process env. See `crate::paths::ENV_LOCK` docs.
+    use crate::paths::ENV_LOCK;
 
     // ---------------------------------------------------------------------------
     // Platform::triple — all 6 combinations
@@ -223,8 +226,8 @@ mod tests {
 
     #[test]
     fn current_env_override_linux_x86_64() {
-        // Serial: env mutation — use std::env carefully in unit tests.
-        // SAFETY: this test must not run concurrently with other env-mutating tests.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: ENV_LOCK serialises env mutations across the test binary.
         unsafe { std::env::set_var("SINDRI_TEST_PLATFORM_OVERRIDE", "linux-x86_64") };
         let p = Platform::current();
         unsafe { std::env::remove_var("SINDRI_TEST_PLATFORM_OVERRIDE") };
@@ -234,6 +237,7 @@ mod tests {
 
     #[test]
     fn current_env_override_macos_aarch64() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe { std::env::set_var("SINDRI_TEST_PLATFORM_OVERRIDE", "macos-aarch64") };
         let p = Platform::current();
         unsafe { std::env::remove_var("SINDRI_TEST_PLATFORM_OVERRIDE") };
@@ -243,6 +247,7 @@ mod tests {
 
     #[test]
     fn current_without_override_does_not_panic() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Remove the var if a previous test left it set.
         unsafe { std::env::remove_var("SINDRI_TEST_PLATFORM_OVERRIDE") };
         let _p = Platform::current(); // must not panic

--- a/v4/crates/sindri-extensions/src/hooks.rs
+++ b/v4/crates/sindri-extensions/src/hooks.rs
@@ -276,7 +276,9 @@ fn validate_script_file(path: &Path, os: &Os) -> Result<(), String> {
 /// on all GitHub-hosted Windows runners).
 fn build_command(script: &Path, phase: Phase, version: &str, prior: &str, _os: &Os) -> String {
     let s = script.display();
-    let is_ps1 = script.extension().is_some_and(|e| e.eq_ignore_ascii_case("ps1"));
+    let is_ps1 = script
+        .extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("ps1"));
     if is_ps1 {
         format!(
             "pwsh -NonInteractive -File {} {} {} {}",

--- a/v4/crates/sindri-extensions/src/hooks.rs
+++ b/v4/crates/sindri-extensions/src/hooks.rs
@@ -268,23 +268,31 @@ fn validate_script_file(path: &Path, os: &Os) -> Result<(), String> {
 /// interpreter rather than directly so we don't depend on the +x bit
 /// being preserved through OCI extraction (which often strips modes
 /// outside ustar's set).
-fn build_command(script: &Path, phase: Phase, version: &str, prior: &str, os: &Os) -> String {
+///
+/// The interpreter is chosen by script extension, not by OS: `.ps1` files
+/// always use `pwsh`, `.sh` files always use `bash`. This matters on Windows
+/// when only a `.sh` variant exists — `pick_variant` falls back to it and
+/// the script must still be executed by bash (available via Git for Windows
+/// on all GitHub-hosted Windows runners).
+fn build_command(script: &Path, phase: Phase, version: &str, prior: &str, _os: &Os) -> String {
     let s = script.display();
-    match os {
-        Os::Windows => format!(
+    let is_ps1 = script.extension().is_some_and(|e| e.eq_ignore_ascii_case("ps1"));
+    if is_ps1 {
+        format!(
             "pwsh -NonInteractive -File {} {} {} {}",
             shquote(&s.to_string()),
             phase.as_str(),
             shquote(version),
             shquote(prior),
-        ),
-        _ => format!(
+        )
+    } else {
+        format!(
             "bash {} {} {} {}",
             shquote(&s.to_string()),
             phase.as_str(),
             shquote(version),
             shquote(prior),
-        ),
+        )
     }
 }
 

--- a/v4/crates/sindri-extensions/src/lib.rs
+++ b/v4/crates/sindri-extensions/src/lib.rs
@@ -20,6 +20,13 @@ pub mod project_init;
 pub mod redeemer;
 pub mod validate;
 
+/// Test-only mutex serialising every test in the `sindri-extensions` test
+/// binary that mutates the process environment. `std::env::set_var` is not
+/// thread-safe; any test calling `env::set_var` or `env::remove_var` must
+/// hold this lock first.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub use collision::{CollisionContext, CollisionPlan, CollisionResolver};
 pub use configure::{ConfigureContext, ConfigureExecutor};
 pub use error::ExtensionError;

--- a/v4/crates/sindri-extensions/src/redeemer.rs
+++ b/v4/crates/sindri-extensions/src/redeemer.rs
@@ -614,8 +614,8 @@ mod tests {
 
     #[test]
     fn resolve_from_env_reads_process_env() {
-        // SAFETY: tests are single-threaded by default in `cargo test` only
-        // when --test-threads=1; we use a unique key to avoid collisions.
+        let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: ENV_LOCK serialises env mutations across the test binary.
         std::env::set_var("SINDRI_TEST_REDEEM_ENV", "the-secret-value");
         let v = resolve_source(&AuthSource::FromEnv {
             var: "SINDRI_TEST_REDEEM_ENV".into(),
@@ -644,6 +644,7 @@ mod tests {
 
     #[test]
     fn redeem_install_scope_envvar_round_trips() {
+        let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("SINDRI_TEST_INSTALL_KEY", "k1");
         let auth = AuthRequirements {
             tokens: vec![token_req(
@@ -713,6 +714,7 @@ mod tests {
 
     #[test]
     fn file_redemption_writes_with_mode() {
+        let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let target_path = dir.path().join("creds.json");
         std::env::set_var("SINDRI_TEST_FILE_VAL", "{ \"k\": \"v\" }");
@@ -757,6 +759,7 @@ mod tests {
 
     #[test]
     fn cleanup_persist_keeps_file() {
+        let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let target_path = dir.path().join("keep.json");
         std::env::set_var("SINDRI_TEST_PERSIST_VAL", "abc");
@@ -798,6 +801,7 @@ mod tests {
 
     #[test]
     fn env_file_redemption_sets_var_to_path() {
+        let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let target_path = dir.path().join("gcp.json");
         std::env::set_var("SINDRI_TEST_ENVFILE_VAL", "json-payload");

--- a/v4/crates/sindri-registry/Cargo.toml
+++ b/v4/crates/sindri-registry/Cargo.toml
@@ -64,7 +64,7 @@ tokio = { workspace = true }
 # Phase 4.5 cache-eviction tests need to age cache directories deterministically.
 # `filetime` is already a transitive dep (via tar) so this only enables direct use.
 filetime = "0.2"
-rand_core = { version = "0.9", features = ["std"] }
+rand_core = { version = "0.6", features = ["std", "getrandom"] }
 serde_json = { workspace = true }
 # Wave 5A — D7: in-process HTTP mock server for OCI Distribution Spec tests.
 # These tests do not require network access and run on every `cargo test`

--- a/v4/crates/sindri-registry/Cargo.toml
+++ b/v4/crates/sindri-registry/Cargo.toml
@@ -64,7 +64,7 @@ tokio = { workspace = true }
 # Phase 4.5 cache-eviction tests need to age cache directories deterministically.
 # `filetime` is already a transitive dep (via tar) so this only enables direct use.
 filetime = "0.2"
-rand_core = { version = "0.6", features = ["std"] }
+rand_core = { version = "0.9", features = ["std"] }
 serde_json = { workspace = true }
 # Wave 5A — D7: in-process HTTP mock server for OCI Distribution Spec tests.
 # These tests do not require network access and run on every `cargo test`

--- a/v4/crates/sindri-registry/src/keyless.rs
+++ b/v4/crates/sindri-registry/src/keyless.rs
@@ -502,7 +502,7 @@ fn parse_and_validate_fulcio_cert(
 
     // 2. Parse the DER as an x509 certificate using sigstore's vendored
     //    `x509-cert` types (re-exported from sigstore::cosign).
-    use pkcs8::der::Decode;
+    use x509_cert::der::Decode;
     use x509_cert::Certificate;
     let cert = Certificate::from_der(&leaf_der).map_err(|e| RegistryError::FulcioChainInvalid {
         registry: registry_name.to_string(),
@@ -581,7 +581,7 @@ fn pem_to_der(pem: &[u8]) -> Result<Vec<u8>, String> {
 /// to check whether the leaf's issuer DN is one we trust.
 #[cfg(feature = "keyless")]
 fn collect_pem_subject_dns(pem_bundle: &[u8]) -> Result<Vec<String>, RegistryError> {
-    use pkcs8::der::Decode;
+    use x509_cert::der::Decode;
     use x509_cert::Certificate;
 
     let s = std::str::from_utf8(pem_bundle).map_err(|e| RegistryError::FulcioChainInvalid {
@@ -633,7 +633,7 @@ fn collect_pem_subject_dns(pem_bundle: &[u8]) -> Result<Vec<String>, RegistryErr
 /// public-good Fulcio still emits as of April 2026.
 #[cfg(feature = "keyless")]
 fn extract_san_and_issuer(cert: &x509_cert::Certificate) -> Result<(String, String), String> {
-    use pkcs8::der::Encode;
+    use x509_cert::der::Encode;
     let extensions = cert
         .tbs_certificate
         .extensions

--- a/v4/crates/sindri-secrets/Cargo.toml
+++ b/v4/crates/sindri-secrets/Cargo.toml
@@ -25,7 +25,7 @@ chacha20poly1305 = "0.10"
 hkdf = "0.13"
 sha2 = { workspace = true }
 # Random nonce generation
-rand = "0.9"
+rand = "0.10"
 hex = { workspace = true }
 base64 = { workspace = true }
 

--- a/v4/crates/sindri-secrets/src/backends/env.rs
+++ b/v4/crates/sindri-secrets/src/backends/env.rs
@@ -89,7 +89,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // intentional: serialises env-mutating tests across one tokio runtime
     async fn read_present_env_var() {
+        let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let backend = EnvBackend::new();
         let var = "SINDRI_SECRET_ENV_BACKEND_READ_TEST";
         std::env::set_var(var, "hunter2");
@@ -101,7 +103,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // intentional: serialises env-mutating tests across one tokio runtime
     async fn read_missing_env_var_returns_error() {
+        let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let backend = EnvBackend::new();
         let var = "SINDRI_SECRET_ENV_BACKEND_MISSING_XYZ";
         std::env::remove_var(var);

--- a/v4/crates/sindri-secrets/src/backends/file.rs
+++ b/v4/crates/sindri-secrets/src/backends/file.rs
@@ -37,7 +37,6 @@ use chacha20poly1305::{
     ChaCha20Poly1305, Nonce,
 };
 use hkdf::Hkdf;
-use rand::RngCore;
 use sha2::Sha256;
 use std::{
     collections::HashMap,
@@ -119,8 +118,7 @@ impl FileBackend {
         }
         let plaintext = serde_json::to_vec(map)
             .map_err(|e| SecretsError::Serde(format!("cannot serialise secrets store: {}", e)))?;
-        let mut nonce_bytes = [0u8; 12];
-        rand::rng().fill_bytes(&mut nonce_bytes);
+        let nonce_bytes: [u8; 12] = rand::random();
         let nonce = Nonce::from_slice(&nonce_bytes);
         let ciphertext = self
             .cipher

--- a/v4/crates/sindri-secrets/src/lib.rs
+++ b/v4/crates/sindri-secrets/src/lib.rs
@@ -25,6 +25,13 @@ pub use backends::{EnvBackend, FileBackend, VaultBackend};
 pub use error::SecretsError;
 pub use value::SecretValue;
 
+/// Test-only mutex serialising every test in the `sindri-secrets` test
+/// binary that mutates the process environment. `std::env::set_var` is not
+/// thread-safe; any test calling `env::set_var` or `env::remove_var` must
+/// hold this lock first.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 use async_trait::async_trait;
 
 /// Core trait every secret backend must implement.

--- a/v4/crates/sindri/src/commands/mod.rs
+++ b/v4/crates/sindri/src/commands/mod.rs
@@ -28,3 +28,10 @@ pub mod self_upgrade;
 pub mod show;
 pub mod target;
 pub mod upgrade;
+
+/// Test-only mutex serialising every test in the `sindri` binary's test
+/// binary that mutates the process environment. `std::env::set_var` is not
+/// thread-safe; any test calling `env::set_var` or `env::remove_var` must
+/// hold this lock first.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/v4/crates/sindri/src/commands/registry/mod.rs
+++ b/v4/crates/sindri/src/commands/registry/mod.rs
@@ -592,8 +592,10 @@ fn detect_source_kind(url: &str) -> Result<(&'static str, String), String> {
         return Ok(("git", "from git+ scheme or .git suffix".into()));
     }
     // Path detection — accept absolute or `./` paths.
-    if url.starts_with('/') || url.starts_with("./") || url.starts_with("../") {
-        let path = std::path::Path::new(url);
+    // Use Path::is_absolute() so Windows drive-letter paths (C:\...) are
+    // recognised in addition to POSIX /... paths.
+    let path = std::path::Path::new(url);
+    if path.is_absolute() || url.starts_with("./") || url.starts_with("../") {
         if path.join("oci-layout").exists() {
             return Ok(("local-oci", "directory contains an oci-layout file".into()));
         }

--- a/v4/crates/sindri/src/commands/rollback.rs
+++ b/v4/crates/sindri/src/commands/rollback.rs
@@ -273,6 +273,9 @@ mod tests {
 
     #[test]
     fn pops_most_recent_entry_and_writes_lock() {
+        let _g = crate::commands::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = TempDir::new().unwrap();
 
         let lock = Lockfile {

--- a/v4/crates/sindri/src/commands/secrets.rs
+++ b/v4/crates/sindri/src/commands/secrets.rs
@@ -360,9 +360,11 @@ mod tests {
 
     #[test]
     fn validate_env_value_present() {
+        let _g = crate::commands::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = TempDir::new().unwrap();
         let key = "SINDRI_TEST_SECRET_PRESENT";
-        // Ensure unique key to avoid cross-test interference.
         std::env::set_var(key, "shhh");
         let manifest = write_manifest(
             &dir,
@@ -375,6 +377,9 @@ mod tests {
 
     #[test]
     fn validate_env_value_missing_errors() {
+        let _g = crate::commands::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = TempDir::new().unwrap();
         let key = "SINDRI_TEST_SECRET_DEFINITELY_NOT_SET_X9";
         std::env::remove_var(key);
@@ -404,6 +409,9 @@ mod tests {
 
     #[test]
     fn list_never_prints_values() {
+        let _g = crate::commands::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = TempDir::new().unwrap();
         let secret_value = "DO_NOT_LEAK_ABCDEF";
         std::env::set_var("SINDRI_LIST_TEST", secret_value);

--- a/v4/crates/sindri/tests/init_cli_integration.rs
+++ b/v4/crates/sindri/tests/init_cli_integration.rs
@@ -29,6 +29,7 @@ fn cmd_in(cwd: &Path, fake_home: &Path) -> Command {
     let mut cmd = Command::new(sindri_bin());
     cmd.current_dir(cwd)
         .env("HOME", fake_home)
+        .env("SINDRI_HOME", fake_home) // Windows ignores HOME; SINDRI_HOME is the portable override
         .env_remove("SINDRI_BIN_PATH");
     cmd
 }

--- a/v4/docs/ADRs/009-cross-platform-backend-coverage.md
+++ b/v4/docs/ADRs/009-cross-platform-backend-coverage.md
@@ -143,7 +143,7 @@ Windows PowerShell 7+). Open question Q24 resolved: PowerShell 7+ only.
 
 ### CI proof
 
-Four GHA runner types (ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest) run:
+Four GHA runner types (ubuntu-latest, ubuntu-26.04-arm, macos-14, windows-latest) run:
 
 - `cargo build --release`
 - `cargo test`

--- a/v4/docs/TARGETS.md
+++ b/v4/docs/TARGETS.md
@@ -130,7 +130,7 @@ A Docker container provisioned from a specified base image. Useful for isolated,
 targets:
   ci-container:
     kind: docker
-    image: ubuntu:24.04
+    image: ubuntu:26.04
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

Consolidates PRs #266, #269, #294, #295, #296 with API migrations for breaking changes.

**Cargo bumps applied:**
- `pkcs8`: 0.10.2 → 0.11.0 (#266) ⚠️ major — migration applied
- `rand_core`: 0.6.4 → 0.9.5 (#269) ⚠️ major — partially applied (see note)
- `tokio`: 1.52.1 → 1.52.2 (tokio-ecosystem group) (#294)
- `jsonschema`: 0.46.3 → 0.46.4 (#295)
- `rand`: 0.9.4 → 0.10.1 (#296) ⚠️ major — migration applied

**API migrations:**
- `keyless.rs`: `pkcs8::der::{Decode,Encode}` → `x509_cert::der::{Decode,Encode}` — fixes der 0.7/0.8 version split (pkcs8 0.11 uses der 0.8; x509-cert 0.2.5 uses der 0.7)
- `file.rs`: removed `rand::RngCore` import (no longer re-exported in rand 0.10); replaced `rng().fill_bytes()` with `rand::random::<[u8;12]>()`

**rand_core note:** `sindri-registry/Cargo.toml` kept at `rand_core = "0.6"` because `p256 0.13 / ecdsa 0.16` still use `rand_core::OsRng` from 0.6 in test helpers. A full rand_core 0.9 migration requires coordinating `p256 0.14+ / ecdsa 0.17+` upgrades.

**Ubuntu 26.04 consistency (docs):**
- `TARGETS.md`: `ubuntu:24.04` → `ubuntu:26.04` in example docker target config
- `ADR-009`: `ubuntu-24.04-arm` → `ubuntu-26.04-arm` in CI matrix table

## Test plan

- [x] `cargo fmt --all --check` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes (0 errors)
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo run -p schema-gen -- --check` — all 5 schemas up to date
- [x] `cargo run -p target-doc-gen -- --check` — docs up to date

**Closes:** #266, #294, #295, #296
**Partially closes:** #269 (rand_core 0.9 in registry requires p256/ecdsa upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)