### PR TITLE
deps(v3): round-2 consolidated patch bumps (clap_complete, jsonschema, tokio)

### DIFF
--- a/v3/Cargo.lock
+++ b/v3/Cargo.lock
@@ -4903,9 +4903,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/v3/Cargo.lock
+++ b/v3/Cargo.lock
@@ -2569,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3503,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/v3/Cargo.lock
+++ b/v3/Cargo.lock
@@ -135,7 +135,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -1463,7 +1463,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1582,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2839,7 +2839,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2974,7 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3720,7 +3720,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3777,7 +3777,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4561,7 +4561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4703,7 +4703,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4745,7 +4745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5548,7 +5548,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/v3/crates/sindri-extensions/src/log_files.rs
+++ b/v3/crates/sindri-extensions/src/log_files.rs
@@ -256,17 +256,19 @@ mod tests {
         // Create an "old" log file with a past timestamp in the filename
         let ext_dir = temp_dir.path().join("python");
         std::fs::create_dir_all(&ext_dir).unwrap();
-        let old_name = "20240101T000000Z.log";
-        std::fs::write(ext_dir.join(old_name), "old log content").unwrap();
+        let old_ts = Utc::now() - chrono::Duration::days(120);
+        let old_name = format!("{}.log", old_ts.format("%Y%m%dT%H%M%SZ"));
+        std::fs::write(ext_dir.join(&old_name), "old log content").unwrap();
 
-        // Create a "recent" log file
-        let recent_name = "20260213T120000Z.log";
-        std::fs::write(ext_dir.join(recent_name), "recent log content").unwrap();
+        // Create a "recent" log file (within the 90-day window)
+        let recent_ts = Utc::now() - chrono::Duration::days(1);
+        let recent_name = format!("{}.log", recent_ts.format("%Y%m%dT%H%M%SZ"));
+        std::fs::write(ext_dir.join(&recent_name), "recent log content").unwrap();
 
         let removed = writer.cleanup_old_logs(90).unwrap();
         assert_eq!(removed, 1);
-        assert!(!ext_dir.join(old_name).exists());
-        assert!(ext_dir.join(recent_name).exists());
+        assert!(!ext_dir.join(&old_name).exists());
+        assert!(ext_dir.join(&recent_name).exists());
     }
 
     #[test]

--- a/v3/crates/sindri/Cargo.toml
+++ b/v3/crates/sindri/Cargo.toml
@@ -25,7 +25,7 @@ sindri-backup = { workspace = true }
 
 # CLI
 clap = { workspace = true }
-clap_complete = "4.6.3"
+clap_complete = "4.6.5"
 tokio = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }


### PR DESCRIPTION
## Summary

Round-2 dependabot consolidation against `v3`. Cherry-picks three patch-only bumps:

- **clap_complete** 4.6.3 → 4.6.5 (closes #307)
- **jsonschema** 0.46.4 → 0.46.5 (closes #308)
- **tokio** 1.52.2 → 1.52.3 (tokio-ecosystem, closes #291)

Also includes a test-fix:

- `test(v3): make test_cleanup_old_logs date-independent` — the test's "recent" log fixture used a hardcoded timestamp `20260213T120000Z`, which fell outside the 90-day cleanup window as of 2026-05-14. Replaced with `Utc::now() - Duration::days(1)` so the assertion is stable regardless of run date.

## Alignment sweep

All three are patch bumps. Searched `v3/docs/`, `v3/Dockerfile*`, and `v3/compatibility-matrix.yaml` for pinned references — none found. No lockstep updates required.

## Test plan

- [x] `cd v3 && cargo fmt --all --check`
- [x] `cd v3 && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cd v3 && cargo test --workspace` — all crates green, including the fixed `log_files::tests::test_cleanup_old_logs`

## Closes

- #307
- #308
- #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)