### PR TITLE
deps(v4): bump tar, git2, oci-client

### DIFF
--- a/v4/Cargo.lock
+++ b/v4/Cargo.lock
@@ -1457,15 +1457,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -2073,6 +2072,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
@@ -2134,9 +2134,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -2457,13 +2457,14 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "hex",
  "http",
  "http-auth",
  "jsonwebtoken",
@@ -2474,7 +2475,7 @@ dependencies = [
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4116,7 +4117,7 @@ dependencies = [
  "fs4",
  "git2",
  "hex",
- "oci-client 0.16.1",
+ "oci-client 0.17.0",
  "oci-spec 0.9.0",
  "p256",
  "pkcs8 0.11.0",
@@ -4148,7 +4149,7 @@ dependencies = [
  "anyhow",
  "dirs-next",
  "hex",
- "oci-client 0.16.1",
+ "oci-client 0.17.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4344,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/v4/Cargo.toml
+++ b/v4/Cargo.toml
@@ -42,7 +42,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], def
 semver = "1"
 # OCI client (successor to oci-distribution; ADR-003). Wired into sindri-registry
 # scaffold in Wave 3A.1; live OCI fetch lands in Wave 3A.2.
-oci-client = { version = "0.16", default-features = false, features = ["rustls-tls"] }
+oci-client = { version = "0.17", default-features = false, features = ["rustls-tls"] }
 # OCI image-layout v1.1 spec types — used by `LocalOciSource` to read/walk
 # on-disk layouts (DDD-08, ADR-028 — Phase 2). Pure-data structs, no I/O.
 # Apache-2.0 licensed.
@@ -73,7 +73,7 @@ tar = "0.4"
 zstd = "0.13"
 # Git source (`GitSource`) — libgit2 bindings, vendored libgit2 for cross-OS
 # determinism (Phase 3.1, ADR-028). Apache-2.0 / MIT dual-licensed.
-git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2"] }
+git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 # Embedded OCI registry server for `sindri registry serve` (Phase 3.2,
 # ADR-028). MIT-licensed.
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "macros"] }


### PR DESCRIPTION
## Summary

Coalesces three open Dependabot PRs into a single update:

- **tar**: 0.4.45 → 0.4.46
- **git2**: 0.20.4 → 0.21.0 (drops `url` dep; uses vendored libgit2 1.9.3)
- **oci-client**: 0.16.1 → 0.17.0 (adds `aws-lc-rs`, `hex`; bumps sha2 0.10→0.11)

## Closes

Closes #323
Closes #324
Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)